### PR TITLE
Add support for signed data root parameter in transactions

### DIFF
--- a/src/pages/Summary/index.tsx
+++ b/src/pages/Summary/index.tsx
@@ -143,7 +143,7 @@ const _SummaryPage = ({
       // eslint-disable-next-line camelcase
       withdrawal_credentials,
       // eslint-disable-next-line camelcase
-      deposit_data_root,
+      signed_deposit_data_root,
     } = depositFile;
 
     try {
@@ -163,7 +163,7 @@ const _SummaryPage = ({
           prefix0X(pubkey),
           prefix0X(withdrawal_credentials),
           prefix0X(signature),
-          prefix0X(deposit_data_root)
+          prefix0X(signed_deposit_data_root)
         )
         .send(transactionParameters)
         // Event for when the user confirms the tx

--- a/src/store/actions/keyFileActions.ts
+++ b/src/store/actions/keyFileActions.ts
@@ -8,6 +8,8 @@ export interface keyFile {
   signature: string;
   // eslint-disable-next-line camelcase
   deposit_data_root: string;
+  // eslint-disable-next-line camelcase
+  signed_deposit_data_root: string;
 }
 export interface UpdateKeyFilesAction {
   type: ActionTypes.updateKeyFiles;


### PR DESCRIPTION
In the eth2 CLI tooling we changed the data root parameter to be the unsigned version. 

This updates the dapp to use the signed version when making calls to the contract.