### PR TITLE
Remove status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 The [Launchpad](https://launchpad.ethereum.org/) is the Ethereum Foundation's official way to deposit your Eth for Ethereum 2.0
 
-  - **Status**:  This Launchpad is in active development for testnet
-
 ## Dependencies
 
   - **Technology stack**: 


### PR DESCRIPTION
Reading "This Launchpad is in active development for testnet" gave me the impression that we're saying it's not ready for use on Mainnet. I don't think this is the message we want to send, given this app is used on Mainnet.

Am I misunderstanding this? Otherwise I think we should remove this statement.