### PR TITLE
Adds links to e.org glossary terms

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -401,6 +401,12 @@
       "value": "Troubleshooting"
     }
   ],
+  "2HVWJL": [
+    {
+      "type": 0,
+      "value": "execution layer"
+    }
+  ],
   "2PI6Di": [
     {
       "type": 0,
@@ -983,6 +989,12 @@
       "value": "Prysm offers step-by-step guidelines to run their client after completing your deposit through the launchpad."
     }
   ],
+  "A8r7Hg": [
+    {
+      "type": 0,
+      "value": "consensus layer"
+    }
+  ],
   "AC669U": [
     {
       "type": 0,
@@ -1045,6 +1057,12 @@
     {
       "type": 0,
       "value": " to be sent at one time to be accepted."
+    }
+  ],
+  "ATwOPg": [
+    {
+      "type": 0,
+      "value": "execution client"
     }
   ],
   "AYKxmf": [
@@ -1525,6 +1543,12 @@
     {
       "type": 0,
       "value": "Make sure you aren't being phished"
+    }
+  ],
+  "GN2Cu5": [
+    {
+      "type": 0,
+      "value": "consensus client"
     }
   ],
   "GOHkCO": [
@@ -2775,6 +2799,28 @@
     {
       "type": 0,
       "value": "If you do not have a testnet folder it is likely you have not built and run Nimbus correctly. Run the make commands again."
+    }
+  ],
+  "V19Udt": [
+    {
+      "type": 0,
+      "value": "Ethereum will consist of the "
+    },
+    {
+      "type": 1,
+      "value": "executionLayer"
+    },
+    {
+      "type": 0,
+      "value": " (handles transactions and execution, formerly 'Eth1'), and the "
+    },
+    {
+      "type": 1,
+      "value": "consensusLayer"
+    },
+    {
+      "type": 0,
+      "value": " (handles proof-of-stake Beacon Chain, formerly 'Eth2' or 'Ethereum 2.0')."
     }
   ],
   "VASo1/": [
@@ -4671,12 +4717,6 @@
       "value": "Nimbus looks for keystores in your validators folder."
     }
   ],
-  "pofmhk": [
-    {
-      "type": 0,
-      "value": "Ethereum will consist of the execution layer (handles transactions and execution, formerly 'Eth1'), and the consensus layer (handles proof-of-stake Beacon Chain, formerly 'Eth2' or 'Ethereum 2.0')."
-    }
-  ],
   "pqC+qt": [
     {
       "type": 0,
@@ -5359,6 +5399,28 @@
     {
       "type": 0,
       "value": "Early adopter risks"
+    }
+  ],
+  "wrnpoO": [
+    {
+      "type": 0,
+      "value": "To process incoming validator deposits from the execution layer (formerly 'Eth1' chain), you'll need to run an "
+    },
+    {
+      "type": 1,
+      "value": "executionClient"
+    },
+    {
+      "type": 0,
+      "value": " as well as your "
+    },
+    {
+      "type": 1,
+      "value": "consensusClient"
+    },
+    {
+      "type": 0,
+      "value": " (formerly 'Eth2'). You can use a third-party service like Infura, but we recommend running your own client to keep the network as decentralized as possible."
     }
   ],
   "wtTeex": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -155,6 +155,9 @@
   "2CYEJa": {
     "message": "Troubleshooting"
   },
+  "2HVWJL": {
+    "message": "execution layer"
+  },
   "2PI6Di": {
     "message": "Consensus Clients: {clientName}"
   },
@@ -378,6 +381,9 @@
   "A6Oppp": {
     "message": "Prysm offers step-by-step guidelines to run their client after completing your deposit through the launchpad."
   },
+  "A8r7Hg": {
+    "message": "consensus layer"
+  },
   "AC669U": {
     "message": "If you need help, check out the Python documentation."
   },
@@ -389,6 +395,9 @@
   },
   "AJD+66": {
     "message": "The Ethereum staking deposit contract requires a minimum of {minTopupValue} {TICKER_NAME} to be sent at one time to be accepted."
+  },
+  "ATwOPg": {
+    "message": "execution client"
   },
   "AYKxmf": {
     "message": "Connect your hardware wallet to Metamask"
@@ -594,6 +603,9 @@
   },
   "GDaRAW": {
     "message": "Make sure you aren't being phished"
+  },
+  "GN2Cu5": {
+    "message": "consensus client"
   },
   "GOHkCO": {
     "message": "Today, you'll secure the Beacon Chain, the first main scaling upgrade. It's a separate chain that uses a proof-of-stake consensus mechanism. Eventually you'll help secure all of Ethereum, once mainnet (the Ethereum we use today) merges with the Beacon Chain."
@@ -1109,6 +1121,10 @@
   },
   "V0cb8p": {
     "message": "If you do not have a testnet folder it is likely you have not built and run Nimbus correctly. Run the make commands again."
+  },
+  "V19Udt": {
+    "description": "{executionLayer} is a link labeled 'execution layer'. {consensusLayer} is a link labeled 'consensus layer'",
+    "message": "Ethereum will consist of the {executionLayer} (handles transactions and execution, formerly 'Eth1'), and the {consensusLayer} (handles proof-of-stake Beacon Chain, formerly 'Eth2' or 'Ethereum 2.0')."
   },
   "VASo1/": {
     "message": "Connect wallet"
@@ -1835,9 +1851,6 @@
   "pnxB8A": {
     "message": "Nimbus looks for keystores in your validators folder."
   },
-  "pofmhk": {
-    "message": "Ethereum will consist of the execution layer (handles transactions and execution, formerly 'Eth1'), and the consensus layer (handles proof-of-stake Beacon Chain, formerly 'Eth2' or 'Ethereum 2.0')."
-  },
   "pqC+qt": {
     "message": "Slashing"
   },
@@ -2105,6 +2118,10 @@
   },
   "wqUcy/": {
     "message": "Early adopter risks"
+  },
+  "wrnpoO": {
+    "description": "{executionLayer} is a link labeled 'execution layer'. {consensusLayer} is a link labeled 'consensus layer'",
+    "message": "To process incoming validator deposits from the execution layer (formerly 'Eth1' chain), you'll need to run an {executionClient} as well as your {consensusClient} (formerly 'Eth2'). You can use a third-party service like Infura, but we recommend running your own client to keep the network as decentralized as possible."
   },
   "wtTeex": {
     "message": "Are there spelling mistakes?"

--- a/src/pages/Checklist/index.tsx
+++ b/src/pages/Checklist/index.tsx
@@ -328,10 +328,29 @@ export const Checklist = () => {
               <Text>
                 <FormattedMessage
                   defaultMessage="To process incoming validator deposits from the execution layer
-                    (formerly 'Eth1' chain), you'll need to run an execution client as well as your
-                    consensus client (formerly 'Eth2'). You can use a third-party service
+                    (formerly 'Eth1' chain), you'll need to run an {executionClient} as well as your
+                    {consensusClient} (formerly 'Eth2'). You can use a third-party service
                     like Infura, but we recommend running your own client to
                     keep the network as decentralized as possible."
+                  values={{
+                    executionClient: (
+                      <Link
+                        to="https://ethereum.org/en/glossary/#execution-client"
+                        inline
+                      >
+                        <FormattedMessage defaultMessage="execution client" />
+                      </Link>
+                    ),
+                    consensusClient: (
+                      <Link
+                        to="https://ethereum.org/en/glossary/#consensus-client"
+                        inline
+                      >
+                        <FormattedMessage defaultMessage="consensus client" />
+                      </Link>
+                    ),
+                  }}
+                  description="{executionLayer} is a link labeled 'execution layer'. {consensusLayer} is a link labeled 'consensus layer'"
                 />
               </Text>
             </li>

--- a/src/pages/FAQ/index.jsx
+++ b/src/pages/FAQ/index.jsx
@@ -248,8 +248,27 @@ export const FAQ = () => {
             </Text>
             <Text className="mt10">
               <FormattedMessage
-                defaultMessage="Ethereum will consist of the execution layer (handles transactions and execution, formerly 'Eth1'), and the
-                  consensus layer (handles proof-of-stake Beacon Chain, formerly 'Eth2' or 'Ethereum 2.0')."
+                defaultMessage="Ethereum will consist of the {executionLayer} (handles transactions and execution, formerly 'Eth1'), and the
+                  {consensusLayer} (handles proof-of-stake Beacon Chain, formerly 'Eth2' or 'Ethereum 2.0')."
+                values={{
+                  executionLayer: (
+                    <Link
+                      to="https://ethereum.org/en/glossary/#execution-layer"
+                      inline
+                    >
+                      <FormattedMessage defaultMessage="execution layer" />
+                    </Link>
+                  ),
+                  consensusLayer: (
+                    <Link
+                      to="https://ethereum.org/en/glossary/#consensus-layer"
+                      inline
+                    >
+                      <FormattedMessage defaultMessage="consensus layer" />
+                    </Link>
+                  ),
+                }}
+                description="{executionLayer} is a link labeled 'execution layer'. {consensusLayer} is a link labeled 'consensus layer'"
               />
             </Text>
             <Text className="mt10">


### PR DESCRIPTION
- Adds links for `execution layer` and `consensus layer` terms on the FAQ page
- Adds links for `execution client` and `consensus client` terms on the checklist page
- `yarn extract && yarn compile` has been run
 
https://www.notion.so/efdn/Add-links-to-glossary-terms-a7ea3cf7feff4e05a69d15ce28a81204