### PR TITLE
Add client diversity warning if user selects Prysm

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -3397,6 +3397,12 @@
       "value": "However, bear in mind that for the foreseeable future, once you’ve exited, there’s no going back."
     }
   ],
+  "b8APBK": [
+    {
+      "type": 0,
+      "value": "More on client diversity"
+    }
+  ],
   "bNFkSo": [
     {
       "type": 0,
@@ -4421,6 +4427,12 @@
     {
       "type": 0,
       "value": "Hard drive"
+    }
+  ],
+  "mIkyPD": [
+    {
+      "type": 0,
+      "value": "Currently the majority of validators run Prysm as their consensus client. Client diversity is extremely important for the network health of Ethereum: A bug in a client with a share of over 33% can cause Ethereum to go offline. If the client has a super-majority (>66%), a bug could cause the chain to incorrectly split, potentially leading to slashing."
     }
   ],
   "mZOXtM": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -145,6 +145,12 @@
       "value": "Transactions"
     }
   ],
+  "/rmnC0": [
+    {
+      "type": 0,
+      "value": "If at all possible, consider running another client at this time to help protect yourself and the network."
+    }
+  ],
   "/ub26/": [
     {
       "type": 0,
@@ -4429,12 +4435,6 @@
       "value": "Hard drive"
     }
   ],
-  "mIkyPD": [
-    {
-      "type": 0,
-      "value": "Currently the majority of validators run Prysm as their consensus client. Client diversity is extremely important for the network health of Ethereum: A bug in a client with a share of over 33% can cause Ethereum to go offline. If the client has a super-majority (>66%), a bug could cause the chain to incorrectly split, potentially leading to slashing."
-    }
-  ],
   "mZOXtM": [
     {
       "type": 0,
@@ -5451,6 +5451,12 @@
     {
       "type": 0,
       "value": "Validating in Ethereum is not the same as mining. The outcomes are similar: the work you do will extend and secure the chain. But the process is completely different because they use different consensus mechanisms."
+    }
+  ],
+  "x8+8fi": [
+    {
+      "type": 0,
+      "value": "Currently the majority of validators run Prysm as their consensus client. Client diversity is extremely important for the network health of Ethereum: A bug in a client with a share of over 33% can cause Ethereum to go offline. If the client has a supermajority (>66%), a bug could cause the chain to incorrectly split, potentially leading to slashing."
     }
   ],
   "xDyl3T": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -1322,6 +1322,9 @@
   "b4csjU": {
     "message": "However, bear in mind that for the foreseeable future, once you’ve exited, there’s no going back."
   },
+  "b8APBK": {
+    "message": "More on client diversity"
+  },
   "bNFkSo": {
     "message": "Now follow the instructions presented to you in the terminal window to generate your keys."
   },
@@ -1736,6 +1739,9 @@
   },
   "mArJcj": {
     "message": "Hard drive"
+  },
+  "mIkyPD": {
+    "message": "Currently the majority of validators run Prysm as their consensus client. Client diversity is extremely important for the network health of Ethereum: A bug in a client with a share of over 33% can cause Ethereum to go offline. If the client has a super-majority (>66%), a bug could cause the chain to incorrectly split, potentially leading to slashing."
   },
   "mZOXtM": {
     "message": "Validators"

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -56,6 +56,9 @@
   "/jJLYy": {
     "message": "Transactions"
   },
+  "/rmnC0": {
+    "message": "If at all possible, consider running another client at this time to help protect yourself and the network."
+  },
   "/ub26/": {
     "message": "Understand the risks"
   },
@@ -1740,9 +1743,6 @@
   "mArJcj": {
     "message": "Hard drive"
   },
-  "mIkyPD": {
-    "message": "Currently the majority of validators run Prysm as their consensus client. Client diversity is extremely important for the network health of Ethereum: A bug in a client with a share of over 33% can cause Ethereum to go offline. If the client has a super-majority (>66%), a bug could cause the chain to incorrectly split, potentially leading to slashing."
-  },
   "mZOXtM": {
     "message": "Validators"
   },
@@ -2137,6 +2137,9 @@
   },
   "x0tVK4": {
     "message": "Validating in Ethereum is not the same as mining. The outcomes are similar: the work you do will extend and secure the chain. But the process is completely different because they use different consensus mechanisms."
+  },
+  "x8+8fi": {
+    "message": "Currently the majority of validators run Prysm as their consensus client. Client diversity is extremely important for the network health of Ethereum: A bug in a client with a share of over 33% can cause Ethereum to go offline. If the client has a supermajority (>66%), a bug could cause the chain to incorrectly split, potentially leading to slashing."
   },
   "xDyl3T": {
     "description": "{ethereumorg} is a link to deposit contract page on ethereum.org",

--- a/src/pages/Clients/Consensus/Prysm.tsx
+++ b/src/pages/Clients/Consensus/Prysm.tsx
@@ -23,19 +23,26 @@ const ClientDiversityWarning = styled(Text as any)`
 export const PrysmDetails = ({ shortened }: { shortened?: boolean }) => (
   <>
     <ClientDiversityWarning>
-      <FormattedMessage
-        defaultMessage="Currently the majority of validators run Prysm as their consensus client.
-      Client diversity is extremely important for the network health of Ethereum:
-      A bug in a client with a share of over 33% can cause Ethereum to go offline. If the client has
-      a super-majority (>66%), a bug could cause the chain to incorrectly split, potentially leading to
-      slashing."
-      />
-      <Link
-        to="https://ethereum.org/en/developers/docs/nodes-and-clients/client-diversity/"
-        primary
-      >
-        <FormattedMessage defaultMessage="More on client diversity" />
-      </Link>
+      <p>
+        <FormattedMessage
+          defaultMessage="Currently the majority of validators run Prysm as their consensus client.
+            Client diversity is extremely important for the network health of Ethereum:
+            A bug in a client with a share of over 33% can cause Ethereum to go offline. If the client has
+            a supermajority (>66%), a bug could cause the chain to incorrectly split, potentially leading to
+            slashing."
+        />
+      </p>
+      <p>
+        <FormattedMessage defaultMessage="If at all possible, consider running another client at this time to help protect yourself and the network." />
+      </p>
+      <p>
+        <Link
+          to="https://ethereum.org/en/developers/docs/nodes-and-clients/client-diversity/"
+          primary
+        >
+          <FormattedMessage defaultMessage="More on client diversity" />
+        </Link>
+      </p>
     </ClientDiversityWarning>
     <SectionTitle level={2} className="mb5">
       Prysm

--- a/src/pages/Clients/Consensus/Prysm.tsx
+++ b/src/pages/Clients/Consensus/Prysm.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components';
 import { PageTemplate } from '../../../components/PageTemplate';
 import prysmBg from '../../../static/prysmatic-bg.png';
 import {
@@ -11,9 +12,31 @@ import { Link } from '../../../components/Link';
 import { PRYSM_INSTALLATION_URL } from '../../../utils/envVars';
 import { FormattedMessage, useIntl } from 'react-intl';
 
+const ClientDiversityWarning = styled(Text as any)`
+  background: #ffdeb32e;
+  border: 1px solid burlywood;
+  padding: 30px;
+  border-radius: 4px;
+`;
+
 // eslint-disable-next-line no-unused-vars
 export const PrysmDetails = ({ shortened }: { shortened?: boolean }) => (
   <>
+    <ClientDiversityWarning>
+      <FormattedMessage
+        defaultMessage="Currently the majority of validators run Prysm as their consensus client.
+      Client diversity is extremely important for the network health of Ethereum:
+      A bug in a client with a share of over 33% can cause Ethereum to go offline. If the client has
+      a super-majority (>66%), a bug could cause the chain to incorrectly split, potentially leading to
+      slashing."
+      />
+      <Link
+        to="https://ethereum.org/en/developers/docs/nodes-and-clients/client-diversity/"
+        primary
+      >
+        <FormattedMessage defaultMessage="More on client diversity" />
+      </Link>
+    </ClientDiversityWarning>
     <SectionTitle level={2} className="mb5">
       Prysm
     </SectionTitle>


### PR DESCRIPTION
Like I mentioned in #427, I think it is important to inform users of the risks of running a (super-) majority consensus client.
I added a simple disclaimer if the user chooses Prysm and a link to the Ethereum docs about client diversity.
The warning is hardcoded in the Prysm markup which means it has to be manually moved if another client gets majority in the future, but I don't see this happening anytime soon.

I don't know if this is even something you want on the website in this form or another but I'm open for suggestions.

![disclaimer](https://user-images.githubusercontent.com/5159852/153538983-0ea2a615-ebf8-4153-82a5-aaaee971b126.png)

