### PR TITLE
Use English "Goerli" instead of typo German "Göerli"

### DIFF
--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -150,7 +150,7 @@ const _AppBar = ({ location }: RouteComponentProps) => {
     ? TESTNET_LAUNCHPAD_URL
     : MAINNET_LAUNCHPAD_URL;
 
-  const networkName = IS_MAINNET ? 'mainnet' : 'Göerli testnet';
+  const networkName = IS_MAINNET ? 'mainnet' : 'Goerli testnet';
 
   return (
     <RainbowBackground

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -2243,6 +2243,16 @@
       "value": "Remember that a validator’s vote is weighted by the amount it has at stake."
     }
   ],
+  "NZzzW1": [
+    {
+      "type": 0,
+      "value": "Connect to "
+    },
+    {
+      "type": 1,
+      "value": "network"
+    }
+  ],
   "NatYUJ": [
     {
       "type": 0,
@@ -5505,16 +5515,6 @@
     {
       "type": 0,
       "value": "More on proof of stake"
-    }
-  ],
-  "wfSgCZ": [
-    {
-      "type": 0,
-      "value": "Connect to "
-    },
-    {
-      "type": 1,
-      "value": "network"
     }
   ],
   "wm04oC": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -898,6 +898,10 @@
   "NZUWs7": {
     "message": "Remember that a validator’s vote is weighted by the amount it has at stake."
   },
+  "NZzzW1": {
+    "description": "{network} is either 'Ethereum mainnet' or 'Goerli testnet'",
+    "message": "Connect to {network}"
+  },
   "NatYUJ": {
     "message": "Learn more about the roles and responsibilities of Ethereum validators."
   },
@@ -2164,10 +2168,6 @@
   },
   "wdb1NC": {
     "message": "More on proof of stake"
-  },
-  "wfSgCZ": {
-    "description": "{network} is either 'Ethereum mainnet' or 'Göerli testnet'",
-    "message": "Connect to {network}"
   },
   "wm04oC": {
     "message": "Run the following command:"

--- a/src/pages/ConnectWallet/WrongNetwork.tsx
+++ b/src/pages/ConnectWallet/WrongNetwork.tsx
@@ -5,7 +5,7 @@ import { WorkflowPageTemplate } from '../../components/WorkflowPage/WorkflowPage
 import { IS_MAINNET } from '../../utils/envVars';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-const networkName = IS_MAINNET ? 'Mainnet' : 'Göerli testnet';
+const networkName = IS_MAINNET ? 'Mainnet' : 'Goerli testnet';
 
 export const WrongNetwork = () => {
   const { formatMessage } = useIntl();

--- a/src/pages/ConnectWallet/index.tsx
+++ b/src/pages/ConnectWallet/index.tsx
@@ -293,7 +293,7 @@ const _ConnectWalletPage = ({
           { defaultMessage: 'Connect {wallet} to {network}' },
           {
             wallet: getWalletName(walletProvider),
-            network: IS_MAINNET ? 'Ethereum mainnet' : 'Göerli testnet',
+            network: IS_MAINNET ? 'Ethereum mainnet' : 'Goerli testnet',
           }
         )
       );
@@ -489,7 +489,7 @@ const _ConnectWalletPage = ({
           <FormattedMessage
             defaultMessage="Your wallet is on the wrong network. Switch to {network}"
             values={{
-              network: IS_MAINNET ? 'Ethereum mainnet' : 'Göerli testnet',
+              network: IS_MAINNET ? 'Ethereum mainnet' : 'Goerli testnet',
             }}
           />
         </div>

--- a/src/pages/ConnectWallet/web3Utils.ts
+++ b/src/pages/ConnectWallet/web3Utils.ts
@@ -18,7 +18,7 @@ export enum NetworkChainId {
   'Mainnet' = 1,
   'Ropsten' = 3,
   'Rinkeby' = 4,
-  'Göerli' = 5,
+  'Goerli' = 5,
   'Kovan' = 42,
 }
 
@@ -28,7 +28,7 @@ export enum NetworkChainId {
  */
 
 const supportedNetworks = [
-  NetworkChainId['Göerli'],
+  NetworkChainId.Goerli,
   NetworkChainId.Mainnet,
   NetworkChainId.Rinkeby,
   NetworkChainId.Ropsten,
@@ -36,7 +36,7 @@ const supportedNetworks = [
 ];
 
 enum Testnet {
-  'Göerli',
+  'Goerli',
 }
 
 enum Mainnet {
@@ -56,7 +56,7 @@ export const portis: PortisConnector = new PortisConnector({
 
 export const fortmatic: FortmaticConnector = new FortmaticConnector({
   apiKey: FORTMATIC_KEY as string,
-  chainId: IS_MAINNET ? NetworkChainId.Mainnet : NetworkChainId['Göerli'],
+  chainId: IS_MAINNET ? NetworkChainId.Mainnet : NetworkChainId.Goerli,
   rpcUrl: INFURA_URL,
 });
 

--- a/src/pages/Summary/index.tsx
+++ b/src/pages/Summary/index.tsx
@@ -51,9 +51,7 @@ const Row = styled.div`
 const Container = styled.div`
   width: 100%;
 `;
-const NETWORK_ID = IS_MAINNET
-  ? NetworkChainId.Mainnet
-  : NetworkChainId['Göerli'];
+const NETWORK_ID = IS_MAINNET ? NetworkChainId.Mainnet : NetworkChainId.Goerli;
 
 // Prop definitions
 interface OwnProps {}

--- a/src/pages/TopUp/components/WalletConnectModal.tsx
+++ b/src/pages/TopUp/components/WalletConnectModal.tsx
@@ -61,9 +61,9 @@ const WalletConnectModal: React.FC = () => {
             <FormattedMessage
               defaultMessage="Connect to {network}"
               values={{
-                network: IS_MAINNET ? 'Ethereum mainnet' : 'Göerli testnet',
+                network: IS_MAINNET ? 'Ethereum mainnet' : 'Goerli testnet',
               }}
-              description="{network} is either 'Ethereum mainnet' or 'Göerli testnet'"
+              description="{network} is either 'Ethereum mainnet' or 'Goerli testnet'"
             />
           </Text>
         </div>

--- a/src/pages/Transactions/index.tsx
+++ b/src/pages/Transactions/index.tsx
@@ -35,9 +35,7 @@ import {
 import { IS_MAINNET } from '../../utils/envVars';
 import { routeToCorrectWorkflowStep } from '../../utils/RouteToCorrectWorkflowStep';
 
-const NETWORK_ID = IS_MAINNET
-  ? NetworkChainId.Mainnet
-  : NetworkChainId['Göerli'];
+const NETWORK_ID = IS_MAINNET ? NetworkChainId.Mainnet : NetworkChainId.Goerli;
 
 // Prop definitions
 interface OwnProps {}


### PR DESCRIPTION
1. Using German is config made us have to use `NetworkChainId['Göerli']`. As we are adding Ropsten and other EL testnets, it would be easier in parameterization if we can just use English "Goerli".
2. It turns out `Göerli` is a typo and it should have been `Görli`. 😅  Let's just use `Goerli`.