### PR TITLE
Add top-up modal escape [Fixes #383]

### DIFF
--- a/src/components/NakedButton.tsx
+++ b/src/components/NakedButton.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const NakedButton = styled.button`
+  appearance: none;
+  background: none;
+  border: none;
+  color: inherit;
+  display: inline-block;
+  font: inherit;
+  padding: initial;
+  cursor: pointer;
+`;

--- a/src/hooks/useKeyPress.ts
+++ b/src/hooks/useKeyPress.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+export const useKeyPress = (
+  targetKey: string,
+  handler: (event: KeyboardEvent) => void
+) => {
+  const downHandler = (event: KeyboardEvent) => {
+    if (event.key === targetKey) {
+      handler(event);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('keydown', downHandler);
+    // Remove event listeners on cleanup
+    return () => {
+      window.removeEventListener('keydown', downHandler);
+    };
+  });
+};

--- a/src/pages/TopUp/components/ValidatorTable.tsx
+++ b/src/pages/TopUp/components/ValidatorTable.tsx
@@ -12,7 +12,6 @@ import {
 import ReactTooltip from 'react-tooltip';
 import { Wifi, StatusWarning, Refresh, StatusDisabled } from 'grommet-icons';
 import numeral from 'numeral';
-import { useWeb3React } from '@web3-react/core';
 import { styledComponentsTheme as theme } from '../../../styles/styledComponentsTheme';
 import { BeaconChainValidator } from '../types';
 import { Text } from '../../../components/Text';
@@ -37,8 +36,8 @@ const FakeLink = styled.span`
 const ValidatorTable: React.FC<{
   validators: BeaconChainValidator[];
   setSelectedValidator: (validator: BeaconChainValidator) => void;
-}> = ({ validators, setSelectedValidator }) => {
-  const { deactivate } = useWeb3React();
+  handleConnect: () => void;
+}> = ({ validators, setSelectedValidator, handleConnect }) => {
   const { formatMessage } = useIntl();
 
   const validatorStatus = (validator: BeaconChainValidator) => {
@@ -246,7 +245,7 @@ const ValidatorTable: React.FC<{
           defaultMessage="You can {changeYourWallet} to load validators for a different address."
           values={{
             changeYourWallet: (
-              <FakeLink onClick={deactivate}>
+              <FakeLink onClick={handleConnect}>
                 <FormattedMessage defaultMessage="change your wallet" />
               </FakeLink>
             ),

--- a/src/pages/TopUp/components/WalletConnectModal.tsx
+++ b/src/pages/TopUp/components/WalletConnectModal.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
+import styled from 'styled-components';
 import { useWeb3React } from '@web3-react/core';
 import { Web3Provider } from '@ethersproject/providers';
 import { AbstractConnector } from '@web3-react/abstract-connector';
@@ -15,6 +16,7 @@ import {
 import { WalletButton } from '../../ConnectWallet/WalletButton';
 import { web3ReactInterface } from '../../ConnectWallet';
 import metamaskLogo from '../../../static/metamask.svg';
+import closeGlyph from '../../../static/close.svg';
 import {
   ENABLE_RPC_FEATURES,
   IS_MAINNET,
@@ -27,7 +29,19 @@ import { Heading } from '../../../components/Heading';
 import { Text } from '../../../components/Text';
 import { MetamaskHardwareButton } from '../../ConnectWallet/MetamaskHardwareButton';
 
-const WalletConnectModal: React.FC = () => {
+const Close = styled.img`
+  height: 24px;
+  width: 24px;
+  display: block;
+  align-self: flex-end;
+  margin: 16px 16px 0 0;
+  cursor: pointer;
+`;
+
+const WalletConnectModal: React.FC<{
+  loading: boolean;
+  setLoading: any;
+}> = ({ loading, setLoading }: { loading: any; setLoading: any }) => {
   const {
     connector,
     error,
@@ -47,10 +61,14 @@ const WalletConnectModal: React.FC = () => {
     return !Object.values(AllowedNetworks).includes(network);
   }, [chainId]);
 
+  const handleClose = () => {
+    setLoading(false);
+  };
+
   if (isInvalidNetwork) {
     return (
       <Layer>
-        <div className="p20">
+        <div className="p20 flex">
           <Heading level={2} color="blueMedium" center className="mb20">
             <FormattedMessage defaultMessage="Wrong network" />
           </Heading>
@@ -74,10 +92,11 @@ const WalletConnectModal: React.FC = () => {
     );
   }
 
-  if (active) return null;
+  if (active || !loading) return null;
 
   return (
     <Layer>
+      <Close src={closeGlyph} onClick={handleClose} />
       <Heading level={2} color="blueMedium" style={{ margin: '20px auto' }}>
         <FormattedMessage defaultMessage="Connect a wallet" />
       </Heading>

--- a/src/pages/TopUp/components/WalletConnectModal.tsx
+++ b/src/pages/TopUp/components/WalletConnectModal.tsx
@@ -40,13 +40,13 @@ const Close = styled.img`
 
 const WalletConnectModal: React.FC<{
   loading: boolean;
-  setLoading: (_: boolean) => void;
+  handleModalClose: () => void;
 }> = ({
   loading,
-  setLoading,
+  handleModalClose,
 }: {
   loading: boolean;
-  setLoading: (_: boolean) => void;
+  handleModalClose: () => void;
 }) => {
   const {
     connector,
@@ -66,10 +66,6 @@ const WalletConnectModal: React.FC<{
 
     return !Object.values(AllowedNetworks).includes(network);
   }, [chainId]);
-
-  const handleClose = () => {
-    setLoading(false);
-  };
 
   if (isInvalidNetwork) {
     return (
@@ -102,7 +98,7 @@ const WalletConnectModal: React.FC<{
 
   return (
     <Layer>
-      <Close src={closeGlyph} onClick={handleClose} />
+      <Close src={closeGlyph} onClick={handleModalClose} />
       <Heading level={2} color="blueMedium" style={{ margin: '20px auto' }}>
         <FormattedMessage defaultMessage="Connect a wallet" />
       </Heading>

--- a/src/pages/TopUp/components/WalletConnectModal.tsx
+++ b/src/pages/TopUp/components/WalletConnectModal.tsx
@@ -40,8 +40,14 @@ const Close = styled.img`
 
 const WalletConnectModal: React.FC<{
   loading: boolean;
-  setLoading: any;
-}> = ({ loading, setLoading }: { loading: any; setLoading: any }) => {
+  setLoading: (_: boolean) => void;
+}> = ({
+  loading,
+  setLoading,
+}: {
+  loading: boolean;
+  setLoading: (_: boolean) => void;
+}) => {
   const {
     connector,
     error,

--- a/src/pages/TopUp/components/WalletConnectModal.tsx
+++ b/src/pages/TopUp/components/WalletConnectModal.tsx
@@ -27,15 +27,19 @@ import portisLogo from '../../../static/portis.svg';
 import fortmaticLogo from '../../../static/fortmatic.svg';
 import { Heading } from '../../../components/Heading';
 import { Text } from '../../../components/Text';
+import { NakedButton } from '../../../components/NakedButton';
 import { MetamaskHardwareButton } from '../../ConnectWallet/MetamaskHardwareButton';
+import { useKeyPress } from '../../../hooks/useKeyPress';
+
+const CloseButton = styled(NakedButton)`
+  padding: 1rem;
+  align-self: flex-end;
+`;
 
 const Close = styled.img`
   height: 24px;
   width: 24px;
   display: block;
-  align-self: flex-end;
-  margin: 16px 16px 0 0;
-  cursor: pointer;
 `;
 
 const WalletConnectModal: React.FC<{
@@ -66,6 +70,8 @@ const WalletConnectModal: React.FC<{
 
     return !Object.values(AllowedNetworks).includes(network);
   }, [chainId]);
+
+  useKeyPress('Escape', handleModalClose);
 
   if (isInvalidNetwork) {
     return (
@@ -98,7 +104,9 @@ const WalletConnectModal: React.FC<{
 
   return (
     <Layer>
-      <Close src={closeGlyph} onClick={handleModalClose} />
+      <CloseButton onClick={handleModalClose}>
+        <Close src={closeGlyph} />
+      </CloseButton>
       <Heading level={2} color="blueMedium" style={{ margin: '20px auto' }}>
         <FormattedMessage defaultMessage="Connect a wallet" />
       </Heading>

--- a/src/pages/TopUp/index.tsx
+++ b/src/pages/TopUp/index.tsx
@@ -26,6 +26,7 @@ import {
 import { AllowedNetworks, NetworkChainId } from '../ConnectWallet/web3Utils';
 import { Alert } from '../../components/Alert';
 import { Link } from '../../components/Link';
+import { Button } from '../../components/Button';
 
 const Arrow = styled(props => <FormPrevious {...props} />)`
   position: absolute;
@@ -50,6 +51,10 @@ const FakeLink = styled.span`
   text-decoration: underline;
   cursor: pointer;
   display: inline;
+`;
+
+const ButtonLink = styled(FakeLink)`
+  text-decoration: none;
 `;
 
 const _TopUpPage: React.FC<Props> = () => {
@@ -146,11 +151,27 @@ const _TopUpPage: React.FC<Props> = () => {
     setSelectedValidator,
   ] = useState<BeaconChainValidator | null>(null);
 
+  const handleConnect = () => {
+    setLoading(true);
+    deactivate();
+  };
+
   const topUpPageContent = React.useMemo(() => {
-    if (loading || !active) {
+    if (loading) {
       return <Spinner className="mt40" />;
     }
 
+    if (!active) {
+      return (
+        <ButtonLink onClick={handleConnect}>
+          <Button
+            className="flex"
+            rainbow
+            label={formatMessage({ defaultMessage: 'Connect wallet' })}
+          />
+        </ButtonLink>
+      );
+    }
     if (validatorLoadError) {
       return (
         <Alert variant="warning" className="my10">
@@ -212,6 +233,7 @@ const _TopUpPage: React.FC<Props> = () => {
         <ValidatorTable
           validators={validators}
           setSelectedValidator={setSelectedValidator}
+          handleConnect={handleConnect}
         />
       </>
     );
@@ -228,7 +250,7 @@ const _TopUpPage: React.FC<Props> = () => {
   return (
     <>
       {/* the wallet connect modal controls it's own display, so it is always rendered here */}
-      <WalletConnectModal />
+      <WalletConnectModal loading={loading} setLoading={setLoading} />
 
       <PageTemplate
         title={formatMessage({ defaultMessage: 'Top up a validator' })}

--- a/src/pages/TopUp/index.tsx
+++ b/src/pages/TopUp/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useWeb3React } from '@web3-react/core';
 import { Web3Provider } from '@ethersproject/providers';
@@ -77,7 +77,7 @@ const _TopUpPage: React.FC<Props> = () => {
   const { formatMessage } = useIntl();
 
   // an effect that fetches validators from beaconchain when the user connects or changes their wallet
-  React.useEffect(() => {
+  useEffect(() => {
     const fetchValidatorsForUserAddress = async () => {
       setLoading(true);
 
@@ -151,12 +151,12 @@ const _TopUpPage: React.FC<Props> = () => {
     setSelectedValidator,
   ] = useState<BeaconChainValidator | null>(null);
 
-  const handleConnect = () => {
+  const handleConnect = useCallback(() => {
     setLoading(true);
     deactivate();
-  };
+  }, [setLoading, deactivate]);
 
-  const topUpPageContent = React.useMemo(() => {
+  const topUpPageContent = useMemo(() => {
     if (loading) {
       return <Spinner className="mt40" />;
     }

--- a/src/pages/TopUp/index.tsx
+++ b/src/pages/TopUp/index.tsx
@@ -245,6 +245,8 @@ const _TopUpPage: React.FC<Props> = () => {
     validators,
     showDepositVerificationWarning,
     deactivate,
+    formatMessage,
+    handleConnect,
   ]);
 
   return (

--- a/src/pages/TopUp/index.tsx
+++ b/src/pages/TopUp/index.tsx
@@ -166,10 +166,14 @@ const _TopUpPage: React.FC<Props> = () => {
     setSelectedValidator,
   ] = useState<BeaconChainValidator | null>(null);
 
-  const handleConnect = useCallback(() => {
+  const handleConnect = useCallback((): void => {
     setLoading(true);
     deactivate();
   }, [setLoading, deactivate]);
+
+  const handleModalClose = useCallback((): void => {
+    setLoading(false);
+  }, [setLoading]);
 
   const topUpPageContent = useMemo(() => {
     if (loading) {
@@ -268,7 +272,10 @@ const _TopUpPage: React.FC<Props> = () => {
   return (
     <>
       {/* the wallet connect modal controls it's own display, so it is always rendered here */}
-      <WalletConnectModal loading={loading} setLoading={setLoading} />
+      <WalletConnectModal
+        loading={loading}
+        handleModalClose={handleModalClose}
+      />
 
       <PageTemplate
         title={formatMessage({ defaultMessage: 'Top up a validator' })}

--- a/src/pages/TopUp/index.tsx
+++ b/src/pages/TopUp/index.tsx
@@ -55,6 +55,21 @@ const FakeLink = styled.span`
 
 const ButtonLink = styled(FakeLink)`
   text-decoration: none;
+  width: fit-content;
+  button {
+    padding: 16px 32px;
+  }
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  @media screen and (max-width: 518px) {
+    span,
+    button {
+      width: 100%;
+    }
+  }
 `;
 
 const _TopUpPage: React.FC<Props> = () => {
@@ -163,13 +178,14 @@ const _TopUpPage: React.FC<Props> = () => {
 
     if (!active) {
       return (
-        <ButtonLink onClick={handleConnect}>
-          <Button
-            className="flex"
-            rainbow
-            label={formatMessage({ defaultMessage: 'Connect wallet' })}
-          />
-        </ButtonLink>
+        <ButtonContainer>
+          <ButtonLink onClick={handleConnect}>
+            <Button
+              rainbow
+              label={formatMessage({ defaultMessage: 'Connect wallet' })}
+            />
+          </ButtonLink>
+        </ButtonContainer>
       );
     }
     if (validatorLoadError) {

--- a/src/static/close.svg
+++ b/src/static/close.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M22 2L2 22M2 2L22 22" stroke="black" stroke-width="4"/>
+</svg>


### PR DESCRIPTION
## Description
- Adds closing `X` to modal pop-up on `/top-up` page
- Adds "Connect wallet" button to same page if user has not connected, and has exited the modal

## Related issue
[Fixes #383]