### PR TITLE
Link hover styling change [Fixes #501]

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -19,8 +19,9 @@ const styles = `
   color:inherit;
   display: inherit;
   text-decoration: none;
+  font-weight: 400;
   &:hover {
-    font-weight: 400;
+    opacity: 0.8;
   };
   &:focus,
   &:visited,


### PR DESCRIPTION
### Description
Changes Link component to `font-weight: 400;` always, and instead dims to `opacity: 0.8;` on hover.

### Related issue
[Fixes #501]