### PR TITLE
Ropsten post-merge update

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -159,24 +159,6 @@
       "value": " ETH maximum?"
     }
   ],
-  "/iuoP7": [
-    {
-      "type": 1,
-      "value": "networkBold"
-    },
-    {
-      "type": 0,
-      "value": " will be the first longstanding public testnet to undergo The Merge. Historically a proof-of-work testnet, "
-    },
-    {
-      "type": 1,
-      "value": "network"
-    },
-    {
-      "type": 0,
-      "value": " now has its own proof-of-stake beacon chain which will be merged with the execution layer in the near future (if it hasn't happened already)."
-    }
-  ],
   "/jJLYy": [
     {
       "type": 0,
@@ -1987,6 +1969,24 @@
       "value": "Total amount required"
     }
   ],
+  "H/LXxz": [
+    {
+      "type": 1,
+      "value": "networkBold"
+    },
+    {
+      "type": 0,
+      "value": " was the first longstanding public testnet to undergo The Merge, which occurred on June 8, 2022. Historically a proof-of-work testnet, "
+    },
+    {
+      "type": 1,
+      "value": "network"
+    },
+    {
+      "type": 0,
+      "value": " has now transitioned to proof-of-stake by merging its historical execution layer with a new beacon chain."
+    }
+  ],
   "H0lQfu": [
     {
       "type": 0,
@@ -3169,6 +3169,16 @@
     {
       "type": 0,
       "value": "How many validators would you like to run?"
+    }
+  ],
+  "Riq4Yh": [
+    {
+      "type": 1,
+      "value": "network"
+    },
+    {
+      "type": 0,
+      "value": " is open for anyone to interact with. Try sending some transactions, running a validator, or see if you can get slashed!"
     }
   ],
   "RkSC5Q": [
@@ -5879,16 +5889,6 @@
     {
       "type": 0,
       "value": "Deposit summary"
-    }
-  ],
-  "q+ux+M": [
-    {
-      "type": 1,
-      "value": "network"
-    },
-    {
-      "type": 0,
-      "value": " is open for anyone to interact with. Try sending some transactions, running a validator on its new beacon chain, or see if you can get slashed!"
     }
   ],
   "q2XW/k": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -59,9 +59,6 @@
   "/h0DGY": {
     "message": "Why the {pricePerValidator} ETH maximum?"
   },
-  "/iuoP7": {
-    "message": "{networkBold} will be the first longstanding public testnet to undergo The Merge. Historically a proof-of-work testnet, {network} now has its own proof-of-stake beacon chain which will be merged with the execution layer in the near future (if it hasn't happened already)."
-  },
   "/jJLYy": {
     "message": "Transactions"
   },
@@ -764,6 +761,9 @@
   "H+kIpp": {
     "message": "Total amount required"
   },
+  "H/LXxz": {
+    "message": "{networkBold} was the first longstanding public testnet to undergo The Merge, which occurred on June 8, 2022. Historically a proof-of-work testnet, {network} has now transitioned to proof-of-stake by merging its historical execution layer with a new beacon chain."
+  },
   "H0lQfu": {
     "message": "Merge Readiness Checklist"
   },
@@ -1219,6 +1219,9 @@
   },
   "Rg5ySE": {
     "message": "How many validators would you like to run?"
+  },
+  "Riq4Yh": {
+    "message": "{network} is open for anyone to interact with. Try sending some transactions, running a validator, or see if you can get slashed!"
   },
   "RkSC5Q": {
     "message": "Reminder, the Merge upgrade will {not} implement withdrawing or transferring of staked ETH. This feature will be included in the Shanghai upgrade planned to follow the Merge."
@@ -2257,9 +2260,6 @@
   },
   "pyWt01": {
     "message": "Deposit summary"
-  },
-  "q+ux+M": {
-    "message": "{network} is open for anyone to interact with. Try sending some transactions, running a validator on its new beacon chain, or see if you can get slashed!"
   },
   "q2XW/k": {
     "message": "If your withdrawal key is stolen, the thief can transfer your validator’s balance, but only once the validator has exited."

--- a/src/pages/MergeReadiness/index.tsx
+++ b/src/pages/MergeReadiness/index.tsx
@@ -476,7 +476,7 @@ export const MergeReadiness = () => {
           </Text>
           <Text className="mt20">
             <FormattedMessage
-              defaultMessage="{networkBold} will be the first longstanding public testnet to undergo The Merge. Historically a proof-of-work testnet, {network} now has its own proof-of-stake beacon chain which will be merged with the execution layer in the near future (if it hasn't happened already)."
+              defaultMessage="{networkBold} was the first longstanding public testnet to undergo The Merge, which occurred on June 8, 2022. Historically a proof-of-work testnet, {network} has now transitioned to proof-of-stake by merging its historical execution layer with a new beacon chain."
               values={{
                 networkBold: <strong>Ropsten</strong>,
                 network: 'Ropsten',
@@ -485,7 +485,7 @@ export const MergeReadiness = () => {
           </Text>
           <Text className="mt20">
             <FormattedMessage
-              defaultMessage="{network} is open for anyone to interact with. Try sending some transactions, running a validator on its new beacon chain, or see if you can get slashed!"
+              defaultMessage="{network} is open for anyone to interact with. Try sending some transactions, running a validator, or see if you can get slashed!"
               values={{ network: 'Ropsten' }}
             />
           </Text>


### PR DESCRIPTION
Ropsten underwent The Merge today :tada:
Updates Merge Readiness copy to frame Ropsten merge as past-tense. 