### PR TITLE
Await TTD notice added for MergeReadiness [Fixes #511]

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -5,12 +5,6 @@
       "value": "Step 2: Generate deposit keys using the Ethereum Foundation deposit tool"
     }
   ],
-  "+M/NC/": [
-    {
-      "type": 0,
-      "value": "After the merge, there will no longer be two distinct Ethereum networks; there will only be Ethereum."
-    }
-  ],
   "+UUcBt": [
     {
       "type": 0,
@@ -407,6 +401,12 @@
     {
       "type": 0,
       "value": "Documentation on running Nethermind"
+    }
+  ],
+  "1wSJQU": [
+    {
+      "type": 0,
+      "value": "Timing:"
     }
   ],
   "22EpKq": [
@@ -1231,6 +1231,24 @@
       "value": "Overview"
     }
   ],
+  "9vLu6E": [
+    {
+      "type": 1,
+      "value": "note"
+    },
+    {
+      "type": 0,
+      "value": " This step should be performed on "
+    },
+    {
+      "type": 1,
+      "value": "testnetsOnly"
+    },
+    {
+      "type": 0,
+      "value": " until the Mainnet TTD (terminal total difficulty) has been announced and clients have released an update. Info is presented for preparation in the meantime."
+    }
+  ],
   "9xeLhs": [
     {
       "type": 0,
@@ -1859,6 +1877,12 @@
     {
       "type": 0,
       "value": "Terms of service"
+    }
+  ],
+  "FqztZR": [
+    {
+      "type": 0,
+      "value": "Note:"
     }
   ],
   "FzkbsB": [
@@ -3007,6 +3031,20 @@
     {
       "type": 0,
       "value": " to max out your effective balance."
+    }
+  ],
+  "Q8fnvz": [
+    {
+      "type": 0,
+      "value": "testnets only (e.g. "
+    },
+    {
+      "type": 1,
+      "value": "kiln"
+    },
+    {
+      "type": 0,
+      "value": ")"
     }
   ],
   "QKFeMq": [
@@ -6237,6 +6275,12 @@
       "value": "What should the address be?"
     }
   ],
+  "tgvES0": [
+    {
+      "type": 0,
+      "value": "Now"
+    }
+  ],
   "tigMuZ": [
     {
       "type": 0,
@@ -6399,6 +6443,12 @@
       "value": "Become a validator with Nimbus"
     }
   ],
+  "ulgIVs": [
+    {
+      "type": 0,
+      "value": "After the merge, there will no longer be two distinct Ethereum networks; there will only be Ethereum."
+    }
+  ],
   "uoKhQB": [
     {
       "type": 0,
@@ -6453,6 +6503,12 @@
     {
       "type": 0,
       "value": "Proceed with caution. Our on-chain data source is down and we are unable to flag any double deposits."
+    }
+  ],
+  "vUxy+H": [
+    {
+      "type": 0,
+      "value": "After TTD client releases"
     }
   ],
   "vV6ua0": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -2,9 +2,6 @@
   "+L0IkF": {
     "message": "Step 2: Generate deposit keys using the Ethereum Foundation deposit tool"
   },
-  "+M/NC/": {
-    "message": "After the merge, there will no longer be two distinct Ethereum networks; there will only be Ethereum."
-  },
   "+UUcBt": {
     "message": "Choose a language"
   },
@@ -164,6 +161,9 @@
   },
   "1pUw7Y": {
     "message": "Documentation on running Nethermind"
+  },
+  "1wSJQU": {
+    "message": "Timing:"
   },
   "22EpKq": {
     "description": "{JSON} is filetype extension",
@@ -456,6 +456,9 @@
   "9uOFF3": {
     "message": "Overview"
   },
+  "9vLu6E": {
+    "message": "{note} This step should be performed on {testnetsOnly} until the Mainnet TTD (terminal total difficulty) has been announced and clients have released an update. Info is presented for preparation in the meantime."
+  },
   "9xeLhs": {
     "message": "Ethereum address withdrawal: If you want to withdraw to your Mainnet wallet address (formerly 'Eth1' address) after the post-merge cleanup upgrade, you can set {ethAddressWithdraw} when running deposit-cli. {boldWarning}"
   },
@@ -706,6 +709,9 @@
   },
   "FqgDIV": {
     "message": "Terms of service"
+  },
+  "FqztZR": {
+    "message": "Note:"
   },
   "FzkbsB": {
     "message": "validators"
@@ -1156,6 +1162,9 @@
   },
   "Q8P0rZ": {
     "message": "Validators have a maximum effective balance of {PRICE_PER_VALIDATOR} {TICKER_NAME}. You only need to top up {maxTopupValue} {TICKER_NAME} to max out your effective balance."
+  },
+  "Q8fnvz": {
+    "message": "testnets only (e.g. {kiln})"
   },
   "QKFeMq": {
     "message": "Internet"
@@ -2392,6 +2401,9 @@
   "teyxVk": {
     "message": "What should the address be?"
   },
+  "tgvES0": {
+    "message": "Now"
+  },
   "tigMuZ": {
     "message": "Wait at least 30 minutes before trying to resubmit a transaction with this {depositData} file. This will give our on-chain data source time to flag any duplicate deposits."
   },
@@ -2451,6 +2463,9 @@
   "ukfwum": {
     "message": "Become a validator with Nimbus"
   },
+  "ulgIVs": {
+    "message": "After the merge, there will no longer be two distinct Ethereum networks; there will only be Ethereum."
+  },
   "uoKhQB": {
     "message": "Authentication API"
   },
@@ -2475,6 +2490,9 @@
   },
   "vJez0K": {
     "message": "Proceed with caution. Our on-chain data source is down and we are unable to flag any double deposits."
+  },
+  "vUxy+H": {
+    "message": "After TTD client releases"
   },
   "vV6ua0": {
     "message": "Step 1: Download the Wagyu Key Gen app for your operating system"

--- a/src/pages/MergeReadiness/index.tsx
+++ b/src/pages/MergeReadiness/index.tsx
@@ -22,6 +22,10 @@ const ChecklistPageStyles = styled.div`
       margin-bottom: 5px;
     }
   }
+  section.pending {
+    filter: grayscale(100%);
+    opacity: 75%;
+  }
   label {
     padding: 1rem;
   }
@@ -54,6 +58,7 @@ const Subtitle = styled.p`
 const CardContainer = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 200px), 1fr));
+  grid-auto-rows: 1fr;
   gap: 1rem;
   @media only screen and (max-width: ${p => p.theme.screenSizes.medium}) {
     flex-direction: column;
@@ -61,12 +66,13 @@ const CardContainer = styled.div`
 `;
 
 const Card = styled.div`
+  display: flex;
   padding: 24px;
   border: 1px solid ${p => p.theme.gray.dark};
   border-radius: 4px;
   width: 100%;
+  height: 100%;
   background: white;
-  display: flex;
   align-items: center;
   width: 100%;
   justify-content: space-between;
@@ -74,12 +80,24 @@ const Card = styled.div`
     margin: 0px;
     margin-top: 16px;
   }
+  &.pending {
+    filter: grayscale(75%);
+    opacity: 60%;
+  }
 
+  transform: scale(1);
+  transition: transform 0.1s;
   &:hover {
     cursor: pointer;
     box-shadow: 0px 8px 17px rgba(0, 0, 0, 0.15);
     transition: transform 0.1s;
     transform: scale(1.02);
+  }
+
+  p.timing {
+    font-size: 0.875rem;
+    line-height: 140%;
+    margin-bottom: 0;
   }
 `;
 
@@ -113,18 +131,23 @@ export const MergeReadiness = () => {
   const sections = [
     {
       heading: <FormattedMessage defaultMessage="Task 1" />,
+      timing: <FormattedMessage defaultMessage="Now" />,
       title: <FormattedMessage defaultMessage="Both layers required" />,
       id: 'el-plus-cl',
     },
     {
       heading: <FormattedMessage defaultMessage="Task 2" />,
+      timing: <FormattedMessage defaultMessage="After TTD client releases" />,
       title: <FormattedMessage defaultMessage="Authenticate Engine API" />,
       id: 'authenticate',
+      pending: true,
     },
     {
       heading: <FormattedMessage defaultMessage="Task 3" />,
+      timing: <FormattedMessage defaultMessage="After TTD client releases" />,
       title: <FormattedMessage defaultMessage="Set fee recipient" />,
       id: 'fee-recipient',
+      pending: true,
     },
     {
       heading: <FormattedMessage defaultMessage="Bonus" />,
@@ -132,6 +155,33 @@ export const MergeReadiness = () => {
       id: 'additional-reminders',
     },
   ];
+
+  const TimingWarning = () => (
+    <SectionHeader className="m0 pt0">
+      <Alert variant="error" className="m0">
+        <Text>
+          <FormattedMessage
+            defaultMessage="{note} This step should be performed on {testnetsOnly} until the Mainnet TTD (terminal total difficulty) has been announced and clients have released an update. Info is presented for preparation in the meantime."
+            values={{
+              note: (
+                <strong>
+                  <FormattedMessage defaultMessage="Note:" />
+                </strong>
+              ),
+              testnetsOnly: (
+                <Link to="#testing-the-merge" inline primary>
+                  <FormattedMessage
+                    defaultMessage="testnets only (e.g. {kiln})"
+                    values={{ kiln: 'Kiln' }}
+                  />
+                </Link>
+              ),
+            }}
+          />
+        </Text>
+      </Alert>
+    </SectionHeader>
+  );
 
   return (
     <PageTemplate
@@ -148,9 +198,9 @@ export const MergeReadiness = () => {
       </Subtitle>
 
       <CardContainer>
-        {sections.map(({ heading, title, id }) => (
+        {sections.map(({ heading, title, timing, pending, id }) => (
           <StyledLink to={`#${id}`} inline isTextLink={false} key={id}>
-            <Card>
+            <Card className={pending ? 'pending' : ''}>
               <div>
                 <Heading level={4} className="mb10">
                   {heading}
@@ -158,13 +208,17 @@ export const MergeReadiness = () => {
                 <BoldGreen className="mr10" fontSize={24}>
                   {title}
                 </BoldGreen>
+                {timing && (
+                  <p className={`timing ${pending ? 'pending' : null}`}>
+                    <FormattedMessage defaultMessage="Timing:" /> {timing}
+                  </p>
+                )}
               </div>
               <FormNext size="large" />
             </Card>
           </StyledLink>
         ))}
       </CardContainer>
-
       <ChecklistPageStyles>
         <SectionHeader id={sections[0].id}>
           <Heading level={3}>
@@ -176,7 +230,7 @@ export const MergeReadiness = () => {
             <FormattedMessage defaultMessage="Post-merge, an Ethereum node will be comprised of both an execution layer (EL) client, and a consensus layer (CL) client. EL + CL = Ethereum." />
           </Text>
         </SectionHeader>
-        <section>
+        <section className={sections[0].pending ? 'pending' : ''}>
           <Text className="mt20">
             <FormattedMessage defaultMessage="Since the genesis of the Beacon Chain, many validators running their own consensus layer (CL) client have opted to use third-party services for their execution layer (EL) connection. This has been acceptable since the only thing being listened to has been the staking deposit contract." />
           </Text>
@@ -219,10 +273,8 @@ export const MergeReadiness = () => {
             <FormattedMessage defaultMessage="The execution and consensus layers work together tightly, and require authentication to stay safe. " />
           </Text>
         </SectionHeader>
-        <section>
-          {/* <Heading level={3} id="engine-api-jwt">
-            <FormattedMessage defaultMessage="Engine API" />
-          </Heading> */}
+        <TimingWarning />
+        <section className={sections[1].pending ? 'pending' : ''}>
           <Text className="mt20">
             <FormattedMessage
               defaultMessage="Communication between the execution layer and consensus layer will occur using the {engineApi}. This is a new set of JSON RPC methods that can be used to communicate between the two client layers."
@@ -239,9 +291,6 @@ export const MergeReadiness = () => {
               }}
             />
           </Text>
-          {/* <Heading level={3} id="engine-api-jwt">
-            <FormattedMessage defaultMessage="JWT" />
-          </Heading> */}
           <Text className="mt20">
             <FormattedMessage
               defaultMessage="This communication is secured using a {jwt} secret, which is a secret key that is shared only between the two clients to authenticate one another. This shared JWT secret must be made available to each client (both EL and CL) to properly authenticate the Engine API, allowing them to properly communicate between one another."
@@ -353,6 +402,7 @@ export const MergeReadiness = () => {
                 />
               </Text>
             }
+            disabled={sections[1].pending}
           />
         </section>
         <SectionHeader id={sections[2].id}>
@@ -365,7 +415,8 @@ export const MergeReadiness = () => {
             <FormattedMessage defaultMessage="Fees rewards are coming to validators, don't miss out!" />
           </Text>
         </SectionHeader>
-        <section>
+        <TimingWarning />
+        <section className={sections[2].pending ? 'pending' : ''}>
           <Text className="mt20">
             <FormattedMessage defaultMessage="Now that transactions must be processed by validators, the validators that propose blocks including these transactions are eligible to receive the transaction fee tips. These are also known as priority fees, and are the unburnt portion of gas fees." />
           </Text>
@@ -435,6 +486,7 @@ export const MergeReadiness = () => {
                 <FormattedMessage defaultMessage="I understand that I will earn the unburnt transaction fees (tips/priority fees) when I propose a block, and this is accounted for on the execution layer, not my validator balance." />
               </Text>
             }
+            disabled={sections[2].pending}
           />
           <CheckBox
             label={
@@ -442,6 +494,7 @@ export const MergeReadiness = () => {
                 <FormattedMessage defaultMessage="I have provided an Ethereum address to my validator where I would like my fee rewards to be deposited." />
               </Text>
             }
+            disabled={sections[2].pending}
           />
         </section>
         <SectionHeader id={sections[3].id}>


### PR DESCRIPTION
## Description
- Updates design of /merge-readiness page to include notices about waiting on certain tasks until the TTD has been announced and included in client updates.
- Design changes include dimming of the two tasks that should not yet be performed and disabling the checklist buttons.
- Adds "timing" note to the task cards

## Related issue
- #511 

## Preview link
https://deploy-preview-514--serene-carson-3331d5.netlify.app/en/merge-readiness