### PR TITLE
Add sync note to client selection

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -4773,6 +4773,12 @@
       "value": "During setup"
     }
   ],
+  "fZwn+P": [
+    {
+      "type": 0,
+      "value": "After client installation, ensure you are fully synced before submitting your staking deposit. This can take several days."
+    }
+  ],
   "fbiteI": [
     {
       "type": 0,

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -1825,6 +1825,9 @@
   "fR8+bQ": {
     "message": "During setup"
   },
+  "fZwn+P": {
+    "message": "After client installation, ensure you are fully synced before submitting your staking deposit. This can take several days."
+  },
   "fbiteI": {
     "message": "only stored on one validator machine"
   },

--- a/src/pages/SelectClient/SelectClientSection.tsx
+++ b/src/pages/SelectClient/SelectClientSection.tsx
@@ -93,10 +93,20 @@ const SelectClientSection = ({
         <Heading level={4} className="mb10">
           <FormattedMessage defaultMessage="Remember" />
         </Heading>
-        <FormattedMessage defaultMessage="All stakers must operate an execution client as well as a consensus client starting at the Merge. Make sure you're prepared." />
-        <Link primary to="/merge-readiness" className="mt10">
-          <FormattedMessage defaultMessage="Merge Readiness Checklist" />
-        </Link>
+        <ul>
+          <li>
+            <FormattedMessage defaultMessage="After client installation, ensure you are fully synced before submitting your staking deposit. This can take several days." />{' '}
+            <Link primary inline to="/checklist">
+              <FormattedMessage defaultMessage="Validator checklist" />
+            </Link>
+          </li>
+          <li>
+            <FormattedMessage defaultMessage="All stakers must operate an execution client as well as a consensus client starting at the Merge. Make sure you're prepared." />{' '}
+            <Link primary inline to="/merge-readiness">
+              <FormattedMessage defaultMessage="Merge readiness checklist" />
+            </Link>
+          </li>
+        </ul>
       </Alert>
     </Box>
   </Paper>


### PR DESCRIPTION
## Description
- Adds a note on the client selection page to remind users that they should make sure their clients are fully syncs before submitting their staking deposit. 

## Related issue
Suggested [here](https://hackmd.io/@prysmaticlabs/validator-ux)