### PR TITLE
Translate "merge readiness checklist" on upgrades page

### DIFF
--- a/src/pages/Landing/Upgrades/index.tsx
+++ b/src/pages/Landing/Upgrades/index.tsx
@@ -133,7 +133,7 @@ export const Upgrades = (): JSX.Element => {
                   values={{
                     mergeReadinessChecklist: (
                       <Link primary inline to="/merge-readiness">
-                        Merge Readiness Checklist
+                        <FormattedMessage defaultMessage="Merge readiness checklist" />
                       </Link>
                     ),
                   }}


### PR DESCRIPTION
## Description

- Noticed [we're translating this string elsewhere](https://github.com/ethereum/staking-launchpad/blob/b65c9e38fd59c78bfeb84f4f0b8846e270a8caea/src/components/MergeNotification.tsx#L19), but not here.