### PR TITLE
Add translation support for nested strings

### DIFF
--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -8,7 +8,6 @@ import { useWeb3React } from '@web3-react/core';
 import { Web3Provider } from '@ethersproject/providers';
 import EthDiamond from '../static/eth-diamond-plain.svg';
 import { web3ReactInterface } from '../pages/ConnectWallet';
-import { trimString } from '../utils/trimString';
 import {
   AllowedNetworks,
   NetworkChainId,
@@ -24,8 +23,9 @@ import {
   MAINNET_LAUNCHPAD_URL,
   TESTNET_LAUNCHPAD_NAME,
   TESTNET_LAUNCHPAD_URL,
-  EL_TESTNET_NAME,
 } from '../utils/envVars';
+import { trimString } from '../utils/trimString';
+import useNetworkName from '../hooks/useIntlNetworkName';
 import useMobileCheck from '../hooks/useMobileCheck';
 
 const RainbowBackground = styled(Box)`
@@ -124,6 +124,15 @@ const _AppBar = ({ location }: RouteComponentProps) => {
     account,
     chainId,
   }: web3ReactInterface = useWeb3React<Web3Provider>();
+  const { executionLayerName, consensusLayerName } = useNetworkName();
+  const oppositeNetwork = IS_MAINNET ? (
+    <FormattedMessage
+      defaultMessage="{TESTNET_LAUNCHPAD_NAME} testnet"
+      values={{ TESTNET_LAUNCHPAD_NAME }}
+    />
+  ) : (
+    <FormattedMessage defaultMessage="Mainnet" />
+  );
 
   let network;
   let networkAllowed = false;
@@ -150,16 +159,6 @@ const _AppBar = ({ location }: RouteComponentProps) => {
   const switchLaunchpadUrl = IS_MAINNET
     ? TESTNET_LAUNCHPAD_URL
     : MAINNET_LAUNCHPAD_URL;
-
-  const networkName = IS_MAINNET ? (
-    <FormattedMessage defaultMessage="Mainnet" />
-  ) : (
-    <FormattedMessage
-      defaultMessage="{testNetwork} testnet"
-      values={{ testNetwork: EL_TESTNET_NAME }}
-      description="{testNetwork} is the proper testnet name; do not translate this name"
-    />
-  );
 
   return (
     <RainbowBackground
@@ -321,30 +320,12 @@ const _AppBar = ({ location }: RouteComponentProps) => {
                   )}
                   <span>
                     <FormattedMessage defaultMessage="Launchpad network:" />{' '}
-                    <b>
-                      {IS_MAINNET ? (
-                        <FormattedMessage defaultMessage="Mainnet" />
-                      ) : (
-                        <FormattedMessage
-                          defaultMessage="{TESTNET_LAUNCHPAD_NAME} testnet"
-                          values={{ TESTNET_LAUNCHPAD_NAME }}
-                        />
-                      )}
-                    </b>
+                    <b>{consensusLayerName}</b>
                   </span>
                   <Link primary to={switchLaunchpadUrl}>
                     <FormattedMessage
-                      defaultMessage="Switch to {network} launchpad"
-                      values={{
-                        network: IS_MAINNET ? (
-                          <FormattedMessage
-                            defaultMessage="{TESTNET_LAUNCHPAD_NAME} testnet"
-                            values={{ TESTNET_LAUNCHPAD_NAME }}
-                          />
-                        ) : (
-                          <FormattedMessage defaultMessage="Mainnet" />
-                        ),
-                      }}
+                      defaultMessage="Switch to {oppositeNetwork} launchpad"
+                      values={{ oppositeNetwork }}
                     />
                   </Link>
                   <Text className="mt20">
@@ -410,17 +391,8 @@ const _AppBar = ({ location }: RouteComponentProps) => {
                   )}
                   <DropdownLink to={switchLaunchpadUrl}>
                     <FormattedMessage
-                      defaultMessage="Switch to {network} launchpad"
-                      values={{
-                        network: IS_MAINNET ? (
-                          <FormattedMessage
-                            defaultMessage="{TESTNET_LAUNCHPAD_NAME} testnet"
-                            values={{ TESTNET_LAUNCHPAD_NAME }}
-                          />
-                        ) : (
-                          <FormattedMessage defaultMessage="Mainnet" />
-                        ),
-                      }}
+                      defaultMessage="Switch to {oppositeNetwork} launchpad"
+                      values={{ oppositeNetwork }}
                     />
                   </DropdownLink>
                 </Box>
@@ -453,8 +425,8 @@ const _AppBar = ({ location }: RouteComponentProps) => {
                   <Box pad="small">
                     <Text>
                       <FormattedMessage
-                        defaultMessage="Your wallet should be set to {networkName} to use this launchpad."
-                        values={{ networkName }}
+                        defaultMessage="Your wallet should be set to {executionLayerName} to use this launchpad."
+                        values={{ executionLayerName }}
                       />
                     </Text>
                   </Box>

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -151,9 +151,15 @@ const _AppBar = ({ location }: RouteComponentProps) => {
     ? TESTNET_LAUNCHPAD_URL
     : MAINNET_LAUNCHPAD_URL;
 
-  const networkName = IS_MAINNET
-    ? 'mainnet'
-    : `${EL_TESTNET_NAME.toLowerCase()} testnet`;
+  const networkName = IS_MAINNET ? (
+    <FormattedMessage defaultMessage="Mainnet" />
+  ) : (
+    <FormattedMessage
+      defaultMessage="{testNetwork} testnet"
+      values={{ testNetwork: EL_TESTNET_NAME }}
+      description="{testNetwork} is the proper testnet name; do not translate this name"
+    />
+  );
 
   return (
     <RainbowBackground
@@ -316,20 +322,28 @@ const _AppBar = ({ location }: RouteComponentProps) => {
                   <span>
                     <FormattedMessage defaultMessage="Launchpad network:" />{' '}
                     <b>
-                      {IS_MAINNET
-                        ? `mainnet`
-                        : `${TESTNET_LAUNCHPAD_NAME} testnet`}
+                      {IS_MAINNET ? (
+                        <FormattedMessage defaultMessage="Mainnet" />
+                      ) : (
+                        <FormattedMessage
+                          defaultMessage="{TESTNET_LAUNCHPAD_NAME} testnet"
+                          values={{ TESTNET_LAUNCHPAD_NAME }}
+                        />
+                      )}
                     </b>
                   </span>
                   <Link primary to={switchLaunchpadUrl}>
                     <FormattedMessage
                       defaultMessage="Switch to {network} launchpad"
                       values={{
-                        network: `${
-                          IS_MAINNET
-                            ? `${TESTNET_LAUNCHPAD_NAME} testnet`
-                            : `mainnet`
-                        }`,
+                        network: IS_MAINNET ? (
+                          <FormattedMessage
+                            defaultMessage="{TESTNET_LAUNCHPAD_NAME} testnet"
+                            values={{ TESTNET_LAUNCHPAD_NAME }}
+                          />
+                        ) : (
+                          <FormattedMessage defaultMessage="Mainnet" />
+                        ),
                       }}
                     />
                   </Link>
@@ -398,11 +412,14 @@ const _AppBar = ({ location }: RouteComponentProps) => {
                     <FormattedMessage
                       defaultMessage="Switch to {network} launchpad"
                       values={{
-                        network: `${
-                          IS_MAINNET
-                            ? `${TESTNET_LAUNCHPAD_NAME} testnet`
-                            : `mainnet`
-                        }`,
+                        network: IS_MAINNET ? (
+                          <FormattedMessage
+                            defaultMessage="{TESTNET_LAUNCHPAD_NAME} testnet"
+                            values={{ TESTNET_LAUNCHPAD_NAME }}
+                          />
+                        ) : (
+                          <FormattedMessage defaultMessage="Mainnet" />
+                        ),
                       }}
                     />
                   </DropdownLink>
@@ -437,9 +454,7 @@ const _AppBar = ({ location }: RouteComponentProps) => {
                     <Text>
                       <FormattedMessage
                         defaultMessage="Your wallet should be set to {networkName} to use this launchpad."
-                        values={{
-                          networkName: <span>{networkName}</span>,
-                        }}
+                        values={{ networkName }}
                       />
                     </Text>
                   </Box>

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -25,7 +25,7 @@ import {
   TESTNET_LAUNCHPAD_URL,
 } from '../utils/envVars';
 import { trimString } from '../utils/trimString';
-import useNetworkName from '../hooks/useIntlNetworkName';
+import useIntlNetworkName from '../hooks/useIntlNetworkName';
 import useMobileCheck from '../hooks/useMobileCheck';
 
 const RainbowBackground = styled(Box)`
@@ -124,7 +124,7 @@ const _AppBar = ({ location }: RouteComponentProps) => {
     account,
     chainId,
   }: web3ReactInterface = useWeb3React<Web3Provider>();
-  const { executionLayerName, consensusLayerName } = useNetworkName();
+  const { executionLayerName, consensusLayerName } = useIntlNetworkName();
   const oppositeNetwork = IS_MAINNET ? (
     <FormattedMessage
       defaultMessage="{TESTNET_LAUNCHPAD_NAME} testnet"

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -376,7 +376,7 @@ const _AppBar = ({ location }: RouteComponentProps) => {
             className="secondary-link"
             label={
               <NetworkText>
-                {IS_MAINNET ? `Mainnet` : `${NETWORK_NAME}`}
+                {NETWORK_NAME}
                 <FormDown />
               </NetworkText>
             }

--- a/src/hooks/useIntlNetworkName.tsx
+++ b/src/hooks/useIntlNetworkName.tsx
@@ -10,14 +10,15 @@ const useIntlNetworkName = (): {
   consensusLayerName: string;
 } => {
   const { formatMessage } = useIntl();
+  const mainnet = formatMessage({ defaultMessage: 'Mainnet' });
   const executionLayerName: string = IS_MAINNET
-    ? formatMessage({ defaultMessage: 'Mainnet' })
+    ? mainnet
     : formatMessage(
         { defaultMessage: '{EL_TESTNET_NAME} testnet' },
         { EL_TESTNET_NAME }
       );
   const consensusLayerName: string = IS_MAINNET
-    ? formatMessage({ defaultMessage: 'Mainnet' })
+    ? mainnet
     : formatMessage(
         { defaultMessage: '{TESTNET_LAUNCHPAD_NAME} testnet' },
         { TESTNET_LAUNCHPAD_NAME }

--- a/src/hooks/useIntlNetworkName.tsx
+++ b/src/hooks/useIntlNetworkName.tsx
@@ -5,7 +5,7 @@ import {
   TESTNET_LAUNCHPAD_NAME,
 } from '../utils/envVars';
 
-const useNetworkName = (): {
+const useIntlNetworkName = (): {
   executionLayerName: string;
   consensusLayerName: string;
 } => {
@@ -25,4 +25,4 @@ const useNetworkName = (): {
   return { executionLayerName, consensusLayerName };
 };
 
-export default useNetworkName;
+export default useIntlNetworkName;

--- a/src/hooks/useIntlNetworkName.tsx
+++ b/src/hooks/useIntlNetworkName.tsx
@@ -1,0 +1,28 @@
+import { useIntl } from 'react-intl';
+import {
+  IS_MAINNET,
+  EL_TESTNET_NAME,
+  TESTNET_LAUNCHPAD_NAME,
+} from '../utils/envVars';
+
+const useNetworkName = (): {
+  executionLayerName: string;
+  consensusLayerName: string;
+} => {
+  const { formatMessage } = useIntl();
+  const executionLayerName: string = IS_MAINNET
+    ? formatMessage({ defaultMessage: 'Mainnet' })
+    : formatMessage(
+        { defaultMessage: '{EL_TESTNET_NAME} testnet' },
+        { EL_TESTNET_NAME }
+      );
+  const consensusLayerName: string = IS_MAINNET
+    ? formatMessage({ defaultMessage: 'Mainnet' })
+    : formatMessage(
+        { defaultMessage: '{TESTNET_LAUNCHPAD_NAME} testnet' },
+        { TESTNET_LAUNCHPAD_NAME }
+      );
+  return { executionLayerName, consensusLayerName };
+};
+
+export default useNetworkName;

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -41,24 +41,6 @@
       "value": "Polish"
     }
   ],
-  "+s8Gac": [
-    {
-      "type": 0,
-      "value": "Connect "
-    },
-    {
-      "type": 1,
-      "value": "wallet"
-    },
-    {
-      "type": 0,
-      "value": " to "
-    },
-    {
-      "type": 1,
-      "value": "network"
-    }
-  ],
   "/+atl4": [
     {
       "type": 0,
@@ -859,20 +841,6 @@
       "value": "Teku installation documentation"
     }
   ],
-  "5T9IMn": [
-    {
-      "type": 0,
-      "value": "I've synced my beacon node on "
-    },
-    {
-      "type": 1,
-      "value": "network"
-    },
-    {
-      "type": 0,
-      "value": "."
-    }
-  ],
   "5UH1sh": [
     {
       "type": 0,
@@ -905,16 +873,6 @@
     {
       "type": 0,
       "value": ". It is possible to drop below this with poor node performance, but it is not possible to raise above it."
-    }
-  ],
-  "5f+3FF": [
-    {
-      "type": 0,
-      "value": "Your wallet is on the wrong network. Switch to "
-    },
-    {
-      "type": 1,
-      "value": "networkName"
     }
   ],
   "5t8oYl": [
@@ -1045,6 +1003,20 @@
     {
       "type": 0,
       "value": "Merge panda emoji"
+    }
+  ],
+  "7DFXQj": [
+    {
+      "type": 0,
+      "value": "Switch to "
+    },
+    {
+      "type": 1,
+      "value": "oppositeNetwork"
+    },
+    {
+      "type": 0,
+      "value": " launchpad"
     }
   ],
   "7Iz3JI": [
@@ -1319,6 +1291,20 @@
     {
       "type": 0,
       "value": " until the Mainnet TTD (terminal total difficulty) has been announced and clients have released an update. Info is presented for preparation in the meantime."
+    }
+  ],
+  "9vwGlT": [
+    {
+      "type": 0,
+      "value": "I've synced my beacon node on "
+    },
+    {
+      "type": 1,
+      "value": "consensusLayerName"
+    },
+    {
+      "type": 0,
+      "value": "."
     }
   ],
   "9xeLhs": [
@@ -1685,6 +1671,16 @@
       "value": "You should certainly top up if your balance is close to 16 ETH. This is to ensure you don’t get kicked out of the validator set (which automatically happens if your balance falls below 16 ETH)."
     }
   ],
+  "CWKE9c": [
+    {
+      "type": 0,
+      "value": "Your wallet is on the wrong network. Switch to "
+    },
+    {
+      "type": 1,
+      "value": "executionLayerName"
+    }
+  ],
   "Cacfkx": [
     {
       "type": 0,
@@ -1923,6 +1919,28 @@
       "value": "I understand that this transaction is not reversible."
     }
   ],
+  "FU7JYy": [
+    {
+      "type": 0,
+      "value": "Make sure you have set "
+    },
+    {
+      "type": 1,
+      "value": "flag"
+    },
+    {
+      "type": 0,
+      "value": " for "
+    },
+    {
+      "type": 1,
+      "value": "consensusLayerName"
+    },
+    {
+      "type": 0,
+      "value": ", otherwise the deposit will be invalid."
+    }
+  ],
   "FZa0R+": [
     {
       "type": 0,
@@ -1971,6 +1989,20 @@
     {
       "type": 0,
       "value": "Step 1: Download the deposit command line interface app for your operating system"
+    }
+  ],
+  "FmGmFH": [
+    {
+      "type": 0,
+      "value": "Your wallet should be set to "
+    },
+    {
+      "type": 1,
+      "value": "executionLayerName"
+    },
+    {
+      "type": 0,
+      "value": " to use this launchpad."
     }
   ],
   "FqgDIV": [
@@ -2413,16 +2445,6 @@
       "value": "Geth installation documentation"
     }
   ],
-  "KAE6tZ": [
-    {
-      "type": 1,
-      "value": "testNetwork"
-    },
-    {
-      "type": 0,
-      "value": " testnet"
-    }
-  ],
   "KBSbmP": [
     {
       "type": 0,
@@ -2557,6 +2579,16 @@
     {
       "type": 0,
       "value": "Complete your last deposit"
+    }
+  ],
+  "L7wMQN": [
+    {
+      "type": 0,
+      "value": "Connect to "
+    },
+    {
+      "type": 1,
+      "value": "executionLayerName"
     }
   ],
   "L8jrV5": [
@@ -3045,28 +3077,6 @@
       "value": "Your network has changed"
     }
   ],
-  "PVtsnq": [
-    {
-      "type": 0,
-      "value": "Please make sure you have set "
-    },
-    {
-      "type": 1,
-      "value": "flag"
-    },
-    {
-      "type": 0,
-      "value": " for "
-    },
-    {
-      "type": 1,
-      "value": "network"
-    },
-    {
-      "type": 0,
-      "value": ", otherwise the deposit will be invalid."
-    }
-  ],
   "Pd0hC/": [
     {
       "type": 0,
@@ -3245,20 +3255,6 @@
     {
       "type": 0,
       "value": "Action"
-    }
-  ],
-  "QnS0CA": [
-    {
-      "type": 0,
-      "value": "Your wallet should be set to "
-    },
-    {
-      "type": 1,
-      "value": "networkName"
-    },
-    {
-      "type": 0,
-      "value": " to use this launchpad."
     }
   ],
   "QqqeNk": [
@@ -3543,12 +3539,6 @@
       "value": "initial and maximum"
     }
   ],
-  "TH/TNr": [
-    {
-      "type": 0,
-      "value": "Ethereum Mainnet"
-    }
-  ],
   "THIzw6": [
     {
       "type": 0,
@@ -3763,20 +3753,6 @@
     {
       "type": 0,
       "value": " file that you did not create yourself, or that you do not own the mnemonic phrase for."
-    }
-  ],
-  "VJZrCQ": [
-    {
-      "type": 0,
-      "value": "Switch to "
-    },
-    {
-      "type": 1,
-      "value": "network"
-    },
-    {
-      "type": 0,
-      "value": " launchpad"
     }
   ],
   "VKfWR3": [
@@ -4007,16 +3983,6 @@
       "value": "That is not a valid deposit_data JSON file."
     }
   ],
-  "X911Fz": [
-    {
-      "type": 0,
-      "value": "Connect to "
-    },
-    {
-      "type": 1,
-      "value": "network"
-    }
-  ],
   "XBEBYR": [
     {
       "type": 0,
@@ -4107,6 +4073,24 @@
     {
       "type": 1,
       "value": "teku"
+    }
+  ],
+  "Y07Hwy": [
+    {
+      "type": 0,
+      "value": "Connect "
+    },
+    {
+      "type": 1,
+      "value": "wallet"
+    },
+    {
+      "type": 0,
+      "value": " to "
+    },
+    {
+      "type": 1,
+      "value": "executionLayerName"
     }
   ],
   "Y47aYU": [
@@ -5575,20 +5559,6 @@
       "value": " deposit have a URL you expect?"
     }
   ],
-  "lNRvej": [
-    {
-      "type": 0,
-      "value": "Your wallet is on the wrong Ethereum network. To continue, connect to "
-    },
-    {
-      "type": 1,
-      "value": "networkName"
-    },
-    {
-      "type": 0,
-      "value": "."
-    }
-  ],
   "lQzdpT": [
     {
       "type": 0,
@@ -5839,6 +5809,20 @@
     {
       "type": 0,
       "value": "Advanced system architecture"
+    }
+  ],
+  "nwgrRp": [
+    {
+      "type": 0,
+      "value": "Staking Launchpad for "
+    },
+    {
+      "type": 1,
+      "value": "TESTNET_LAUNCHPAD_NAME"
+    },
+    {
+      "type": 0,
+      "value": " testnet"
     }
   ],
   "nyx/4g": [
@@ -6501,6 +6485,20 @@
       "value": "Status"
     }
   ],
+  "u/3saa": [
+    {
+      "type": 0,
+      "value": "Your wallet is on the wrong Ethereum network. To continue, connect to "
+    },
+    {
+      "type": 1,
+      "value": "executionLayerName"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
   "u28qA1": [
     {
       "type": 0,
@@ -6709,20 +6707,6 @@
       "value": "With your signing key, you could attempt to quickly exit the validator and then transfer the funds – with the withdrawal key – before the thief."
     }
   ],
-  "vyvUB5": [
-    {
-      "type": 0,
-      "value": "This JSON file isn't for the right network. Upload a file generated for your current network: "
-    },
-    {
-      "type": 1,
-      "value": "network"
-    },
-    {
-      "type": 0,
-      "value": "."
-    }
-  ],
   "w6qYSU": [
     {
       "type": 0,
@@ -6733,16 +6717,6 @@
     {
       "type": 0,
       "value": "both"
-    }
-  ],
-  "wIpuL/": [
-    {
-      "type": 1,
-      "value": "testNetwork"
-    },
-    {
-      "type": 0,
-      "value": " testnet"
     }
   ],
   "wJ1PbL": [
@@ -6867,28 +6841,6 @@
       "value": "Block rewards are calculated using a sliding scale based on the total amount of ETH staked on the network."
     }
   ],
-  "xTqOi7": [
-    {
-      "type": 0,
-      "value": "Make sure you have set "
-    },
-    {
-      "type": 1,
-      "value": "flag"
-    },
-    {
-      "type": 0,
-      "value": " for "
-    },
-    {
-      "type": 1,
-      "value": "network"
-    },
-    {
-      "type": 0,
-      "value": ", otherwise the deposit will be invalid."
-    }
-  ],
   "xXKkhR": [
     {
       "type": 0,
@@ -6909,10 +6861,46 @@
       "value": "The Beacon Chain"
     }
   ],
+  "xXntjc": [
+    {
+      "type": 0,
+      "value": "Please make sure you have set "
+    },
+    {
+      "type": 1,
+      "value": "flag"
+    },
+    {
+      "type": 0,
+      "value": " for "
+    },
+    {
+      "type": 1,
+      "value": "consensusLayerName"
+    },
+    {
+      "type": 0,
+      "value": ", otherwise the deposit will be invalid."
+    }
+  ],
   "xbet2w": [
     {
       "type": 0,
       "value": "Install python3.7+"
+    }
+  ],
+  "xm3Ivd": [
+    {
+      "type": 0,
+      "value": "This JSON file isn't for the right network. Upload a file generated for your current network: "
+    },
+    {
+      "type": 1,
+      "value": "consensusLayerName"
+    },
+    {
+      "type": 0,
+      "value": "."
     }
   ],
   "xogY3N": [
@@ -7099,20 +7087,6 @@
     {
       "type": 0,
       "value": "We'll help you create a signing key for every validator you want to run. Because there are no withdrawals until the Shanghai upgrade planned to follow the Merge, you will not create your withdrawal keys now. When it is possible to withdraw your funds, you can derive your withdrawal keys from your mnemonic."
-    }
-  ],
-  "zmMF+G": [
-    {
-      "type": 0,
-      "value": "Staking Launchpad for "
-    },
-    {
-      "type": 1,
-      "value": "TESTNET_LAUNCHPAD_NAME"
-    },
-    {
-      "type": 0,
-      "value": " testnet"
     }
   ],
   "zqOrZZ": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -257,6 +257,12 @@
       "value": "Section 3 - After depositing"
     }
   ],
+  "0FTs1T": [
+    {
+      "type": 0,
+      "value": "not"
+    }
+  ],
   "0PlVao": [
     {
       "type": 0,
@@ -887,6 +893,12 @@
       "value": " at any time during your setup for some friendly help!"
     }
   ],
+  "63gLLu": [
+    {
+      "type": 0,
+      "value": "average"
+    }
+  ],
   "6CK2Nu": [
     {
       "type": 0,
@@ -1219,6 +1231,12 @@
       "value": " option."
     }
   ],
+  "9mLaI9": [
+    {
+      "type": 0,
+      "value": "deposit"
+    }
+  ],
   "9qMyhY": [
     {
       "type": 0,
@@ -1229,6 +1247,12 @@
     {
       "type": 0,
       "value": "Configure Nethermind"
+    }
+  ],
+  "9r8j5+": [
+    {
+      "type": 0,
+      "value": "Engine API"
     }
   ],
   "9uOFF3": [
@@ -1431,6 +1455,12 @@
     {
       "type": 0,
       "value": "Top up validator"
+    }
+  ],
+  "AyaNND": [
+    {
+      "type": 0,
+      "value": "TestingTheMerge"
     }
   ],
   "AzjyIx": [
@@ -3417,6 +3447,12 @@
       "value": "wrench"
     }
   ],
+  "T2O2Gr": [
+    {
+      "type": 0,
+      "value": "initial and maximum"
+    }
+  ],
   "THIzw6": [
     {
       "type": 0,
@@ -3857,6 +3893,12 @@
       "value": "Has the block explorer named the contract?"
     }
   ],
+  "X3NiFM": [
+    {
+      "type": 0,
+      "value": "proof-of-custody game"
+    }
+  ],
   "X3rOq5": [
     {
       "type": 0,
@@ -4203,20 +4245,6 @@
     {
       "type": 0,
       "value": " a block proposal every 50 days."
-    }
-  ],
-  "ZlLjuq": [
-    {
-      "type": 0,
-      "value": "Please make sure you select "
-    },
-    {
-      "type": 1,
-      "value": "network"
-    },
-    {
-      "type": 0,
-      "value": " when prompted for a network, otherwise the deposit will be invalid."
     }
   ],
   "ZsXdlw": [
@@ -5045,6 +5073,12 @@
       "value": " outstanding deposit"
     }
   ],
+  "hwkLRc": [
+    {
+      "type": 0,
+      "value": "node operator"
+    }
+  ],
   "hzLd+/": [
     {
       "type": 0,
@@ -5561,6 +5595,20 @@
       "value": "File uploaded"
     }
   ],
+  "lslEna": [
+    {
+      "type": 0,
+      "value": "Please make sure you select "
+    },
+    {
+      "type": 1,
+      "value": "network"
+    },
+    {
+      "type": 0,
+      "value": " when prompted for a network, otherwise the deposit will be invalid."
+    }
+  ],
   "mArJcj": [
     {
       "type": 0,
@@ -6057,6 +6105,12 @@
     {
       "type": 0,
       "value": "Configure Prysm"
+    }
+  ],
+  "r2j8jL": [
+    {
+      "type": 0,
+      "value": "validator client"
     }
   ],
   "r4JsKB": [
@@ -6607,6 +6661,12 @@
     {
       "type": 0,
       "value": "Run the following command to launch the app"
+    }
+  ],
+  "wHvmSN": [
+    {
+      "type": 0,
+      "value": "both"
     }
   ],
   "wJ1PbL": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -331,6 +331,16 @@
       "value": "While validating on the testnet, perform these simulations to learn more about your node, and better prepare yourself for Mainnet:"
     }
   ],
+  "17Epwt": [
+    {
+      "type": 1,
+      "value": "TESTNET_LAUNCHPAD_NAME"
+    },
+    {
+      "type": 0,
+      "value": " testnet"
+    }
+  ],
   "192AR6": [
     {
       "type": 0,
@@ -389,6 +399,12 @@
     {
       "type": 0,
       "value": "Check that the password files don’t have trailing new-lines."
+    }
+  ],
+  "1Z0sad": [
+    {
+      "type": 0,
+      "value": "EF Blog"
     }
   ],
   "1fDfw7": [
@@ -843,6 +859,20 @@
       "value": "Teku installation documentation"
     }
   ],
+  "5T9IMn": [
+    {
+      "type": 0,
+      "value": "I've synced my beacon node on "
+    },
+    {
+      "type": 1,
+      "value": "network"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
   "5UH1sh": [
     {
       "type": 0,
@@ -877,6 +907,16 @@
       "value": ". It is possible to drop below this with poor node performance, but it is not possible to raise above it."
     }
   ],
+  "5f+3FF": [
+    {
+      "type": 0,
+      "value": "Your wallet is on the wrong network. Switch to "
+    },
+    {
+      "type": 1,
+      "value": "networkName"
+    }
+  ],
   "5t8oYl": [
     {
       "type": 0,
@@ -903,16 +943,6 @@
     {
       "type": 0,
       "value": "average"
-    }
-  ],
-  "6CK2Nu": [
-    {
-      "type": 0,
-      "value": "Your wallet is on the wrong network. Switch to "
-    },
-    {
-      "type": 1,
-      "value": "network"
     }
   ],
   "6CN01C": [
@@ -1681,16 +1711,6 @@
       "value": "I've set up a firewall."
     }
   ],
-  "Cm8zxo": [
-    {
-      "type": 0,
-      "value": "Connect to "
-    },
-    {
-      "type": 1,
-      "value": "network"
-    }
-  ],
   "D0Rigq": [
     {
       "type": 0,
@@ -2135,6 +2155,20 @@
       "value": "Slashing has two purposes: (1) to make it prohibitively expensive to attack the network, and (2) to stop validators from being lazy by checking that they actually perform their duties. If you're slashed because you've acted in a provably destructive manner, a portion of your stake will be destroyed."
     }
   ],
+  "Hmxd5S": [
+    {
+      "type": 0,
+      "value": "Please make sure you select "
+    },
+    {
+      "type": 1,
+      "value": "NETWORK_NAME"
+    },
+    {
+      "type": 0,
+      "value": " when prompted for a network, otherwise the deposit will be invalid."
+    }
+  ],
   "HoahTd": [
     {
       "type": 0,
@@ -2377,6 +2411,16 @@
     {
       "type": 0,
       "value": "Geth installation documentation"
+    }
+  ],
+  "KAE6tZ": [
+    {
+      "type": 1,
+      "value": "testNetwork"
+    },
+    {
+      "type": 0,
+      "value": " testnet"
     }
   ],
   "KBSbmP": [
@@ -2813,6 +2857,12 @@
       "value": " deposits"
     }
   ],
+  "NZYRdf": [
+    {
+      "type": 0,
+      "value": "Mainnet"
+    }
+  ],
   "NatYUJ": [
     {
       "type": 0,
@@ -2993,6 +3043,28 @@
     {
       "type": 0,
       "value": "Your network has changed"
+    }
+  ],
+  "PVtsnq": [
+    {
+      "type": 0,
+      "value": "Please make sure you have set "
+    },
+    {
+      "type": 1,
+      "value": "flag"
+    },
+    {
+      "type": 0,
+      "value": " for "
+    },
+    {
+      "type": 1,
+      "value": "network"
+    },
+    {
+      "type": 0,
+      "value": ", otherwise the deposit will be invalid."
     }
   ],
   "Pd0hC/": [
@@ -3471,6 +3543,12 @@
       "value": "initial and maximum"
     }
   ],
+  "TH/TNr": [
+    {
+      "type": 0,
+      "value": "Ethereum Mainnet"
+    }
+  ],
   "THIzw6": [
     {
       "type": 0,
@@ -3929,6 +4007,16 @@
       "value": "That is not a valid deposit_data JSON file."
     }
   ],
+  "X911Fz": [
+    {
+      "type": 0,
+      "value": "Connect to "
+    },
+    {
+      "type": 1,
+      "value": "network"
+    }
+  ],
   "XBEBYR": [
     {
       "type": 0,
@@ -4149,6 +4237,16 @@
       "value": "Execution clients"
     }
   ],
+  "Yep32z": [
+    {
+      "type": 1,
+      "value": "EL_TESTNET_NAME"
+    },
+    {
+      "type": 0,
+      "value": " testnet"
+    }
+  ],
   "Yganfl": [
     {
       "type": 0,
@@ -4311,20 +4409,6 @@
     {
       "type": 0,
       "value": "Nimbus is Apache 2 licensed and written in Nim, a language with Python-like syntax that compiles to C."
-    }
-  ],
-  "aZ7pUj": [
-    {
-      "type": 0,
-      "value": "Your wallet is on the wrong Ethereum network. To continue, connect to the "
-    },
-    {
-      "type": 1,
-      "value": "networkName"
-    },
-    {
-      "type": 0,
-      "value": " network."
     }
   ],
   "acrOoz": [
@@ -5127,28 +5211,6 @@
       "value": "With transfers disabled for now, you won't be able to voluntarily exit and then restart later. This means you need to be in it for the long haul."
     }
   ],
-  "iWg7mL": [
-    {
-      "type": 0,
-      "value": "Please make sure you have set "
-    },
-    {
-      "type": 1,
-      "value": "flag"
-    },
-    {
-      "type": 0,
-      "value": " for "
-    },
-    {
-      "type": 1,
-      "value": "network"
-    },
-    {
-      "type": 0,
-      "value": ", otherwise the deposit will be invalid."
-    }
-  ],
   "iX90gu": [
     {
       "type": 0,
@@ -5513,6 +5575,20 @@
       "value": " deposit have a URL you expect?"
     }
   ],
+  "lNRvej": [
+    {
+      "type": 0,
+      "value": "Your wallet is on the wrong Ethereum network. To continue, connect to "
+    },
+    {
+      "type": 1,
+      "value": "networkName"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
   "lQzdpT": [
     {
       "type": 0,
@@ -5625,20 +5701,6 @@
     {
       "type": 0,
       "value": "File uploaded"
-    }
-  ],
-  "lslEna": [
-    {
-      "type": 0,
-      "value": "Please make sure you select "
-    },
-    {
-      "type": 1,
-      "value": "network"
-    },
-    {
-      "type": 0,
-      "value": " when prompted for a network, otherwise the deposit will be invalid."
     }
   ],
   "mArJcj": [
@@ -6317,20 +6379,6 @@
       "value": ". This is a new set of JSON RPC methods that can be used to communicate between the two client layers."
     }
   ],
-  "sdQRah": [
-    {
-      "type": 0,
-      "value": "I've synced my beacon node on "
-    },
-    {
-      "type": 1,
-      "value": "NETWORK_NAME"
-    },
-    {
-      "type": 0,
-      "value": "."
-    }
-  ],
   "sj/Zef": [
     {
       "type": 0,
@@ -6687,6 +6735,16 @@
       "value": "both"
     }
   ],
+  "wIpuL/": [
+    {
+      "type": 1,
+      "value": "testNetwork"
+    },
+    {
+      "type": 0,
+      "value": " testnet"
+    }
+  ],
   "wJ1PbL": [
     {
       "type": 0,
@@ -6807,6 +6865,28 @@
     {
       "type": 0,
       "value": "Block rewards are calculated using a sliding scale based on the total amount of ETH staked on the network."
+    }
+  ],
+  "xTqOi7": [
+    {
+      "type": 0,
+      "value": "Make sure you have set "
+    },
+    {
+      "type": 1,
+      "value": "flag"
+    },
+    {
+      "type": 0,
+      "value": " for "
+    },
+    {
+      "type": 1,
+      "value": "network"
+    },
+    {
+      "type": 0,
+      "value": ", otherwise the deposit will be invalid."
     }
   ],
   "xXKkhR": [
@@ -6955,28 +7035,6 @@
     {
       "type": 0,
       "value": "."
-    }
-  ],
-  "z/ZhML": [
-    {
-      "type": 0,
-      "value": "Make sure you have set "
-    },
-    {
-      "type": 1,
-      "value": "flag"
-    },
-    {
-      "type": 0,
-      "value": " for "
-    },
-    {
-      "type": 1,
-      "value": "network"
-    },
-    {
-      "type": 0,
-      "value": ", otherwise the deposit will be invalid."
     }
   ],
   "z63I56": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -281,6 +281,12 @@
       "value": "Testnet practice"
     }
   ],
+  "0c06tl": [
+    {
+      "type": 0,
+      "value": "Withdrawal Credentials"
+    }
+  ],
   "0i4cCJ": [
     {
       "type": 0,

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -1023,6 +1023,12 @@
       "value": "Consensus Client"
     }
   ],
+  "7Rw2uA": [
+    {
+      "type": 0,
+      "value": "consensus"
+    }
+  ],
   "7UOvbT": [
     {
       "type": 0,
@@ -1303,6 +1309,20 @@
       "value": "boldWarning"
     }
   ],
+  "9ySJSP": [
+    {
+      "type": 0,
+      "value": "Choose your "
+    },
+    {
+      "type": 1,
+      "value": "ethClientType"
+    },
+    {
+      "type": 0,
+      "value": " client and set up a node"
+    }
+  ],
   "A2b4uB": [
     {
       "type": 0,
@@ -1579,6 +1599,12 @@
     {
       "type": 0,
       "value": "Effective balance"
+    }
+  ],
+  "BnwOUO": [
+    {
+      "type": 0,
+      "value": "execution"
     }
   ],
   "BoEpk9": [
@@ -2797,20 +2823,6 @@
     {
       "type": 0,
       "value": "Become a validator with Teku"
-    }
-  ],
-  "Ns8vbQ": [
-    {
-      "type": 0,
-      "value": "Choose "
-    },
-    {
-      "type": 1,
-      "value": "ethClientType"
-    },
-    {
-      "type": 0,
-      "value": " client"
     }
   ],
   "NwzcYT": [
@@ -5277,6 +5289,20 @@
       "value": "Warning: Do not store keys on multiple (backup) validators at once"
     }
   ],
+  "jp9OG2": [
+    {
+      "type": 0,
+      "value": "Choose "
+    },
+    {
+      "type": 1,
+      "value": "ethClientType"
+    },
+    {
+      "type": 0,
+      "value": " client"
+    }
+  ],
   "jse8rl": [
     {
       "type": 0,
@@ -6383,20 +6409,6 @@
     {
       "type": 0,
       "value": "Balance after topping up"
-    }
-  ],
-  "toCscK": [
-    {
-      "type": 0,
-      "value": "Choose your "
-    },
-    {
-      "type": 1,
-      "value": "ethClientType"
-    },
-    {
-      "type": 0,
-      "value": " client and set up a node"
     }
   ],
   "tp1IPS": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -126,6 +126,9 @@
   "14vTrX": {
     "message": "While validating on the testnet, perform these simulations to learn more about your node, and better prepare yourself for Mainnet:"
   },
+  "17Epwt": {
+    "message": "{TESTNET_LAUNCHPAD_NAME} testnet"
+  },
   "192AR6": {
     "message": "More on staking"
   },
@@ -155,6 +158,9 @@
   },
   "1Vkpd0": {
     "message": "Check that the password files don’t have trailing new-lines."
+  },
+  "1Z0sad": {
+    "message": "EF Blog"
   },
   "1fDfw7": {
     "message": "How does this all happen?"
@@ -309,6 +315,9 @@
   "5HJLBU": {
     "message": "Teku installation documentation"
   },
+  "5T9IMn": {
+    "message": "I've synced my beacon node on {network}."
+  },
   "5UH1sh": {
     "message": "Romanian"
   },
@@ -318,15 +327,15 @@
   "5dG331": {
     "message": "Although a validator's vote is weighted by the amount it has at stake, each validators voting weight starts at, and is capped at {pricePerValidator}. It is possible to drop below this with poor node performance, but it is not possible to raise above it."
   },
+  "5f+3FF": {
+    "message": "Your wallet is on the wrong network. Switch to {networkName}"
+  },
   "5t8oYl": {
     "description": "{variables} are social media platform links to Discord and Reddit (do not translate names)",
     "message": "Visit EthStaker on {discord} or {reddit} at any time during your setup for some friendly help!"
   },
   "63gLLu": {
     "message": "average"
-  },
-  "6CK2Nu": {
-    "message": "Your wallet is on the wrong network. Switch to {network}"
   },
   "6CN01C": {
     "message": "After the Shanghai upgrade, your 16 ETH can then be withdrawn – with your withdrawal key – after a delay of around a day."
@@ -625,10 +634,6 @@
   "CeeJfw": {
     "message": "I've set up a firewall."
   },
-  "Cm8zxo": {
-    "description": "{network} is either 'Ethereum mainnet' or '<EL_TESTNET_NAME> testnet'",
-    "message": "Connect to {network}"
-  },
   "D0Rigq": {
     "message": "NO"
   },
@@ -826,6 +831,9 @@
   "Hczrvs": {
     "message": "Slashing has two purposes: (1) to make it prohibitively expensive to attack the network, and (2) to stop validators from being lazy by checking that they actually perform their duties. If you're slashed because you've acted in a provably destructive manner, a portion of your stake will be destroyed."
   },
+  "Hmxd5S": {
+    "message": "Please make sure you select {NETWORK_NAME} when prompted for a network, otherwise the deposit will be invalid."
+  },
   "HoahTd": {
     "message": "If you do not supply a password, Nimbus will interactively ask for it on startup."
   },
@@ -923,6 +931,10 @@
   },
   "K6+jQ3": {
     "message": "Geth installation documentation"
+  },
+  "KAE6tZ": {
+    "description": "{testNetwork} is the proper testnet name; do not translate this name",
+    "message": "{testNetwork} testnet"
   },
   "KBSbmP": {
     "description": "{reloadYourWallet} is a link labeled 'reload your wallet'",
@@ -1095,6 +1107,9 @@
   "NZIM+F": {
     "message": "Send remaining {remainingTxCount} deposits"
   },
+  "NZYRdf": {
+    "message": "Mainnet"
+  },
   "NatYUJ": {
     "message": "Learn more about the roles and responsibilities of Ethereum validators."
   },
@@ -1158,6 +1173,10 @@
   },
   "P9mVZK": {
     "message": "Your network has changed"
+  },
+  "PVtsnq": {
+    "description": "{flag} is a terminal command styled as code.",
+    "message": "Please make sure you have set {flag} for {network}, otherwise the deposit will be invalid."
   },
   "Pd0hC/": {
     "message": "Ethereum Foundation Blog"
@@ -1342,6 +1361,9 @@
   "T2O2Gr": {
     "message": "initial and maximum"
   },
+  "TH/TNr": {
+    "message": "Ethereum Mainnet"
+  },
   "THIzw6": {
     "message": "Validators and Ethereum"
   },
@@ -1510,6 +1532,10 @@
   "X5KFEh": {
     "message": "That is not a valid deposit_data JSON file."
   },
+  "X911Fz": {
+    "description": "{network} is either 'Ethereum Mainnet' or '<EL_TESTNET_NAME> testnet'",
+    "message": "Connect to {network}"
+  },
   "XBEBYR": {
     "message": "More on installing pip"
   },
@@ -1574,6 +1600,9 @@
   },
   "Yd6MEN": {
     "message": "Execution clients"
+  },
+  "Yep32z": {
+    "message": "{EL_TESTNET_NAME} testnet"
   },
   "Yganfl": {
     "message": "Type the following lines into the terminal window:"
@@ -1642,9 +1671,6 @@
   },
   "aXT3iO": {
     "message": "Nimbus is Apache 2 licensed and written in Nim, a language with Python-like syntax that compiles to C."
-  },
-  "aZ7pUj": {
-    "message": "Your wallet is on the wrong Ethereum network. To continue, connect to the {networkName} network."
   },
   "acrOoz": {
     "message": "Continue"
@@ -1974,10 +2000,6 @@
   "iPRnRG": {
     "message": "With transfers disabled for now, you won't be able to voluntarily exit and then restart later. This means you need to be in it for the long haul."
   },
-  "iWg7mL": {
-    "description": "{flag} and {network} are terminal commands styled as code.",
-    "message": "Please make sure you have set {flag} for {network}, otherwise the deposit will be invalid."
-  },
   "iX90gu": {
     "message": "I've joined my execution client's Discord server."
   },
@@ -2127,6 +2149,9 @@
     "description": "{ethAmount} will generally refer to 32 ETH",
     "message": "Does the site asking you for your {ethAmount} deposit have a URL you expect?"
   },
+  "lNRvej": {
+    "message": "Your wallet is on the wrong Ethereum network. To continue, connect to {networkName}."
+  },
   "lQzdpT": {
     "description": "this is used as a command line flag, short for \"number of validators\"",
     "message": "num_validators"
@@ -2160,9 +2185,6 @@
   },
   "lrdlY6": {
     "message": "File uploaded"
-  },
-  "lslEna": {
-    "message": "Please make sure you select {network} when prompted for a network, otherwise the deposit will be invalid."
   },
   "mArJcj": {
     "message": "Hard drive"
@@ -2421,10 +2443,6 @@
   "scfDDt": {
     "message": "Communication between the execution layer and consensus layer will occur using the {engineApi}. This is a new set of JSON RPC methods that can be used to communicate between the two client layers."
   },
-  "sdQRah": {
-    "description": "{NETWORK_NAME} is name of network, do not translate",
-    "message": "I've synced my beacon node on {NETWORK_NAME}."
-  },
   "sj/Zef": {
     "message": "Download Key Gen GUI app"
   },
@@ -2572,6 +2590,9 @@
   "wHvmSN": {
     "message": "both"
   },
+  "wIpuL/": {
+    "message": "{testNetwork} testnet"
+  },
   "wJ1PbL": {
     "description": "Indicates which operating system the instructions are for",
     "message": "For {operatingSystem}"
@@ -2630,6 +2651,10 @@
   },
   "xSvJIi": {
     "message": "Block rewards are calculated using a sliding scale based on the total amount of ETH staked on the network."
+  },
+  "xTqOi7": {
+    "description": "{flag} is a terminal command styled as code.",
+    "message": "Make sure you have set {flag} for {network}, otherwise the deposit will be invalid."
   },
   "xXKkhR": {
     "message": "I've installed and synced my {network} execution client (do not wait on this as it can take several days)."
@@ -2690,9 +2715,6 @@
   },
   "z/ToMo": {
     "message": "Once the transition to proof-of-stake is complete via the Merge, validators will be responsible for processing transactions and signing off on their validity. This data will {not} be available from popular third-party sources after the Merge and will result in your validator being offline. When data sharding is implemented, validators will also be at risk of slashing under the {pocGame}."
-  },
-  "z/ZhML": {
-    "message": "Make sure you have set {flag} for {network}, otherwise the deposit will be invalid."
   },
   "z63I56": {
     "message": "validator"

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -20,9 +20,6 @@
   "+ozGrs": {
     "message": "Polish"
   },
-  "+s8Gac": {
-    "message": "Connect {wallet} to {network}"
-  },
   "/+atl4": {
     "message": "Recommendation disclaimer"
   },
@@ -315,9 +312,6 @@
   "5HJLBU": {
     "message": "Teku installation documentation"
   },
-  "5T9IMn": {
-    "message": "I've synced my beacon node on {network}."
-  },
   "5UH1sh": {
     "message": "Romanian"
   },
@@ -326,9 +320,6 @@
   },
   "5dG331": {
     "message": "Although a validator's vote is weighted by the amount it has at stake, each validators voting weight starts at, and is capped at {pricePerValidator}. It is possible to drop below this with poor node performance, but it is not possible to raise above it."
-  },
-  "5f+3FF": {
-    "message": "Your wallet is on the wrong network. Switch to {networkName}"
   },
   "5t8oYl": {
     "description": "{variables} are social media platform links to Discord and Reddit (do not translate names)",
@@ -381,6 +372,9 @@
   },
   "7C4ikM": {
     "message": "Merge panda emoji"
+  },
+  "7DFXQj": {
+    "message": "Switch to {oppositeNetwork} launchpad"
   },
   "7Iz3JI": {
     "message": "Consensus Client"
@@ -488,6 +482,9 @@
   },
   "9vLu6E": {
     "message": "{note} This step should be performed on {testnetsOnly} until the Mainnet TTD (terminal total difficulty) has been announced and clients have released an update. Info is presented for preparation in the meantime."
+  },
+  "9vwGlT": {
+    "message": "I've synced my beacon node on {consensusLayerName}."
   },
   "9xeLhs": {
     "message": "Ethereum address withdrawal: If you want to withdraw to your Mainnet wallet address (formerly 'Eth1' address) after the post-merge cleanup upgrade, you can set {ethAddressWithdraw} when running deposit-cli. {boldWarning}"
@@ -624,6 +621,9 @@
   "CVDzDs": {
     "message": "You should certainly top up if your balance is close to 16 ETH. This is to ensure you don’t get kicked out of the validator set (which automatically happens if your balance falls below 16 ETH)."
   },
+  "CWKE9c": {
+    "message": "Your wallet is on the wrong network. Switch to {executionLayerName}"
+  },
   "Cacfkx": {
     "message": "More on the Ethereum vision"
   },
@@ -728,6 +728,10 @@
   "FSRfSJ": {
     "message": "I understand that this transaction is not reversible."
   },
+  "FU7JYy": {
+    "description": "{flag} is a terminal command styled as code.",
+    "message": "Make sure you have set {flag} for {consensusLayerName}, otherwise the deposit will be invalid."
+  },
   "FZa0R+": {
     "message": "This scenario is very extreme and unlikely to happen."
   },
@@ -748,6 +752,9 @@
   },
   "FgraU0": {
     "message": "Step 1: Download the deposit command line interface app for your operating system"
+  },
+  "FmGmFH": {
+    "message": "Your wallet should be set to {executionLayerName} to use this launchpad."
   },
   "FqgDIV": {
     "message": "Terms of service"
@@ -932,10 +939,6 @@
   "K6+jQ3": {
     "message": "Geth installation documentation"
   },
-  "KAE6tZ": {
-    "description": "{testNetwork} is the proper testnet name; do not translate this name",
-    "message": "{testNetwork} testnet"
-  },
   "KBSbmP": {
     "description": "{reloadYourWallet} is a link labeled 'reload your wallet'",
     "message": "You can {reloadYourWallet} to try again, or refresh the page. If issue persists, let us know on {github}."
@@ -987,6 +990,10 @@
   },
   "L7fPF+": {
     "message": "Complete your last deposit"
+  },
+  "L7wMQN": {
+    "description": "{executionLayerName} is either 'Mainnet' or '<Execution Layer Testnet Name> testnet'",
+    "message": "Connect to {executionLayerName}"
   },
   "L8jrV5": {
     "message": "reload your wallet"
@@ -1174,10 +1181,6 @@
   "P9mVZK": {
     "message": "Your network has changed"
   },
-  "PVtsnq": {
-    "description": "{flag} is a terminal command styled as code.",
-    "message": "Please make sure you have set {flag} for {network}, otherwise the deposit will be invalid."
-  },
   "Pd0hC/": {
     "message": "Ethereum Foundation Blog"
   },
@@ -1238,9 +1241,6 @@
   },
   "QlsDcr": {
     "message": "Action"
-  },
-  "QnS0CA": {
-    "message": "Your wallet should be set to {networkName} to use this launchpad."
   },
   "QqqeNk": {
     "message": "Transaction rejected"
@@ -1361,9 +1361,6 @@
   "T2O2Gr": {
     "message": "initial and maximum"
   },
-  "TH/TNr": {
-    "message": "Ethereum Mainnet"
-  },
   "THIzw6": {
     "message": "Validators and Ethereum"
   },
@@ -1444,9 +1441,6 @@
   },
   "VIMMdE": {
     "message": "Do not submit any transaction with a {depositData} file that you did not create yourself, or that you do not own the mnemonic phrase for."
-  },
-  "VJZrCQ": {
-    "message": "Switch to {network} launchpad"
   },
   "VKfWR3": {
     "message": "Recommended"
@@ -1532,10 +1526,6 @@
   "X5KFEh": {
     "message": "That is not a valid deposit_data JSON file."
   },
-  "X911Fz": {
-    "description": "{network} is either 'Ethereum Mainnet' or '<EL_TESTNET_NAME> testnet'",
-    "message": "Connect to {network}"
-  },
   "XBEBYR": {
     "message": "More on installing pip"
   },
@@ -1557,6 +1547,9 @@
   "XqbweH": {
     "description": "{variables} are client names, each linking to documentation (do not translate names)",
     "message": "The clients support Prometheus and Grafana to help you visualize important real-time metrics about your validator. You can find client-specific instructions here: {lighthouse} | {nimbus} | {prysm} | {teku}"
+  },
+  "Y07Hwy": {
+    "message": "Connect {wallet} to {executionLayerName}"
   },
   "Y47aYU": {
     "message": "Top up"
@@ -2149,9 +2142,6 @@
     "description": "{ethAmount} will generally refer to 32 ETH",
     "message": "Does the site asking you for your {ethAmount} deposit have a URL you expect?"
   },
-  "lNRvej": {
-    "message": "Your wallet is on the wrong Ethereum network. To continue, connect to {networkName}."
-  },
   "lQzdpT": {
     "description": "this is used as a command line flag, short for \"number of validators\"",
     "message": "num_validators"
@@ -2243,6 +2233,9 @@
   },
   "ntG2by": {
     "message": "Advanced system architecture"
+  },
+  "nwgrRp": {
+    "message": "Staking Launchpad for {TESTNET_LAUNCHPAD_NAME} testnet"
   },
   "nyx/4g": {
     "message": "How to run a node on {network}"
@@ -2495,6 +2488,9 @@
   "tzMNF3": {
     "message": "Status"
   },
+  "u/3saa": {
+    "message": "Your wallet is on the wrong Ethereum network. To continue, connect to {executionLayerName}."
+  },
   "u28qA1": {
     "message": "After depositing"
   },
@@ -2581,17 +2577,11 @@
   "vg1dVR": {
     "message": "With your signing key, you could attempt to quickly exit the validator and then transfer the funds – with the withdrawal key – before the thief."
   },
-  "vyvUB5": {
-    "message": "This JSON file isn't for the right network. Upload a file generated for your current network: {network}."
-  },
   "w6qYSU": {
     "message": "Run the following command to launch the app"
   },
   "wHvmSN": {
     "message": "both"
-  },
-  "wIpuL/": {
-    "message": "{testNetwork} testnet"
   },
   "wJ1PbL": {
     "description": "Indicates which operating system the instructions are for",
@@ -2652,18 +2642,21 @@
   "xSvJIi": {
     "message": "Block rewards are calculated using a sliding scale based on the total amount of ETH staked on the network."
   },
-  "xTqOi7": {
-    "description": "{flag} is a terminal command styled as code.",
-    "message": "Make sure you have set {flag} for {network}, otherwise the deposit will be invalid."
-  },
   "xXKkhR": {
     "message": "I've installed and synced my {network} execution client (do not wait on this as it can take several days)."
   },
   "xXWzDf": {
     "message": "The Beacon Chain"
   },
+  "xXntjc": {
+    "description": "{flag} is a terminal command styled as code.",
+    "message": "Please make sure you have set {flag} for {consensusLayerName}, otherwise the deposit will be invalid."
+  },
   "xbet2w": {
     "message": "Install python3.7+"
+  },
+  "xm3Ivd": {
+    "message": "This JSON file isn't for the right network. Upload a file generated for your current network: {consensusLayerName}."
   },
   "xogY3N": {
     "message": "Besu is written in Java and released under the Apache 2.0 Licence."
@@ -2741,10 +2734,6 @@
   },
   "zkT9Jx": {
     "message": "We'll help you create a signing key for every validator you want to run. Because there are no withdrawals until the Shanghai upgrade planned to follow the Merge, you will not create your withdrawal keys now. When it is possible to withdraw your funds, you can derive your withdrawal keys from your mnemonic."
-  },
-  "zmMF+G": {
-    "description": "This phrase is a sentence ",
-    "message": "Staking Launchpad for {TESTNET_LAUNCHPAD_NAME} testnet"
   },
   "zqOrZZ": {
     "message": "Look over the Merge Readiness Checklist"

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -105,6 +105,9 @@
   "0S8/Wo": {
     "message": "Testnet practice"
   },
+  "0c06tl": {
+    "message": "Withdrawal Credentials"
+  },
   "0i4cCJ": {
     "message": "Confirm deposits ({depositKeys})"
   },

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -93,6 +93,9 @@
   "07C4IQ": {
     "message": "Section 3 - After depositing"
   },
+  "0FTs1T": {
+    "message": "not"
+  },
   "0PlVao": {
     "message": "More on slashing prevention"
   },
@@ -316,6 +319,9 @@
     "description": "{variables} are social media platform links to Discord and Reddit (do not translate names)",
     "message": "Visit EthStaker on {discord} or {reddit} at any time during your setup for some friendly help!"
   },
+  "63gLLu": {
+    "message": "average"
+  },
   "6CK2Nu": {
     "message": "Your wallet is on the wrong network. Switch to {network}"
   },
@@ -450,11 +456,17 @@
   "9lBMQr": {
     "message": "{keyFile} of paths via the {validatorsKeys} option."
   },
+  "9mLaI9": {
+    "message": "deposit"
+  },
   "9qMyhY": {
     "message": "Read options and subcommands documentation"
   },
   "9qpi9h": {
     "message": "Configure Nethermind"
+  },
+  "9r8j5+": {
+    "message": "Engine API"
   },
   "9uOFF3": {
     "message": "Overview"
@@ -525,6 +537,9 @@
   },
   "Aw1mMs": {
     "message": "Top up validator"
+  },
+  "AyaNND": {
+    "message": "TestingTheMerge"
   },
   "AzjyIx": {
     "message": "Since the genesis of the Beacon Chain, many validators running their own consensus client have opted to use third-party services for their execution layer connection. This has been acceptable since the only thing being listened to has been the staking deposit contract."
@@ -1315,6 +1330,9 @@
   "Szwbym": {
     "message": "wrench"
   },
+  "T2O2Gr": {
+    "message": "initial and maximum"
+  },
   "THIzw6": {
     "message": "Validators and Ethereum"
   },
@@ -1474,6 +1492,9 @@
   "X/fKmY": {
     "message": "Has the block explorer named the contract?"
   },
+  "X3NiFM": {
+    "message": "proof-of-custody game"
+  },
   "X3rOq5": {
     "message": "At time of the Merge, Infura and Alchemy will no longer be viable options to outsource execution layer responsibilities."
   },
@@ -1588,10 +1609,6 @@
   },
   "ZdT9Bs": {
     "message": "Your validator will also receive unburnt gas fees when proposing blocks. Validators are chosen randomly by the protocol to propose blocks, and only one validator can propose a block for each 12-second slot. There are 7200 slots each day, so each validator has 7200 chances-per-day to propose a block. If there are 360,000 validators, each validator will {average} a block proposal every 50 days."
-  },
-  "ZlLjuq": {
-    "description": "{flag} and {network} are terminal commands styled as code.",
-    "message": "Please make sure you select {network} when prompted for a network, otherwise the deposit will be invalid."
   },
   "ZsXdlw": {
     "message": "Erigon installation documentation"
@@ -1930,6 +1947,9 @@
     "description": "Singular form, for only one deposit",
     "message": "You have {remainingTxCount} outstanding deposit"
   },
+  "hwkLRc": {
+    "message": "node operator"
+  },
   "hzLd+/": {
     "message": "I understand that it is important to keep my validator online and updated."
   },
@@ -2127,6 +2147,9 @@
   },
   "lrdlY6": {
     "message": "File uploaded"
+  },
+  "lslEna": {
+    "message": "Please make sure you select {network} when prompted for a network, otherwise the deposit will be invalid."
   },
   "mArJcj": {
     "message": "Hard drive"
@@ -2326,6 +2349,9 @@
   },
   "r2BH1M": {
     "message": "Configure Prysm"
+  },
+  "r2j8jL": {
+    "message": "validator client"
   },
   "r4JsKB": {
     "message": "Transaction successful"
@@ -2533,6 +2559,9 @@
   },
   "w6qYSU": {
     "message": "Run the following command to launch the app"
+  },
+  "wHvmSN": {
+    "message": "both"
   },
   "wJ1PbL": {
     "description": "Indicates which operating system the instructions are for",

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -376,6 +376,9 @@
   "7Iz3JI": {
     "message": "Consensus Client"
   },
+  "7Rw2uA": {
+    "message": "consensus"
+  },
   "7UOvbT": {
     "message": "Offline"
   },
@@ -480,6 +483,10 @@
   "9xeLhs": {
     "message": "Ethereum address withdrawal: If you want to withdraw to your Mainnet wallet address (formerly 'Eth1' address) after the post-merge cleanup upgrade, you can set {ethAddressWithdraw} when running deposit-cli. {boldWarning}"
   },
+  "9ySJSP": {
+    "description": "{ethClientType} is either \"execution\" or \"consensus\", depending on which step user is on",
+    "message": "Choose your {ethClientType} client and set up a node"
+  },
   "A2b4uB": {
     "message": "Send deposit"
   },
@@ -580,6 +587,9 @@
   },
   "Bj5yI5": {
     "message": "Effective balance"
+  },
+  "BnwOUO": {
+    "message": "execution"
   },
   "BoEpk9": {
     "message": "Introduction"
@@ -1090,10 +1100,6 @@
   },
   "Nb5DNK": {
     "message": "Become a validator with Teku"
-  },
-  "Ns8vbQ": {
-    "description": "{ethClientType} injects execution or consensus depending on step",
-    "message": "Choose {ethClientType} client"
   },
   "NwzcYT": {
     "message": "Teku needs to be pointed at files containing keystores and their associated passwords at startup. There are 3 methods for doing so."
@@ -2034,6 +2040,10 @@
     "description": "Warns users to not run backup validators that have a live copy of their signing keys. Keys should only be on one validator machine at once.",
     "message": "Warning: Do not store keys on multiple (backup) validators at once"
   },
+  "jp9OG2": {
+    "description": "{ethClientType} injects \"execution\" or \"consensus\" depending on step",
+    "message": "Choose {ethClientType} client"
+  },
   "jse8rl": {
     "message": "How great does my uptime need to be for my validator to be net profitable?"
   },
@@ -2450,10 +2460,6 @@
   },
   "tkFTZw": {
     "message": "Balance after topping up"
-  },
-  "toCscK": {
-    "description": "{ethClientType} is either execution or consensus, depending on which step user is on",
-    "message": "Choose your {ethClientType} client and set up a node"
   },
   "tp1IPS": {
     "message": "Configure the fee recipient"

--- a/src/pages/Checklist/index.tsx
+++ b/src/pages/Checklist/index.tsx
@@ -27,7 +27,7 @@ import GethBg from '../../static/geth-bg.png';
 import { routesEnum } from '../../Routes';
 import { Code } from '../../components/Code';
 import { Alert } from '../../components/Alert';
-import useNetworkName from '../../hooks/useIntlNetworkName';
+import useIntlNetworkName from '../../hooks/useIntlNetworkName';
 
 const ChecklistPageStyles = styled.div`
   section {
@@ -198,7 +198,7 @@ interface Client {
 
 export const Checklist = () => {
   const { formatMessage } = useIntl();
-  const { consensusLayerName } = useNetworkName();
+  const { consensusLayerName } = useIntlNetworkName();
 
   const defaultExecutionPorts: {
     defaultTcp: number;

--- a/src/pages/Checklist/index.tsx
+++ b/src/pages/Checklist/index.tsx
@@ -27,6 +27,7 @@ import GethBg from '../../static/geth-bg.png';
 import { routesEnum } from '../../Routes';
 import { Code } from '../../components/Code';
 import { Alert } from '../../components/Alert';
+import useNetworkName from '../../hooks/useIntlNetworkName';
 
 const ChecklistPageStyles = styled.div`
   section {
@@ -197,6 +198,8 @@ interface Client {
 
 export const Checklist = () => {
   const { formatMessage } = useIntl();
+  const { consensusLayerName } = useNetworkName();
+
   const defaultExecutionPorts: {
     defaultTcp: number;
     defaultUdp: number;
@@ -994,17 +997,8 @@ export const Checklist = () => {
             label={
               <Text className="checkbox-label">
                 <FormattedMessage
-                  defaultMessage="I've synced my beacon node on {network}."
-                  values={{
-                    network: IS_MAINNET ? (
-                      <FormattedMessage defaultMessage="Mainnet" />
-                    ) : (
-                      <FormattedMessage
-                        defaultMessage="{testNetwork} testnet"
-                        values={{ testNetwork: TESTNET_LAUNCHPAD_NAME }}
-                      />
-                    ),
-                  }}
+                  defaultMessage="I've synced my beacon node on {consensusLayerName}."
+                  values={{ consensusLayerName }}
                 />
               </Text>
             }

--- a/src/pages/Checklist/index.tsx
+++ b/src/pages/Checklist/index.tsx
@@ -10,7 +10,6 @@ import { Heading } from '../../components/Heading';
 import { Text } from '../../components/Text';
 import {
   BEACONCHAIN_URL,
-  NETWORK_NAME,
   IS_MAINNET,
   TESTNET_LAUNCHPAD_URL,
   TESTNET_LAUNCHPAD_NAME,
@@ -846,7 +845,11 @@ export const Checklist = () => {
                 <FormattedMessage
                   defaultMessage="I've installed and synced my {network} execution client (do not wait on this as it can take several days)."
                   values={{
-                    network: IS_MAINNET ? 'Mainnet' : EL_TESTNET_NAME,
+                    network: IS_MAINNET ? (
+                      <FormattedMessage defaultMessage="Mainnet" />
+                    ) : (
+                      EL_TESTNET_NAME
+                    ),
                   }}
                 />
               </Text>
@@ -991,9 +994,17 @@ export const Checklist = () => {
             label={
               <Text className="checkbox-label">
                 <FormattedMessage
-                  defaultMessage="I've synced my beacon node on {NETWORK_NAME}."
-                  values={{ NETWORK_NAME }}
-                  description="{NETWORK_NAME} is name of network, do not translate"
+                  defaultMessage="I've synced my beacon node on {network}."
+                  values={{
+                    network: IS_MAINNET ? (
+                      <FormattedMessage defaultMessage="Mainnet" />
+                    ) : (
+                      <FormattedMessage
+                        defaultMessage="{testNetwork} testnet"
+                        values={{ testNetwork: TESTNET_LAUNCHPAD_NAME }}
+                      />
+                    ),
+                  }}
                 />
               </Text>
             }

--- a/src/pages/Congratulations/index.tsx
+++ b/src/pages/Congratulations/index.tsx
@@ -301,7 +301,10 @@ const _CongratulationsPage = ({
                   values={{
                     testnet: (
                       <Link primary inline to={TESTNET_LAUNCHPAD_URL}>
-                        {TESTNET_LAUNCHPAD_NAME} testnet
+                        <FormattedMessage
+                          defaultMessage="{TESTNET_LAUNCHPAD_NAME} testnet"
+                          values={{ TESTNET_LAUNCHPAD_NAME }}
+                        />
                       </Link>
                     ),
                   }}
@@ -321,7 +324,7 @@ const _CongratulationsPage = ({
                 values={{
                   mainnet: (
                     <Link primary inline to={MAINNET_LAUNCHPAD_URL}>
-                      mainnet
+                      <FormattedMessage defaultMessage="Mainnet" />
                     </Link>
                   ),
                 }}

--- a/src/pages/ConnectWallet/WalletDisconnected.tsx
+++ b/src/pages/ConnectWallet/WalletDisconnected.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { WorkflowPageTemplate } from '../../components/WorkflowPage/WorkflowPageTemplate';
 import { AcknowledgementSection } from '../Summary/AcknowledgementSection';
 import { Text } from '../../components/Text';
 import { routesEnum } from '../../Routes';
 import { Link as L } from '../../components/Link';
-import { FormattedMessage, useIntl } from 'react-intl';
 
 const Link = styled(L)`
   display: inline;
@@ -15,7 +15,6 @@ const Link = styled(L)`
 
 export const WalletDisconnected = () => {
   const { formatMessage } = useIntl();
-  const intl = useIntl();
   const acknowledgementTitle = formatMessage({
     defaultMessage: 'Your wallet has disconnected',
   });
@@ -32,7 +31,7 @@ export const WalletDisconnected = () => {
             values={{
               reconnect: (
                 <Link to={routesEnum.connectWalletPage}>
-                  {intl.formatMessage({
+                  {formatMessage({
                     defaultMessage: 'reconnect your wallet',
                   })}
                 </Link>

--- a/src/pages/ConnectWallet/WrongNetwork.tsx
+++ b/src/pages/ConnectWallet/WrongNetwork.tsx
@@ -1,16 +1,20 @@
 import React from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { AcknowledgementSection } from '../Summary/AcknowledgementSection';
 import { Text } from '../../components/Text';
 import { WorkflowPageTemplate } from '../../components/WorkflowPage/WorkflowPageTemplate';
 import { IS_MAINNET, EL_TESTNET_NAME } from '../../utils/envVars';
-import { FormattedMessage, useIntl } from 'react-intl';
-
-const networkName = IS_MAINNET
-  ? 'mainnet'
-  : `${EL_TESTNET_NAME.toLowerCase()} testnet`;
 
 export const WrongNetwork = () => {
   const { formatMessage } = useIntl();
+
+  const networkName = IS_MAINNET
+    ? formatMessage({ defaultMessage: 'Mainnet' })
+    : formatMessage(
+        { defaultMessage: '{testNetwork} testnet' },
+        { testNetwork: EL_TESTNET_NAME }
+      );
+
   const acknowledgementTitle = formatMessage({
     defaultMessage: 'Your network has changed',
   });
@@ -23,9 +27,8 @@ export const WrongNetwork = () => {
       <AcknowledgementSection title={acknowledgementTitle}>
         <Text>
           <FormattedMessage
-            defaultMessage="Your wallet is on the wrong Ethereum network. To continue, connect to the 
-            {networkName} network."
-            values={{ networkName: <span>{networkName}</span> }}
+            defaultMessage="Your wallet is on the wrong Ethereum network. To continue, connect to {networkName}."
+            values={{ networkName }}
           />
         </Text>
       </AcknowledgementSection>

--- a/src/pages/ConnectWallet/WrongNetwork.tsx
+++ b/src/pages/ConnectWallet/WrongNetwork.tsx
@@ -3,17 +3,11 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { AcknowledgementSection } from '../Summary/AcknowledgementSection';
 import { Text } from '../../components/Text';
 import { WorkflowPageTemplate } from '../../components/WorkflowPage/WorkflowPageTemplate';
-import { IS_MAINNET, EL_TESTNET_NAME } from '../../utils/envVars';
+import useNetworkName from '../../hooks/useIntlNetworkName';
 
 export const WrongNetwork = () => {
   const { formatMessage } = useIntl();
-
-  const networkName = IS_MAINNET
-    ? formatMessage({ defaultMessage: 'Mainnet' })
-    : formatMessage(
-        { defaultMessage: '{testNetwork} testnet' },
-        { testNetwork: EL_TESTNET_NAME }
-      );
+  const { executionLayerName } = useNetworkName();
 
   const acknowledgementTitle = formatMessage({
     defaultMessage: 'Your network has changed',
@@ -27,8 +21,8 @@ export const WrongNetwork = () => {
       <AcknowledgementSection title={acknowledgementTitle}>
         <Text>
           <FormattedMessage
-            defaultMessage="Your wallet is on the wrong Ethereum network. To continue, connect to {networkName}."
-            values={{ networkName }}
+            defaultMessage="Your wallet is on the wrong Ethereum network. To continue, connect to {executionLayerName}."
+            values={{ executionLayerName }}
           />
         </Text>
       </AcknowledgementSection>

--- a/src/pages/ConnectWallet/WrongNetwork.tsx
+++ b/src/pages/ConnectWallet/WrongNetwork.tsx
@@ -3,11 +3,11 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import { AcknowledgementSection } from '../Summary/AcknowledgementSection';
 import { Text } from '../../components/Text';
 import { WorkflowPageTemplate } from '../../components/WorkflowPage/WorkflowPageTemplate';
-import useNetworkName from '../../hooks/useIntlNetworkName';
+import useIntlNetworkName from '../../hooks/useIntlNetworkName';
 
 export const WrongNetwork = () => {
   const { formatMessage } = useIntl();
-  const { executionLayerName } = useNetworkName();
+  const { executionLayerName } = useIntlNetworkName();
 
   const acknowledgementTitle = formatMessage({
     defaultMessage: 'Your network has changed',

--- a/src/pages/ConnectWallet/index.tsx
+++ b/src/pages/ConnectWallet/index.tsx
@@ -45,11 +45,11 @@ import {
   IS_MAINNET,
   PRICE_PER_VALIDATOR,
   TICKER_NAME,
-  EL_TESTNET_NAME,
   FAUCET_URL,
 } from '../../utils/envVars';
 import { routeToCorrectWorkflowStep } from '../../utils/RouteToCorrectWorkflowStep';
 import { MetamaskHardwareButton } from './MetamaskHardwareButton';
+import useNetworkName from '../../hooks/useIntlNetworkName';
 
 // styled components
 const Container = styled.div`
@@ -183,6 +183,7 @@ const _ConnectWalletPage = ({
     account,
     library,
   }: web3ReactInterface = useWeb3React<Web3Provider>();
+  const { executionLayerName } = useNetworkName();
 
   // initialize state
   const [balance, setBalance] = useState<number | null>(null);
@@ -202,13 +203,6 @@ const _ConnectWalletPage = ({
   }, [error]);
   const balanceRef = useRef<number | null>(null);
   const { formatMessage } = useIntl();
-
-  const networkName = IS_MAINNET
-    ? formatMessage({ defaultMessage: 'Mainnet' })
-    : formatMessage(
-        { defaultMessage: '{testNetwork} testnet' },
-        { testNetwork: EL_TESTNET_NAME }
-      );
 
   // sets balanceRef to always have current balance (to refer to in callbacks)
   balanceRef.current = balance;
@@ -299,10 +293,10 @@ const _ConnectWalletPage = ({
     } else if (!networkAllowed) {
       setStatus(
         formatMessage(
-          { defaultMessage: 'Connect {wallet} to {network}' },
+          { defaultMessage: 'Connect {wallet} to {executionLayerName}' },
           {
             wallet: getWalletName(walletProvider),
-            network: networkName,
+            executionLayerName,
           }
         )
       );
@@ -316,7 +310,7 @@ const _ConnectWalletPage = ({
     network,
     formatMessage,
     walletProvider,
-    networkName,
+    executionLayerName,
   ]);
 
   const handleSubmit = () => {
@@ -371,7 +365,7 @@ const _ConnectWalletPage = ({
                   </Heading>
                 </Row>
                 <Text color={networkAllowed ? 'greenDark' : 'redMedium'}>
-                  {networkName}
+                  {executionLayerName}
                 </Text>
               </Network>
               <div>
@@ -494,8 +488,8 @@ const _ConnectWalletPage = ({
       {isInvalidNetwork && (
         <div className="flex center mt20">
           <FormattedMessage
-            defaultMessage="Your wallet is on the wrong network. Switch to {networkName}"
-            values={{ networkName }}
+            defaultMessage="Your wallet is on the wrong network. Switch to {executionLayerName}"
+            values={{ executionLayerName }}
           />
         </div>
       )}

--- a/src/pages/ConnectWallet/index.tsx
+++ b/src/pages/ConnectWallet/index.tsx
@@ -141,10 +141,6 @@ const MetaMaskError = styled.div`
   margin-top: 0px;
 `;
 
-const networkName = IS_MAINNET
-  ? 'mainnet'
-  : `${EL_TESTNET_NAME.toLowerCase()} testnet`;
-
 export interface web3ReactInterface {
   activate: (
     connector: AbstractConnectorInterface,
@@ -206,6 +202,13 @@ const _ConnectWalletPage = ({
   }, [error]);
   const balanceRef = useRef<number | null>(null);
   const { formatMessage } = useIntl();
+
+  const networkName = IS_MAINNET
+    ? formatMessage({ defaultMessage: 'Mainnet' })
+    : formatMessage(
+        { defaultMessage: '{testNetwork} testnet' },
+        { testNetwork: EL_TESTNET_NAME }
+      );
 
   // sets balanceRef to always have current balance (to refer to in callbacks)
   balanceRef.current = balance;
@@ -313,6 +316,7 @@ const _ConnectWalletPage = ({
     network,
     formatMessage,
     walletProvider,
+    networkName,
   ]);
 
   const handleSubmit = () => {
@@ -367,7 +371,7 @@ const _ConnectWalletPage = ({
                   </Heading>
                 </Row>
                 <Text color={networkAllowed ? 'greenDark' : 'redMedium'}>
-                  {network === 'Mainnet' ? network : `${network} testnet`}
+                  {networkName}
                 </Text>
               </Network>
               <div>
@@ -490,10 +494,8 @@ const _ConnectWalletPage = ({
       {isInvalidNetwork && (
         <div className="flex center mt20">
           <FormattedMessage
-            defaultMessage="Your wallet is on the wrong network. Switch to {network}"
-            values={{
-              network: networkName,
-            }}
+            defaultMessage="Your wallet is on the wrong network. Switch to {networkName}"
+            values={{ networkName }}
           />
         </div>
       )}

--- a/src/pages/ConnectWallet/index.tsx
+++ b/src/pages/ConnectWallet/index.tsx
@@ -49,7 +49,7 @@ import {
 } from '../../utils/envVars';
 import { routeToCorrectWorkflowStep } from '../../utils/RouteToCorrectWorkflowStep';
 import { MetamaskHardwareButton } from './MetamaskHardwareButton';
-import useNetworkName from '../../hooks/useIntlNetworkName';
+import useIntlNetworkName from '../../hooks/useIntlNetworkName';
 
 // styled components
 const Container = styled.div`
@@ -183,7 +183,7 @@ const _ConnectWalletPage = ({
     account,
     library,
   }: web3ReactInterface = useWeb3React<Web3Provider>();
-  const { executionLayerName } = useNetworkName();
+  const { executionLayerName } = useIntlNetworkName();
 
   // initialize state
   const [balance, setBalance] = useState<number | null>(null);

--- a/src/pages/FAQ/index.jsx
+++ b/src/pages/FAQ/index.jsx
@@ -54,7 +54,11 @@ export const FAQ = () => {
               <FormattedMessage
                 defaultMessage="A {validator} is a virtual entity that lives on the Beacon Chain, represented by a balance, public key, and other properties, and participates in consensus of the Ethereum network."
                 values={{
-                  validator: <em>validator</em>,
+                  validator: (
+                    <em>
+                      <FormattedMessage defaultMessage="validator" />
+                    </em>
+                  ),
                 }}
               />
             </Text>
@@ -67,7 +71,11 @@ export const FAQ = () => {
               <FormattedMessage
                 defaultMessage="A {validatorClient} is the software that acts on behalf of the validator by holding and using its private key to make attestations about the state of the chain. A single validator client can hold many key pairs, controlling many validators."
                 values={{
-                  validatorClient: <em>validator client</em>,
+                  validatorClient: (
+                    <em>
+                      <FormattedMessage defaultMessage="validator client" />
+                    </em>
+                  ),
                 }}
               />
             </Text>
@@ -80,7 +88,11 @@ export const FAQ = () => {
               <FormattedMessage
                 defaultMessage="A {nodeOperator} is the human being who makes sure the client software is running appropriately, maintaining hardware as needed."
                 values={{
-                  nodeOperator: <em>node operator</em>,
+                  nodeOperator: (
+                    <em>
+                      <FormattedMessage defaultMessage="node operator" />
+                    </em>
+                  ),
                 }}
               />
             </Text>
@@ -94,7 +106,11 @@ export const FAQ = () => {
                 defaultMessage="Each key-pair associated with a validator requires locking {ethPerValidator} to be activated, which represents your initial balance as well as your {initialAndMaximum} voting power for any validator."
                 values={{
                   ethPerValidator: <strong>{PRICE_PER_VALIDATOR} ETH</strong>,
-                  initialAndMaximum: <em>initial and maximum</em>,
+                  initialAndMaximum: (
+                    <em>
+                      <FormattedMessage defaultMessage="initial and maximum" />
+                    </em>
+                  ),
                 }}
               />
             </Text>
@@ -369,14 +385,18 @@ export const FAQ = () => {
               <FormattedMessage
                 defaultMessage="Once the transition to proof-of-stake is complete via the Merge, validators will be responsible for processing transactions and signing off on their validity. This data will {not} be available from popular third-party sources after the Merge and will result in your validator being offline. When data sharding is implemented, validators will also be at risk of slashing under the {pocGame}."
                 values={{
-                  not: <em>not</em>,
+                  not: (
+                    <em>
+                      <FormattedMessage defaultMessage="not" />
+                    </em>
+                  ),
                   pocGame: (
                     <Link
                       inline
                       primary
                       to="https://dankradfeist.de/ethereum/2021/09/30/proofs-of-custody.html"
                     >
-                      proof-of-custody game
+                      <FormattedMessage defaultMessage="proof-of-custody game" />
                     </Link>
                   ),
                 }}
@@ -479,7 +499,11 @@ export const FAQ = () => {
                 <FormattedMessage
                   defaultMessage="Your validator will also receive unburnt gas fees when proposing blocks. Validators are chosen randomly by the protocol to propose blocks, and only one validator can propose a block for each 12-second slot. There are 7200 slots each day, so each validator has 7200 chances-per-day to propose a block. If there are 360,000 validators, each validator will {average} a block proposal every 50 days. "
                   values={{
-                    average: <em>average</em>,
+                    average: (
+                      <em>
+                        <FormattedMessage defaultMessage="average" />
+                      </em>
+                    ),
                   }}
                 />
               </Text>

--- a/src/pages/FAQ/index.jsx
+++ b/src/pages/FAQ/index.jsx
@@ -784,7 +784,7 @@ export const FAQ = () => {
                       inline
                       to="https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/validator.md#withdrawal-credentials"
                     >
-                      Withdrawal Credentials
+                      <FormattedMessage defaultMessage="Withdrawal Credentials" />
                     </Link>
                   ),
                 }}

--- a/src/pages/GenerateKeys/Option1.tsx
+++ b/src/pages/GenerateKeys/Option1.tsx
@@ -11,7 +11,7 @@ import { NETWORK_NAME } from '../../utils/envVars';
 import { Button } from '../../components/Button';
 import githubScreenshot from '../../static/github-cli-screenshot.png';
 import { colors } from '../../styles/styledComponentsTheme';
-import useNetworkName from '../../hooks/useIntlNetworkName';
+import useIntlNetworkName from '../../hooks/useIntlNetworkName';
 
 const AlertIcon = styled(p => <GrommetAlert {...p} />)`
   display: block;
@@ -35,7 +35,7 @@ export const Option1 = ({
   os: string;
 }) => {
   const { formatMessage } = useIntl();
-  const { consensusLayerName } = useNetworkName();
+  const { consensusLayerName } = useIntlNetworkName();
 
   return (
     <div className="mt30">

--- a/src/pages/GenerateKeys/Option1.tsx
+++ b/src/pages/GenerateKeys/Option1.tsx
@@ -7,14 +7,11 @@ import { Text } from '../../components/Text';
 import { Link } from '../../components/Link';
 import { Alert } from '../../components/Alert';
 import { Code } from '../../components/Code';
-import {
-  NETWORK_NAME,
-  IS_MAINNET,
-  TESTNET_LAUNCHPAD_NAME,
-} from '../../utils/envVars';
+import { NETWORK_NAME } from '../../utils/envVars';
 import { Button } from '../../components/Button';
 import githubScreenshot from '../../static/github-cli-screenshot.png';
 import { colors } from '../../styles/styledComponentsTheme';
+import useNetworkName from '../../hooks/useIntlNetworkName';
 
 const AlertIcon = styled(p => <GrommetAlert {...p} />)`
   display: block;
@@ -38,6 +35,7 @@ export const Option1 = ({
   os: string;
 }) => {
   const { formatMessage } = useIntl();
+  const { consensusLayerName } = useNetworkName();
 
   return (
     <div className="mt30">
@@ -144,7 +142,7 @@ export const Option1 = ({
         <Alert variant="error" className="my10">
           <Text>
             <FormattedMessage
-              defaultMessage="Please make sure you have set {flag} for {network}, otherwise the deposit will be invalid."
+              defaultMessage="Please make sure you have set {flag} for {consensusLayerName}, otherwise the deposit will be invalid."
               values={{
                 flag: (
                   <Code>
@@ -154,14 +152,7 @@ export const Option1 = ({
                     })} ${NETWORK_NAME.toLowerCase()}`}
                   </Code>
                 ),
-                network: IS_MAINNET ? (
-                  <FormattedMessage defaultMessage="Mainnet" />
-                ) : (
-                  <FormattedMessage
-                    defaultMessage="{TESTNET_LAUNCHPAD_NAME} testnet"
-                    values={{ TESTNET_LAUNCHPAD_NAME }}
-                  />
-                ),
+                consensusLayerName,
               }}
               description="{flag} is a terminal command styled as code."
             />

--- a/src/pages/GenerateKeys/Option1.tsx
+++ b/src/pages/GenerateKeys/Option1.tsx
@@ -7,7 +7,11 @@ import { Text } from '../../components/Text';
 import { Link } from '../../components/Link';
 import { Alert } from '../../components/Alert';
 import { Code } from '../../components/Code';
-import { NETWORK_NAME, IS_MAINNET } from '../../utils/envVars';
+import {
+  NETWORK_NAME,
+  IS_MAINNET,
+  TESTNET_LAUNCHPAD_NAME,
+} from '../../utils/envVars';
 import { Button } from '../../components/Button';
 import githubScreenshot from '../../static/github-cli-screenshot.png';
 import { colors } from '../../styles/styledComponentsTheme';
@@ -150,13 +154,16 @@ export const Option1 = ({
                     })} ${NETWORK_NAME.toLowerCase()}`}
                   </Code>
                 ),
-                network: (
-                  <span>
-                    {IS_MAINNET ? NETWORK_NAME : `${NETWORK_NAME} testnet`}
-                  </span>
+                network: IS_MAINNET ? (
+                  <FormattedMessage defaultMessage="Mainnet" />
+                ) : (
+                  <FormattedMessage
+                    defaultMessage="{TESTNET_LAUNCHPAD_NAME} testnet"
+                    values={{ TESTNET_LAUNCHPAD_NAME }}
+                  />
                 ),
               }}
-              description="{flag} and {network} are terminal commands styled as code."
+              description="{flag} is a terminal command styled as code."
             />
           </Text>
         </Alert>

--- a/src/pages/GenerateKeys/Option1.tsx
+++ b/src/pages/GenerateKeys/Option1.tsx
@@ -96,7 +96,11 @@ export const Option1 = ({
           <FormattedMessage
             defaultMessage="Use the terminal to move into the directory that contains the {deposit} executable"
             values={{
-              deposit: <code>deposit</code>,
+              deposit: (
+                <code>
+                  <FormattedMessage defaultMessage="deposit" />
+                </code>
+              ),
             }}
             description="{deposit} = 'deposit' styled as code"
           />

--- a/src/pages/GenerateKeys/Option2.tsx
+++ b/src/pages/GenerateKeys/Option2.tsx
@@ -118,7 +118,6 @@ export const Option2 = ({ os }: { os: string }) => {
               values={{
                 network: <span>{NETWORK_NAME}</span>,
               }}
-              description="{flag} and {network} are terminal commands styled as code."
             />
           </Text>
         </Alert>

--- a/src/pages/GenerateKeys/Option2.tsx
+++ b/src/pages/GenerateKeys/Option2.tsx
@@ -114,10 +114,8 @@ export const Option2 = ({ os }: { os: string }) => {
         <Alert variant="error" className="my10">
           <Text>
             <FormattedMessage
-              defaultMessage="Please make sure you select {network} when prompted for a network, otherwise the deposit will be invalid."
-              values={{
-                network: <span>{NETWORK_NAME}</span>,
-              }}
+              defaultMessage="Please make sure you select {NETWORK_NAME} when prompted for a network, otherwise the deposit will be invalid."
+              values={{ NETWORK_NAME }}
             />
           </Text>
         </Alert>

--- a/src/pages/GenerateKeys/Option3.tsx
+++ b/src/pages/GenerateKeys/Option3.tsx
@@ -6,7 +6,11 @@ import { Link } from '../../components/Link';
 import { Button } from '../../components/Button';
 import { Alert } from '../../components/Alert';
 import { Code } from '../../components/Code';
-import { NETWORK_NAME, IS_MAINNET } from '../../utils/envVars';
+import {
+  NETWORK_NAME,
+  IS_MAINNET,
+  TESTNET_LAUNCHPAD_NAME,
+} from '../../utils/envVars';
 import { colors } from '../../styles/styledComponentsTheme';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -327,17 +331,23 @@ export const Option3 = ({
             defaultMessage="Make sure you have set {flag} for {network}, otherwise the deposit will be invalid."
             values={{
               flag: (
-                <Code>{`--${formatMessage({
-                  defaultMessage: 'chain',
-                  description: 'this is used as a command line flag',
-                })} ${NETWORK_NAME.toLowerCase()}`}</Code>
+                <Code>
+                  {`--${formatMessage({
+                    defaultMessage: 'chain',
+                    description: 'this is used as a command line flag',
+                  })} ${NETWORK_NAME.toLowerCase()}`}
+                </Code>
               ),
-              network: (
-                <span>
-                  {IS_MAINNET ? NETWORK_NAME : `${NETWORK_NAME} testnet`}
-                </span>
+              network: IS_MAINNET ? (
+                <FormattedMessage defaultMessage="Mainnet" />
+              ) : (
+                <FormattedMessage
+                  defaultMessage="{TESTNET_LAUNCHPAD_NAME} testnet"
+                  values={{ TESTNET_LAUNCHPAD_NAME }}
+                />
               ),
             }}
+            description="{flag} is a terminal command styled as code."
           />
         </Text>
       </Alert>

--- a/src/pages/GenerateKeys/Option3.tsx
+++ b/src/pages/GenerateKeys/Option3.tsx
@@ -9,7 +9,7 @@ import { Code } from '../../components/Code';
 import { NETWORK_NAME } from '../../utils/envVars';
 import { colors } from '../../styles/styledComponentsTheme';
 import { FormattedMessage, useIntl } from 'react-intl';
-import useNetworkName from '../../hooks/useIntlNetworkName';
+import useIntlNetworkName from '../../hooks/useIntlNetworkName';
 
 const Pre = styled.pre`
   white-space: normal;
@@ -23,7 +23,7 @@ export const Option3 = ({
   os: string;
 }) => {
   const { formatMessage } = useIntl();
-  const { consensusLayerName } = useNetworkName();
+  const { consensusLayerName } = useIntlNetworkName();
   const renderPythonInstructions = () => {
     if (os === 'linux')
       return (

--- a/src/pages/GenerateKeys/Option3.tsx
+++ b/src/pages/GenerateKeys/Option3.tsx
@@ -6,13 +6,10 @@ import { Link } from '../../components/Link';
 import { Button } from '../../components/Button';
 import { Alert } from '../../components/Alert';
 import { Code } from '../../components/Code';
-import {
-  NETWORK_NAME,
-  IS_MAINNET,
-  TESTNET_LAUNCHPAD_NAME,
-} from '../../utils/envVars';
+import { NETWORK_NAME } from '../../utils/envVars';
 import { colors } from '../../styles/styledComponentsTheme';
 import { FormattedMessage, useIntl } from 'react-intl';
+import useNetworkName from '../../hooks/useIntlNetworkName';
 
 const Pre = styled.pre`
   white-space: normal;
@@ -26,6 +23,7 @@ export const Option3 = ({
   os: string;
 }) => {
   const { formatMessage } = useIntl();
+  const { consensusLayerName } = useNetworkName();
   const renderPythonInstructions = () => {
     if (os === 'linux')
       return (
@@ -328,7 +326,7 @@ export const Option3 = ({
       <Alert variant="error" className="my10">
         <Text>
           <FormattedMessage
-            defaultMessage="Make sure you have set {flag} for {network}, otherwise the deposit will be invalid."
+            defaultMessage="Make sure you have set {flag} for {consensusLayerName}, otherwise the deposit will be invalid."
             values={{
               flag: (
                 <Code>
@@ -338,14 +336,7 @@ export const Option3 = ({
                   })} ${NETWORK_NAME.toLowerCase()}`}
                 </Code>
               ),
-              network: IS_MAINNET ? (
-                <FormattedMessage defaultMessage="Mainnet" />
-              ) : (
-                <FormattedMessage
-                  defaultMessage="{TESTNET_LAUNCHPAD_NAME} testnet"
-                  values={{ TESTNET_LAUNCHPAD_NAME }}
-                />
-              ),
+              consensusLayerName,
             }}
             description="{flag} is a terminal command styled as code."
           />

--- a/src/pages/Landing/Hero.tsx
+++ b/src/pages/Landing/Hero.tsx
@@ -168,7 +168,6 @@ export const Hero = () => {
                             <FormattedMessage
                               defaultMessage="Staking Launchpad for {TESTNET_LAUNCHPAD_NAME} testnet"
                               values={{ TESTNET_LAUNCHPAD_NAME }}
-                              description="This phrase is a sentence "
                             />
                           )}
                         </LogoText>

--- a/src/pages/Landing/SignupSteps/index.tsx
+++ b/src/pages/Landing/SignupSteps/index.tsx
@@ -41,7 +41,7 @@ const ButtonContainer = styled.div`
 
 export const SignupSteps = (): JSX.Element => {
   const m: boolean = (window as any).mobileCheck();
-  const intl = useIntl();
+  const { formatMessage } = useIntl();
   return (
     <Container className="py100">
       <ScrollAnimation animateIn="fadeIn" animateOnce>
@@ -59,11 +59,11 @@ export const SignupSteps = (): JSX.Element => {
         <ScrollAnimation animateIn="fadeInUp" animateOnce>
           <Step
             emoji="📚"
-            emojiAlt={intl.formatMessage({ defaultMessage: 'books' })}
-            title={intl.formatMessage({
+            emojiAlt={formatMessage({ defaultMessage: 'books' })}
+            title={formatMessage({
               defaultMessage: '1. Learn about your responsibilities',
             })}
-            content={intl.formatMessage({
+            content={formatMessage({
               defaultMessage:
                 'The Ethereum upgrades will only be successful if validators understand the risks and responsibilities.',
             })}
@@ -76,9 +76,9 @@ export const SignupSteps = (): JSX.Element => {
         <ScrollAnimation animateIn="fadeInUp" animateOnce delay={300}>
           <Step
             emoji="🔧"
-            emojiAlt={intl.formatMessage({ defaultMessage: 'wrench' })}
-            title={intl.formatMessage({ defaultMessage: '2. Prep nodes' })}
-            content={intl.formatMessage({
+            emojiAlt={formatMessage({ defaultMessage: 'wrench' })}
+            title={formatMessage({ defaultMessage: '2. Prep nodes' })}
+            content={formatMessage({
               defaultMessage:
                 "You'll need to run an execution client (formerly 'Eth1') as well as a consensus client (formerly 'Eth2') to become a validator. Take a look at the checklist to prepare yourself and your equipment.",
             })}
@@ -91,13 +91,13 @@ export const SignupSteps = (): JSX.Element => {
         <ScrollAnimation animateIn="fadeInUp" animateOnce delay={150}>
           <Step
             emoji="🥋"
-            emojiAlt={intl.formatMessage({
+            emojiAlt={formatMessage({
               defaultMessage: 'martial arts uniform',
             })}
-            title={intl.formatMessage({
+            title={formatMessage({
               defaultMessage: '3. Practice on a testnet',
             })}
-            content={intl.formatMessage({
+            content={formatMessage({
               defaultMessage:
                 'We strongly recommend you go through the entire process on a testnet first to get comfortable before risking real ETH.',
             })}
@@ -114,11 +114,11 @@ export const SignupSteps = (): JSX.Element => {
         <ScrollAnimation animateIn="fadeInUp" animateOnce delay={300}>
           <Step
             emoji="🎣"
-            emojiAlt={intl.formatMessage({
+            emojiAlt={formatMessage({
               defaultMessage: 'fishing rod',
             })}
-            title={intl.formatMessage({ defaultMessage: '4. Avoid phishing' })}
-            content={intl.formatMessage({
+            title={formatMessage({ defaultMessage: '4. Avoid phishing' })}
+            content={formatMessage({
               defaultMessage:
                 "Make sure you're aware of how to avoid phishing attacks. We've prepared a list of things to look out for.",
             })}
@@ -131,9 +131,9 @@ export const SignupSteps = (): JSX.Element => {
         <ScrollAnimation animateIn="fadeInUp" animateOnce delay={150}>
           <Step
             emoji="💰"
-            emojiAlt={intl.formatMessage({ defaultMessage: 'money bag' })}
-            title={intl.formatMessage({ defaultMessage: '5. Time to deposit' })}
-            content={intl.formatMessage({
+            emojiAlt={formatMessage({ defaultMessage: 'money bag' })}
+            title={formatMessage({ defaultMessage: '5. Time to deposit' })}
+            content={formatMessage({
               defaultMessage:
                 "Once you're comfortable, you'll go through generating your keys and depositing your ETH.",
             })}
@@ -146,11 +146,11 @@ export const SignupSteps = (): JSX.Element => {
         <ScrollAnimation animateIn="fadeInUp" animateOnce delay={300}>
           <Step
             emoji="🕰"
-            emojiAlt={intl.formatMessage({ defaultMessage: 'clock' })}
-            title={intl.formatMessage({
+            emojiAlt={formatMessage({ defaultMessage: 'clock' })}
+            title={formatMessage({
               defaultMessage: '6. Wait to become active',
             })}
-            content={intl.formatMessage({
+            content={formatMessage({
               defaultMessage:
                 "Once set up, your validator won't become active straight away. Use this time to complete the checklist and get some extra practice on a testnet.",
             })}
@@ -169,7 +169,7 @@ export const SignupSteps = (): JSX.Element => {
               className="m-auto"
               fullWidth
               width={m ? undefined : 400}
-              label={intl.formatMessage({
+              label={formatMessage({
                 defaultMessage: 'Become a validator',
               })}
             />

--- a/src/pages/Landing/Upgrades/index.tsx
+++ b/src/pages/Landing/Upgrades/index.tsx
@@ -133,7 +133,7 @@ export const Upgrades = (): JSX.Element => {
                   values={{
                     mergeReadinessChecklist: (
                       <Link primary inline to="/merge-readiness">
-                        Merge Readiness Checklist
+                        <FormattedMessage defaultMessage="Merge Readiness Checklist" />
                       </Link>
                     ),
                   }}

--- a/src/pages/MergeReadiness/index.tsx
+++ b/src/pages/MergeReadiness/index.tsx
@@ -289,7 +289,7 @@ export const MergeReadiness = () => {
                     primary
                     to="https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md"
                   >
-                    Engine API
+                    <FormattedMessage defaultMessage="Engine API" />
                   </Link>
                 ),
               }}
@@ -402,7 +402,13 @@ export const MergeReadiness = () => {
               <Text className="checkbox-label">
                 <FormattedMessage
                   defaultMessage="I have set up a shared JWT secret and made it available to {both} my execution client, and my consensus client (beacon node)"
-                  values={{ both: <strong>both</strong> }}
+                  values={{
+                    both: (
+                      <strong>
+                        <FormattedMessage defaultMessage="both" />
+                      </strong>
+                    ),
+                  }}
                 />
               </Text>
             }
@@ -528,7 +534,13 @@ export const MergeReadiness = () => {
           <Text className="mt20">
             <FormattedMessage
               defaultMessage="While waiting for the Mainnet transition to proof-of-stake, stakers are encouraged to participate in {testingTheMerge}. This is a great way to learn more about the Merge, practice going through it before Mainnet, and gain confidence in your setup."
-              values={{ testingTheMerge: <code>#TestingTheMerge</code> }}
+              values={{
+                testingTheMerge: (
+                  <code>
+                    #<FormattedMessage defaultMessage="TestingTheMerge" />
+                  </code>
+                ),
+              }}
             />
           </Text>
           <Text className="mt20">
@@ -785,7 +797,13 @@ export const MergeReadiness = () => {
           <Text className="mt20">
             <FormattedMessage
               defaultMessage="Reminder, the Merge upgrade will {not} implement withdrawing or transferring of staked ETH. This feature will be included in the Shanghai upgrade planned to follow the Merge."
-              values={{ not: <em>not</em> }}
+              values={{
+                not: (
+                  <em>
+                    <FormattedMessage defaultMessage="not" />
+                  </em>
+                ),
+              }}
             />
           </Text>
           <Text className="mt20">

--- a/src/pages/MergeReadiness/index.tsx
+++ b/src/pages/MergeReadiness/index.tsx
@@ -635,7 +635,7 @@ export const MergeReadiness = () => {
                   <FormattedMessage
                     defaultMessage="{site} {network} announcement"
                     values={{
-                      site: 'EF Blog',
+                      site: <FormattedMessage defaultMessage="EF Blog" />,
                       network: 'Ropsten',
                     }}
                   />
@@ -725,7 +725,7 @@ export const MergeReadiness = () => {
                   <FormattedMessage
                     defaultMessage="{site} {network} announcement"
                     values={{
-                      site: 'EF Blog',
+                      site: <FormattedMessage defaultMessage="EF Blog" />,
                       network: 'Kiln',
                     }}
                   />

--- a/src/pages/SelectClient/index.tsx
+++ b/src/pages/SelectClient/index.tsx
@@ -179,9 +179,14 @@ const _SelectClientPage = ({
     {
       defaultMessage: `Choose {ethClientType} client`,
       description:
-        '{ethClientType} injects execution or consensus depending on step',
+        '{ethClientType} injects "execution" or "consensus" depending on step',
     },
-    { ethClientType: ethClientStep }
+    {
+      ethClientType:
+        ethClientStep === 'execution'
+          ? formatMessage({ defaultMessage: 'execution' })
+          : formatMessage({ defaultMessage: 'consensus' }),
+    }
   );
 
   return (
@@ -189,10 +194,17 @@ const _SelectClientPage = ({
       <SelectClientSection
         title={formatMessage(
           {
-            defaultMessage: `Choose your {ethClientType} client and set up a node`,
-            description: `{ethClientType} is either execution or consensus, depending on which step user is on`,
+            defaultMessage:
+              'Choose your {ethClientType} client and set up a node',
+            description:
+              '{ethClientType} is either "execution" or "consensus", depending on which step user is on',
           },
-          { ethClientType: ethClientStep }
+          {
+            ethClientType:
+              ethClientStep === 'execution'
+                ? formatMessage({ defaultMessage: 'execution' })
+                : formatMessage({ defaultMessage: 'consensus' }),
+          }
         )}
         clients={clientOptions}
         currentClient={selectedClient}

--- a/src/pages/TopUp/components/WalletConnectModal.tsx
+++ b/src/pages/TopUp/components/WalletConnectModal.tsx
@@ -88,11 +88,16 @@ const WalletConnectModal: React.FC<{
             <FormattedMessage
               defaultMessage="Connect to {network}"
               values={{
-                network: IS_MAINNET
-                  ? 'Ethereum mainnet'
-                  : `${EL_TESTNET_NAME.toLowerCase()} testnet`,
+                network: IS_MAINNET ? (
+                  <FormattedMessage defaultMessage="Ethereum Mainnet" />
+                ) : (
+                  <FormattedMessage
+                    defaultMessage="{EL_TESTNET_NAME} testnet"
+                    values={{ EL_TESTNET_NAME }}
+                  />
+                ),
               }}
-              description="{network} is either 'Ethereum mainnet' or '<EL_TESTNET_NAME> testnet'"
+              description="{network} is either 'Ethereum Mainnet' or '<EL_TESTNET_NAME> testnet'"
             />
           </Text>
         </div>

--- a/src/pages/TopUp/components/WalletConnectModal.tsx
+++ b/src/pages/TopUp/components/WalletConnectModal.tsx
@@ -17,12 +17,7 @@ import { WalletButton } from '../../ConnectWallet/WalletButton';
 import { web3ReactInterface } from '../../ConnectWallet';
 import metamaskLogo from '../../../static/metamask.svg';
 import closeGlyph from '../../../static/close.svg';
-import {
-  ENABLE_RPC_FEATURES,
-  IS_MAINNET,
-  PORTIS_DAPP_ID,
-  EL_TESTNET_NAME,
-} from '../../../utils/envVars';
+import { ENABLE_RPC_FEATURES, PORTIS_DAPP_ID } from '../../../utils/envVars';
 import portisLogo from '../../../static/portis.svg';
 import fortmaticLogo from '../../../static/fortmatic.svg';
 import { Heading } from '../../../components/Heading';
@@ -30,6 +25,7 @@ import { Text } from '../../../components/Text';
 import { NakedButton } from '../../../components/NakedButton';
 import { MetamaskHardwareButton } from '../../ConnectWallet/MetamaskHardwareButton';
 import { useKeyPress } from '../../../hooks/useKeyPress';
+import useNetworkName from '../../../hooks/useIntlNetworkName';
 
 const CloseButton = styled(NakedButton)`
   padding: 1rem;
@@ -58,6 +54,7 @@ const WalletConnectModal: React.FC<{
     chainId,
     active,
   }: web3ReactInterface = useWeb3React<Web3Provider>();
+  const executionLayerName = useNetworkName();
 
   const [selectedWallet, setSelectedWallet] = useState<
     AbstractConnector | null | undefined
@@ -86,18 +83,9 @@ const WalletConnectModal: React.FC<{
           />
           <Text center>
             <FormattedMessage
-              defaultMessage="Connect to {network}"
-              values={{
-                network: IS_MAINNET ? (
-                  <FormattedMessage defaultMessage="Ethereum Mainnet" />
-                ) : (
-                  <FormattedMessage
-                    defaultMessage="{EL_TESTNET_NAME} testnet"
-                    values={{ EL_TESTNET_NAME }}
-                  />
-                ),
-              }}
-              description="{network} is either 'Ethereum Mainnet' or '<EL_TESTNET_NAME> testnet'"
+              defaultMessage="Connect to {executionLayerName}"
+              values={{ executionLayerName }}
+              description="{executionLayerName} is either 'Mainnet' or '<Execution Layer Testnet Name> testnet'"
             />
           </Text>
         </div>

--- a/src/pages/TopUp/components/WalletConnectModal.tsx
+++ b/src/pages/TopUp/components/WalletConnectModal.tsx
@@ -25,7 +25,7 @@ import { Text } from '../../../components/Text';
 import { NakedButton } from '../../../components/NakedButton';
 import { MetamaskHardwareButton } from '../../ConnectWallet/MetamaskHardwareButton';
 import { useKeyPress } from '../../../hooks/useKeyPress';
-import useNetworkName from '../../../hooks/useIntlNetworkName';
+import useIntlNetworkName from '../../../hooks/useIntlNetworkName';
 
 const CloseButton = styled(NakedButton)`
   padding: 1rem;
@@ -54,7 +54,7 @@ const WalletConnectModal: React.FC<{
     chainId,
     active,
   }: web3ReactInterface = useWeb3React<Web3Provider>();
-  const executionLayerName = useNetworkName();
+  const executionLayerName = useIntlNetworkName();
 
   const [selectedWallet, setSelectedWallet] = useState<
     AbstractConnector | null | undefined

--- a/src/pages/Transactions/Keylist/index.tsx
+++ b/src/pages/Transactions/Keylist/index.tsx
@@ -74,7 +74,7 @@ const _KeyList = ({ depositKeys, dispatchTransactionStatusUpdate }: Props) => {
       dispatchTransactionStatusUpdate
     );
   };
-  const intl = useIntl();
+  const { formatMessage } = useIntl();
   return (
     <CustomPaper className="mt20">
       <Heading level={3} size="small" color="blueMedium" className="mb20">
@@ -106,7 +106,7 @@ const _KeyList = ({ depositKeys, dispatchTransactionStatusUpdate }: Props) => {
               return (
                 <CustomTableRow
                   data-for={`double-deposit-${i}`}
-                  data-tip={intl.formatMessage({
+                  data-tip={formatMessage({
                     defaultMessage:
                       'Your initial deposit has already been made for this validator public key. Please wait and check the status of your deposit on the Beaconchain data provider.',
                   })}

--- a/src/pages/UploadValidator/index.tsx
+++ b/src/pages/UploadValidator/index.tsx
@@ -38,7 +38,7 @@ import {
 import { FileUploadAnimation } from './FileUploadAnimation';
 import { GENESIS_FORK_VERSION } from '../../utils/envVars';
 import { routeToCorrectWorkflowStep } from '../../utils/RouteToCorrectWorkflowStep';
-import useNetworkName from '../../hooks/useIntlNetworkName';
+import useIntlNetworkName from '../../hooks/useIntlNetworkName';
 
 const Container = styled(Paper)`
   margin: auto;
@@ -93,7 +93,7 @@ const _UploadValidatorPage = ({
   dispatchBeaconChainAPIStatusUpdate,
 }: Props): JSX.Element => {
   const { formatMessage } = useIntl();
-  const { consensusLayerName } = useNetworkName();
+  const { consensusLayerName } = useIntlNetworkName();
   const [isFileStaged, setIsFileStaged] = useState(depositKeys.length > 0);
   const [isFileAccepted, setIsFileAccepted] = useState(depositKeys.length > 0);
   const [fileError, setFileError] = useState<React.ReactElement | null>(null);

--- a/src/pages/UploadValidator/index.tsx
+++ b/src/pages/UploadValidator/index.tsx
@@ -36,12 +36,9 @@ import {
   WorkflowStep,
 } from '../../store/actions/workflowActions';
 import { FileUploadAnimation } from './FileUploadAnimation';
-import {
-  TESTNET_LAUNCHPAD_NAME,
-  GENESIS_FORK_VERSION,
-  IS_MAINNET,
-} from '../../utils/envVars';
+import { GENESIS_FORK_VERSION } from '../../utils/envVars';
 import { routeToCorrectWorkflowStep } from '../../utils/RouteToCorrectWorkflowStep';
+import useNetworkName from '../../hooks/useIntlNetworkName';
 
 const Container = styled(Paper)`
   margin: auto;
@@ -96,6 +93,7 @@ const _UploadValidatorPage = ({
   dispatchBeaconChainAPIStatusUpdate,
 }: Props): JSX.Element => {
   const { formatMessage } = useIntl();
+  const { consensusLayerName } = useNetworkName();
   const [isFileStaged, setIsFileStaged] = useState(depositKeys.length > 0);
   const [isFileAccepted, setIsFileAccepted] = useState(depositKeys.length > 0);
   const [fileError, setFileError] = useState<React.ReactElement | null>(null);
@@ -130,17 +128,8 @@ const _UploadValidatorPage = ({
     setFileError(
       <Text>
         <FormattedMessage
-          defaultMessage="This JSON file isn't for the right network. Upload a file generated for your current network: {network}."
-          values={{
-            network: IS_MAINNET ? (
-              <FormattedMessage defaultMessage="Mainnet" />
-            ) : (
-              <FormattedMessage
-                defaultMessage="{TESTNET_LAUNCHPAD_NAME} testnet"
-                values={{ TESTNET_LAUNCHPAD_NAME }}
-              />
-            ),
-          }}
+          defaultMessage="This JSON file isn't for the right network. Upload a file generated for your current network: {consensusLayerName}."
+          values={{ consensusLayerName }}
         />
       </Text>
     );

--- a/src/pages/UploadValidator/index.tsx
+++ b/src/pages/UploadValidator/index.tsx
@@ -37,7 +37,7 @@ import {
 } from '../../store/actions/workflowActions';
 import { FileUploadAnimation } from './FileUploadAnimation';
 import {
-  NETWORK_NAME,
+  TESTNET_LAUNCHPAD_NAME,
   GENESIS_FORK_VERSION,
   IS_MAINNET,
 } from '../../utils/envVars';
@@ -132,11 +132,13 @@ const _UploadValidatorPage = ({
         <FormattedMessage
           defaultMessage="This JSON file isn't for the right network. Upload a file generated for your current network: {network}."
           values={{
-            network: (
-              <span>
-                {NETWORK_NAME}
-                {IS_MAINNET ? '' : ' testnet'}
-              </span>
+            network: IS_MAINNET ? (
+              <FormattedMessage defaultMessage="Mainnet" />
+            ) : (
+              <FormattedMessage
+                defaultMessage="{TESTNET_LAUNCHPAD_NAME} testnet"
+                values={{ TESTNET_LAUNCHPAD_NAME }}
+              />
             ),
           }}
         />

--- a/src/utils/envVars.ts
+++ b/src/utils/envVars.ts
@@ -9,7 +9,7 @@ export const ENABLE_RPC_FEATURES        = Boolean(INFURA_PROJECT_ID && INFURA_PR
 export const INFURA_URL                 = `https://${IS_MAINNET ? "mainnet" : EL_TESTNET_NAME.toLowerCase()}.infura.io/v3/${INFURA_PROJECT_ID}`;
 
 // public
-export const NETWORK_NAME          = (IS_MAINNET || !process.env.REACT_APP_TESTNET_LAUNCHPAD_NAME) ? 'Mainnet' : process.env.REACT_APP_TESTNET_LAUNCHPAD_NAME;
+export const NETWORK_NAME               = IS_MAINNET ? 'Mainnet' : TESTNET_LAUNCHPAD_NAME;
 export const TICKER_NAME                = IS_MAINNET ? 'ETH' : 'TestnetETH';
 export const ETHERSCAN_URL              = IS_MAINNET ? 'https://etherscan.io/tx' : `https://${EL_TESTNET_NAME.toLowerCase()}.etherscan.io/tx`;
 export const BEACONSCAN_URL             = IS_MAINNET ? 'https://beaconscan.com/validator' : `https://beaconscan.com/${NETWORK_NAME.toLowerCase()}/validator`;

--- a/src/utils/envVars.ts
+++ b/src/utils/envVars.ts
@@ -9,7 +9,7 @@ export const ENABLE_RPC_FEATURES        = Boolean(INFURA_PROJECT_ID && INFURA_PR
 export const INFURA_URL                 = `https://${IS_MAINNET ? "mainnet" : EL_TESTNET_NAME.toLowerCase()}.infura.io/v3/${INFURA_PROJECT_ID}`;
 
 // public
-export const NETWORK_NAME          = (IS_MAINNET || !process.env.REACT_APP_TESTNET_LAUNCHPAD_NAME) ? 'mainnet' : process.env.REACT_APP_TESTNET_LAUNCHPAD_NAME;
+export const NETWORK_NAME          = (IS_MAINNET || !process.env.REACT_APP_TESTNET_LAUNCHPAD_NAME) ? 'Mainnet' : process.env.REACT_APP_TESTNET_LAUNCHPAD_NAME;
 export const TICKER_NAME                = IS_MAINNET ? 'ETH' : 'TestnetETH';
 export const ETHERSCAN_URL              = IS_MAINNET ? 'https://etherscan.io/tx' : `https://${EL_TESTNET_NAME.toLowerCase()}.etherscan.io/tx`;
 export const BEACONSCAN_URL             = IS_MAINNET ? 'https://beaconscan.com/validator' : `https://beaconscan.com/${NETWORK_NAME.toLowerCase()}/validator`;


### PR DESCRIPTION
Fixes issue where intl variables used within `FormatMessage` component were not always set up for translation themselves.

example:
```ts
// Incorrect, as "not" does not get translated
              values={{ not: <em>not</em> }}
// Corrected to:
              values={{
                not: (
                  <em>
                    <FormattedMessage defaultMessage="not" />
                  </em>
                ),
              }}
```

- Extracts remaining strings, including "Mainnet" and "____ testnet" for translation.
- Also capitalized "Mainnet" and the testnet names for consistency

Note: There are some CLI variables such as `--num_validators` and `--chain` that are currently being translated. @CarlBeek Want to confirm that this is aligned with the `staking-deposit-cli` script.
