### PR TITLE
Update README with deployment branch info [Closes #525]

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ yarn
 yarn start
 ```
 
-## Development pull requests (PRs)
+## Development workflow
 
 By default, `dev` acts as the primary base branch which all PRs should merge into. Make sure any pull requests target this branch.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ yarn
 yarn start
 ```
 
+## Development pull requests (PRs)
+
+By default, `dev` acts as the primary base branch which all PRs should merge into. Make sure any pull requests target this branch.
+
+## Launchpad deployment
+
+- The `master` branch represents the live **testnet** version of the Launchpad. Open a PR to merge `dev` into `master` to deploy a testnet Launchpad (e.g. #517 for https://prater.launchpad.ethereum.org/ )
+- The `mainnet` branch represents the live **Mainnet** version of the Launchpad. Open a PR to merge `master` into `mainnet` to deploy the Mainnet Launchpad (e.g. #518 for https://launchpad.ethereum.org/)
+
 ## Launchpad translation
 
 As part of the [ethereum.org Translation Program](https://ethereum.org/en/contributing/translation-program), our community of translators is also working on translating the Ethereum Staking Launchpad.


### PR DESCRIPTION
## Description
- Adds note about testnet (`master`) vs Mainnet (`mainnet`) deployment branches to the `README.md`

## Related issue
[Closes #525]