### PR TITLE
Update merge readiness checklist for ttd

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -65,12 +65,6 @@
       "value": "Configure the Java Web"
     }
   ],
-  "/FpD8O": [
-    {
-      "type": 0,
-      "value": "Do this after TTD client releases"
-    }
-  ],
   "/QPc9s": [
     {
       "type": 0,
@@ -779,6 +773,12 @@
       "value": "Copy"
     }
   ],
+  "4yPejZ": [
+    {
+      "type": 0,
+      "value": "All execution and consensus clients have recently released updates including this TTD to be merge-ready. Be sure to update your clients."
+    }
+  ],
   "54J/qs": [
     {
       "type": 0,
@@ -1113,20 +1113,6 @@
       "value": "Does the contract address listed on the website match?"
     }
   ],
-  "8L6ufI": [
-    {
-      "type": 0,
-      "value": "Step-by-step guide for how to spin up a "
-    },
-    {
-      "type": 1,
-      "value": "network"
-    },
-    {
-      "type": 0,
-      "value": " node and validator"
-    }
-  ],
   "8Rj/6A": [
     {
       "type": 0,
@@ -1275,24 +1261,6 @@
       "value": "Overview"
     }
   ],
-  "9vLu6E": [
-    {
-      "type": 1,
-      "value": "note"
-    },
-    {
-      "type": 0,
-      "value": " This step should be performed on "
-    },
-    {
-      "type": 1,
-      "value": "testnetsOnly"
-    },
-    {
-      "type": 0,
-      "value": " until the Mainnet TTD (terminal total difficulty) has been announced and clients have released an update. Info is presented for preparation in the meantime."
-    }
-  ],
   "9vwGlT": [
     {
       "type": 0,
@@ -1383,24 +1351,6 @@
     {
       "type": 0,
       "value": " to be sent at one time to be accepted."
-    }
-  ],
-  "ALEY4e": [
-    {
-      "type": 1,
-      "value": "community"
-    },
-    {
-      "type": 0,
-      "value": " "
-    },
-    {
-      "type": 1,
-      "value": "network"
-    },
-    {
-      "type": 0,
-      "value": " guide"
     }
   ],
   "ARyG2Z": [
@@ -1713,6 +1663,24 @@
       "value": "NO"
     }
   ],
+  "D1oCWM": [
+    {
+      "type": 1,
+      "value": "networkBold"
+    },
+    {
+      "type": 0,
+      "value": " is a younger public testnet that has already undergone its transition to proof-of-stake after undergoing a successful merge upgrade in March 2022. "
+    },
+    {
+      "type": 1,
+      "value": "network"
+    },
+    {
+      "type": 0,
+      "value": " is open for anyone to interact with, and will continue to be maintained after the Mainnet merge. Try sending some ETH, interacting with some contracts, or deploying your own."
+    }
+  ],
   "D33f/7": [
     {
       "type": 0,
@@ -2011,12 +1979,6 @@
       "value": "Terms of service"
     }
   ],
-  "FqztZR": [
-    {
-      "type": 0,
-      "value": "Note:"
-    }
-  ],
   "FzkbsB": [
     {
       "type": 0,
@@ -2213,6 +2175,12 @@
       "value": "Support"
     }
   ],
+  "Hy1z78": [
+    {
+      "type": 0,
+      "value": "Thorough guide For those who want more control and less hand-holding"
+    }
+  ],
   "I0BXSi": [
     {
       "type": 0,
@@ -2363,6 +2331,12 @@
     {
       "type": 0,
       "value": "Nimbus installation documentation"
+    }
+  ],
+  "JA1956": [
+    {
+      "type": 0,
+      "value": "Attention:"
     }
   ],
   "JAiV0o": [
@@ -2985,6 +2959,12 @@
       "value": "More on ConsenSys"
     }
   ],
+  "Odx4qP": [
+    {
+      "type": 0,
+      "value": "Everything you need to get started with the network, including faucets"
+    }
+  ],
   "OmAmmi": [
     {
       "type": 0,
@@ -3175,20 +3155,6 @@
       "value": " to max out your effective balance."
     }
   ],
-  "Q8fnvz": [
-    {
-      "type": 0,
-      "value": "testnets only (e.g. "
-    },
-    {
-      "type": 1,
-      "value": "kiln"
-    },
-    {
-      "type": 0,
-      "value": ")"
-    }
-  ],
   "QKFeMq": [
     {
       "type": 0,
@@ -3367,16 +3333,6 @@
     {
       "type": 0,
       "value": "How many validators would you like to run?"
-    }
-  ],
-  "Riq4Yh": [
-    {
-      "type": 1,
-      "value": "network"
-    },
-    {
-      "type": 0,
-      "value": " is open for anyone to interact with. Try sending some transactions, running a validator, or see if you can get slashed!"
     }
   ],
   "RkSC5Q": [
@@ -4003,6 +3959,12 @@
     {
       "type": 0,
       "value": "Besu on Goerli documentation"
+    }
+  ],
+  "XSlPoq": [
+    {
+      "type": 0,
+      "value": "Thorough guide to setting up a testnet node"
     }
   ],
   "XVehvN": [
@@ -4951,6 +4913,24 @@
       "value": "More on virtualenv"
     }
   ],
+  "gFBZIa": [
+    {
+      "type": 1,
+      "value": "attention"
+    },
+    {
+      "type": 0,
+      "value": " Mainnet total terminal difficulty (TTD) has been set to 58750000000000000000000. Ethereum is estimated to reach this TTD on the 15h of September, plus-or-minus a few days (Follow "
+    },
+    {
+      "type": 1,
+      "value": "link"
+    },
+    {
+      "type": 0,
+      "value": " for latest estimate). Act now to update your nodes with the latest client releases, and use the steps below to make sure you're prepared."
+    }
+  ],
   "gIauNz": [
     {
       "type": 0,
@@ -4969,6 +4949,12 @@
     {
       "type": 0,
       "value": " to sync the Goerli testnet."
+    }
+  ],
+  "gOJmxl": [
+    {
+      "type": 0,
+      "value": "I am running my own consensus client, and have updated to a merge-ready release"
     }
   ],
   "gQkd2y": [
@@ -5101,6 +5087,20 @@
       "value": "I have provided an Ethereum address to my validator where I would like my fee rewards to be deposited."
     }
   ],
+  "hKPjQW": [
+    {
+      "type": 0,
+      "value": "While waiting for the Mainnet transition to proof-of-stake, stakers are encouraged to participate in "
+    },
+    {
+      "type": 1,
+      "value": "testingTheMerge"
+    },
+    {
+      "type": 0,
+      "value": ". Goerli was recently the final public Ethereum testnet to successfully undergo The Merge, and will persist as a longstanding PoS testnet. Setting up a Goerli node can be a great way to learn more about operating a post-merge Ethereum node, and gain confidence in your setup."
+    }
+  ],
   "hPCn9f": [
     {
       "type": 0,
@@ -5127,6 +5127,16 @@
     {
       "type": 0,
       "value": "Hungarian"
+    }
+  ],
+  "hgU42i": [
+    {
+      "type": 1,
+      "value": "network"
+    },
+    {
+      "type": 0,
+      "value": " is open for anyone to interact with, but is being deprecated moving forward and will not undergo any further network updates."
     }
   ],
   "hjrLbR": [
@@ -5879,6 +5889,12 @@
       "value": "Before you start"
     }
   ],
+  "oAuBZQ": [
+    {
+      "type": 0,
+      "value": "I am running my own execution client, and have updated to a merge-ready release."
+    }
+  ],
   "oF4os+": [
     {
       "type": 0,
@@ -5935,20 +5951,6 @@
     {
       "type": 0,
       "value": "Responsibilities"
-    }
-  ],
-  "olByWa": [
-    {
-      "type": 0,
-      "value": "While waiting for the Mainnet transition to proof-of-stake, stakers are encouraged to participate in "
-    },
-    {
-      "type": 1,
-      "value": "testingTheMerge"
-    },
-    {
-      "type": 0,
-      "value": ". This is a great way to learn more about the Merge, practice going through it before Mainnet, and gain confidence in your setup."
     }
   ],
   "omJNJw": [
@@ -6079,26 +6081,10 @@
       "value": "I've simulated how to manually stop and restart my Beacon Node (BN) and Validator Client (VC) gracefully."
     }
   ],
-  "pxfiWL": [
-    {
-      "type": 1,
-      "value": "networkBold"
-    },
-    {
-      "type": 0,
-      "value": " is a younger public testnet that has already undergone its transition to proof-of-stake after undergoing a successful merge upgrade in March 2022. Kiln is open for anyone to interact with. Try sending some ETH, interacting with some contracts, or deploying your own."
-    }
-  ],
   "pyWt01": [
     {
       "type": 0,
       "value": "Deposit summary"
-    }
-  ],
-  "q2PJEK": [
-    {
-      "type": 0,
-      "value": "I am running my own consensus client."
     }
   ],
   "q2XW/k": [
@@ -6217,6 +6203,12 @@
     {
       "type": 0,
       "value": "Phishing guide"
+    }
+  ],
+  "rEokPY": [
+    {
+      "type": 0,
+      "value": "bordel.wtf"
     }
   ],
   "rMjMmc": [
@@ -6799,12 +6791,6 @@
       "value": "Are there spelling mistakes?"
     }
   ],
-  "wuhO1L": [
-    {
-      "type": 0,
-      "value": "I am running my own execution client."
-    }
-  ],
   "x+fF+M": [
     {
       "type": 0,
@@ -7109,6 +7095,24 @@
     {
       "type": 0,
       "value": "Look over the Merge Readiness Checklist"
+    }
+  ],
+  "zrK3hS": [
+    {
+      "type": 1,
+      "value": "networkBold"
+    },
+    {
+      "type": 0,
+      "value": " is a long-standing public testnet that began as a proof-of-authority chain, and has now undergone its transition to proof-of-stake via a successful Merge in August 2022. "
+    },
+    {
+      "type": 1,
+      "value": "network"
+    },
+    {
+      "type": 0,
+      "value": " is open for anyone to interact with, and will continue to be maintained after the Mainnet merge. Try interacting with some contracts or operating a validating node."
     }
   ]
 }

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -3883,6 +3883,24 @@
       "value": "An implementation of the consensus protocol with a focus on usability, security, and reliability. Prysm is developed by Prysmatic Labs, a company with the sole focus on the development of their client."
     }
   ],
+  "WeQbEO": [
+    {
+      "type": 1,
+      "value": "attention"
+    },
+    {
+      "type": 0,
+      "value": " Mainnet total terminal difficulty (TTD) has been set to 5.875e22. Ethereum is estimated to reach this TTD within a day of the 15th of September (follow "
+    },
+    {
+      "type": 1,
+      "value": "link"
+    },
+    {
+      "type": 0,
+      "value": " for latest estimate). Act now to update your node with the latest client releases, and use the steps below to make sure you're prepared."
+    }
+  ],
   "Wj99ga": [
     {
       "type": 0,
@@ -4911,24 +4929,6 @@
     {
       "type": 0,
       "value": "More on virtualenv"
-    }
-  ],
-  "gFBZIa": [
-    {
-      "type": 1,
-      "value": "attention"
-    },
-    {
-      "type": 0,
-      "value": " Mainnet total terminal difficulty (TTD) has been set to 58750000000000000000000. Ethereum is estimated to reach this TTD on the 15h of September, plus-or-minus a few days (Follow "
-    },
-    {
-      "type": 1,
-      "value": "link"
-    },
-    {
-      "type": 0,
-      "value": " for latest estimate). Act now to update your nodes with the latest client releases, and use the steps below to make sure you're prepared."
     }
   ],
   "gIauNz": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -277,6 +277,12 @@
       "value": ")"
     }
   ],
+  "0i90U5": [
+    {
+      "type": 0,
+      "value": "5.875e22"
+    }
+  ],
   "0lHkrT": [
     {
       "type": 0,
@@ -1655,6 +1661,32 @@
     {
       "type": 0,
       "value": "I've set up a firewall."
+    }
+  ],
+  "CmbwEn": [
+    {
+      "type": 1,
+      "value": "attention"
+    },
+    {
+      "type": 0,
+      "value": " Mainnet total terminal difficulty (TTD) has been set to "
+    },
+    {
+      "type": 1,
+      "value": "difficulty"
+    },
+    {
+      "type": 0,
+      "value": ". Ethereum is estimated to reach this TTD within a day of the 15th of September (follow "
+    },
+    {
+      "type": 1,
+      "value": "link"
+    },
+    {
+      "type": 0,
+      "value": " for latest estimate). Act now to update your node with the latest client releases, and use the steps below to make sure you're prepared."
     }
   ],
   "D0Rigq": [
@@ -3883,24 +3915,6 @@
       "value": "An implementation of the consensus protocol with a focus on usability, security, and reliability. Prysm is developed by Prysmatic Labs, a company with the sole focus on the development of their client."
     }
   ],
-  "WeQbEO": [
-    {
-      "type": 1,
-      "value": "attention"
-    },
-    {
-      "type": 0,
-      "value": " Mainnet total terminal difficulty (TTD) has been set to 5.875e22. Ethereum is estimated to reach this TTD within a day of the 15th of September (follow "
-    },
-    {
-      "type": 1,
-      "value": "link"
-    },
-    {
-      "type": 0,
-      "value": " for latest estimate). Act now to update your node with the latest client releases, and use the steps below to make sure you're prepared."
-    }
-  ],
   "Wj99ga": [
     {
       "type": 0,
@@ -5703,6 +5717,12 @@
     {
       "type": 0,
       "value": "Hard drive"
+    }
+  ],
+  "mTW7PE": [
+    {
+      "type": 0,
+      "value": "58750000000000000000000"
     }
   ],
   "mUZnem": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -1490,6 +1490,9 @@
   "WdDGn6": {
     "message": "An implementation of the consensus protocol with a focus on usability, security, and reliability. Prysm is developed by Prysmatic Labs, a company with the sole focus on the development of their client."
   },
+  "WeQbEO": {
+    "message": "{attention} Mainnet total terminal difficulty (TTD) has been set to 5.875e22. Ethereum is estimated to reach this TTD within a day of the 15th of September (follow {link} for latest estimate). Act now to update your node with the latest client releases, and use the steps below to make sure you're prepared."
+  },
   "Wj99ga": {
     "message": "Go Ethereum - The Merge"
   },
@@ -1896,9 +1899,6 @@
   },
   "g37XKP": {
     "message": "More on virtualenv"
-  },
-  "gFBZIa": {
-    "message": "{attention} Mainnet total terminal difficulty (TTD) has been set to 58750000000000000000000. Ethereum is estimated to reach this TTD on the 15h of September, plus-or-minus a few days (Follow {link} for latest estimate). Act now to update your nodes with the latest client releases, and use the steps below to make sure you're prepared."
   },
   "gIauNz": {
     "message": "You should see that you have one keystore per validator. This keystore contains your signing key, encrypted with your password. You can use your mnemonic to generate your withdrawal key when you wish to withdraw."

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -32,9 +32,6 @@
   "/E/Zm8": {
     "message": "Configure the Java Web"
   },
-  "/FpD8O": {
-    "message": "Do this after TTD client releases"
-  },
   "/QPc9s": {
     "message": "You can signal your intent to stop validating by signing a voluntary exit message with your validator."
   },
@@ -291,6 +288,9 @@
   "4l6vz1": {
     "message": "Copy"
   },
+  "4yPejZ": {
+    "message": "All execution and consensus clients have recently released updates including this TTD to be merge-ready. Be sure to update your clients."
+  },
   "54J/qs": {
     "message": "What happens if I use BLS withdrawal and I lose my withdrawal key?"
   },
@@ -416,9 +416,6 @@
   "8JtiQS": {
     "message": "Does the contract address listed on the website match?"
   },
-  "8L6ufI": {
-    "message": "Step-by-step guide for how to spin up a {network} node and validator"
-  },
   "8Rj/6A": {
     "message": "Choose the OS of the computer you're currently using. This will be the computer you use to generate your keys. It doesn't need to be the OS you want to use for your node."
   },
@@ -480,9 +477,6 @@
   "9uOFF3": {
     "message": "Overview"
   },
-  "9vLu6E": {
-    "message": "{note} This step should be performed on {testnetsOnly} until the Mainnet TTD (terminal total difficulty) has been announced and clients have released an update. Info is presented for preparation in the meantime."
-  },
   "9vwGlT": {
     "message": "I've synced my beacon node on {consensusLayerName}."
   },
@@ -507,9 +501,6 @@
   },
   "AJD+66": {
     "message": "The Ethereum staking deposit contract requires a minimum of {minTopupValue} {TICKER_NAME} to be sent at one time to be accepted."
-  },
-  "ALEY4e": {
-    "message": "{community} {network} guide"
   },
   "ARyG2Z": {
     "message": "When withdrawals?"
@@ -637,6 +628,9 @@
   "D0Rigq": {
     "message": "NO"
   },
+  "D1oCWM": {
+    "message": "{networkBold} is a younger public testnet that has already undergone its transition to proof-of-stake after undergoing a successful merge upgrade in March 2022. {network} is open for anyone to interact with, and will continue to be maintained after the Mainnet merge. Try sending some ETH, interacting with some contracts, or deploying your own."
+  },
   "D33f/7": {
     "description": "APR refers to Annual Percentage Rate",
     "message": "Current APR"
@@ -759,9 +753,6 @@
   "FqgDIV": {
     "message": "Terms of service"
   },
-  "FqztZR": {
-    "message": "Note:"
-  },
   "FzkbsB": {
     "message": "validators"
   },
@@ -847,6 +838,9 @@
   "HqRNN8": {
     "message": "Support"
   },
+  "Hy1z78": {
+    "message": "Thorough guide For those who want more control and less hand-holding"
+  },
   "I0BXSi": {
     "message": "Configure Geth"
   },
@@ -902,6 +896,9 @@
   },
   "J7T0SR": {
     "message": "Nimbus installation documentation"
+  },
+  "JA1956": {
+    "message": "Attention:"
   },
   "JAiV0o": {
     "message": "In other words, to keep you honest, your actions need to have financial consequences."
@@ -1150,6 +1147,9 @@
   "OdYQYh": {
     "message": "More on ConsenSys"
   },
+  "Odx4qP": {
+    "message": "Everything you need to get started with the network, including faucets"
+  },
   "OmAmmi": {
     "message": "More on the Merge"
   },
@@ -1214,9 +1214,6 @@
   },
   "Q8P0rZ": {
     "message": "Validators have a maximum effective balance of {PRICE_PER_VALIDATOR} {TICKER_NAME}. You only need to top up {maxTopupValue} {TICKER_NAME} to max out your effective balance."
-  },
-  "Q8fnvz": {
-    "message": "testnets only (e.g. {kiln})"
   },
   "QKFeMq": {
     "message": "Internet"
@@ -1284,9 +1281,6 @@
   },
   "Rg5ySE": {
     "message": "How many validators would you like to run?"
-  },
-  "Riq4Yh": {
-    "message": "{network} is open for anyone to interact with. Try sending some transactions, running a validator, or see if you can get slashed!"
   },
   "RkSC5Q": {
     "message": "Reminder, the Merge upgrade will {not} implement withdrawing or transferring of staked ETH. This feature will be included in the Shanghai upgrade planned to follow the Merge."
@@ -1535,6 +1529,9 @@
   "XRxD8r": {
     "description": "Link to documentation about execution client Besu, specifically for Goerli testnet",
     "message": "Besu on Goerli documentation"
+  },
+  "XSlPoq": {
+    "message": "Thorough guide to setting up a testnet node"
   },
   "XVehvN": {
     "description": "{filesPattern} refers to a computer command which will find {keyFile} and\n                {passwordFile} - both files within a computer.",
@@ -1900,11 +1897,17 @@
   "g37XKP": {
     "message": "More on virtualenv"
   },
+  "gFBZIa": {
+    "message": "{attention} Mainnet total terminal difficulty (TTD) has been set to 58750000000000000000000. Ethereum is estimated to reach this TTD on the 15h of September, plus-or-minus a few days (Follow {link} for latest estimate). Act now to update your nodes with the latest client releases, and use the steps below to make sure you're prepared."
+  },
   "gIauNz": {
     "message": "You should see that you have one keystore per validator. This keystore contains your signing key, encrypted with your password. You can use your mnemonic to generate your withdrawal key when you wish to withdraw."
   },
   "gN9D/h": {
     "message": "Use {goerli} to sync the Goerli testnet."
+  },
+  "gOJmxl": {
+    "message": "I am running my own consensus client, and have updated to a merge-ready release"
   },
   "gQkd2y": {
     "message": "Generate deposit keys using the Ethereum Foundation deposit tool"
@@ -1952,6 +1955,9 @@
   "hICY9k": {
     "message": "I have provided an Ethereum address to my validator where I would like my fee rewards to be deposited."
   },
+  "hKPjQW": {
+    "message": "While waiting for the Mainnet transition to proof-of-stake, stakers are encouraged to participate in {testingTheMerge}. Goerli was recently the final public Ethereum testnet to successfully undergo The Merge, and will persist as a longstanding PoS testnet. Setting up a Goerli node can be a great way to learn more about operating a post-merge Ethereum node, and gain confidence in your setup."
+  },
   "hPCn9f": {
     "message": "--JsonRpc.Enabled documentation"
   },
@@ -1964,6 +1970,9 @@
   },
   "hfXlpq": {
     "message": "Hungarian"
+  },
+  "hgU42i": {
+    "message": "{network} is open for anyone to interact with, but is being deprecated moving forward and will not undergo any further network updates."
   },
   "hjrLbR": {
     "message": "For this, we need active participants - known as validators - to propose, verify, and vouch for the validity of blocks. In exchange, honest validators receive financial rewards."
@@ -2253,6 +2262,9 @@
   "o9QvTP": {
     "message": "Before you start"
   },
+  "oAuBZQ": {
+    "message": "I am running my own execution client, and have updated to a merge-ready release."
+  },
   "oF4os+": {
     "message": "Currently Prysm is used by >33% of the network."
   },
@@ -2273,9 +2285,6 @@
   },
   "ohspQX": {
     "message": "Responsibilities"
-  },
-  "olByWa": {
-    "message": "While waiting for the Mainnet transition to proof-of-stake, stakers are encouraged to participate in {testingTheMerge}. This is a great way to learn more about the Merge, practice going through it before Mainnet, and gain confidence in your setup."
   },
   "omJNJw": {
     "message": "Warning!"
@@ -2333,14 +2342,8 @@
   "ptWiT7": {
     "message": "I've simulated how to manually stop and restart my Beacon Node (BN) and Validator Client (VC) gracefully."
   },
-  "pxfiWL": {
-    "message": "{networkBold} is a younger public testnet that has already undergone its transition to proof-of-stake after undergoing a successful merge upgrade in March 2022. Kiln is open for anyone to interact with. Try sending some ETH, interacting with some contracts, or deploying your own."
-  },
   "pyWt01": {
     "message": "Deposit summary"
-  },
-  "q2PJEK": {
-    "message": "I am running my own consensus client."
   },
   "q2XW/k": {
     "message": "If your withdrawal key is stolen, the thief can transfer your validator’s balance, but only once the validator has exited."
@@ -2392,6 +2395,9 @@
   },
   "rD3ot9": {
     "message": "Phishing guide"
+  },
+  "rEokPY": {
+    "message": "bordel.wtf"
   },
   "rMjMmc": {
     "description": "{http} shows '--JsonRpc.Enabled true' terminal command",
@@ -2620,9 +2626,6 @@
   "wtTeex": {
     "message": "Are there spelling mistakes?"
   },
-  "wuhO1L": {
-    "message": "I am running my own execution client."
-  },
   "x+fF+M": {
     "message": "Testnet simulations"
   },
@@ -2743,5 +2746,8 @@
   },
   "zqOrZZ": {
     "message": "Look over the Merge Readiness Checklist"
+  },
+  "zrK3hS": {
+    "message": "{networkBold} is a long-standing public testnet that began as a proof-of-authority chain, and has now undergone its transition to proof-of-stake via a successful Merge in August 2022. {network} is open for anyone to interact with, and will continue to be maintained after the Mainnet merge. Try interacting with some contracts or operating a validating node."
   }
 }

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -105,6 +105,10 @@
   "0i4cCJ": {
     "message": "Confirm deposits ({depositKeys})"
   },
+  "0i90U5": {
+    "description": "Total terminal difficulty written in scientific notation",
+    "message": "5.875e22"
+  },
   "0lHkrT": {
     "message": "Second, install the dependency packages:"
   },
@@ -624,6 +628,9 @@
   },
   "CeeJfw": {
     "message": "I've set up a firewall."
+  },
+  "CmbwEn": {
+    "message": "{attention} Mainnet total terminal difficulty (TTD) has been set to {difficulty}. Ethereum is estimated to reach this TTD within a day of the 15th of September (follow {link} for latest estimate). Act now to update your node with the latest client releases, and use the steps below to make sure you're prepared."
   },
   "D0Rigq": {
     "message": "NO"
@@ -1490,9 +1497,6 @@
   "WdDGn6": {
     "message": "An implementation of the consensus protocol with a focus on usability, security, and reliability. Prysm is developed by Prysmatic Labs, a company with the sole focus on the development of their client."
   },
-  "WeQbEO": {
-    "message": "{attention} Mainnet total terminal difficulty (TTD) has been set to 5.875e22. Ethereum is estimated to reach this TTD within a day of the 15th of September (follow {link} for latest estimate). Act now to update your node with the latest client releases, and use the steps below to make sure you're prepared."
-  },
   "Wj99ga": {
     "message": "Go Ethereum - The Merge"
   },
@@ -2193,6 +2197,10 @@
   },
   "mArJcj": {
     "message": "Hard drive"
+  },
+  "mTW7PE": {
+    "description": "Total terminal difficulty written out fully, without commas, so it can be copied easily. ",
+    "message": "58750000000000000000000"
   },
   "mUZnem": {
     "message": "We strongly recommend you go through the entire process on a testnet first to get comfortable before risking real ETH."

--- a/src/pages/MergeReadiness/index.tsx
+++ b/src/pages/MergeReadiness/index.tsx
@@ -11,6 +11,9 @@ import { Text } from '../../components/Text';
 import { Code } from '../../components/Code';
 import { Alert } from '../../components/Alert';
 
+import { screenSizes } from '../../styles/styledComponentsTheme';
+import useMobileCheck from '../../hooks/useMobileCheck';
+
 const ChecklistPageStyles = styled.div`
   section {
     background-color: white;
@@ -118,6 +121,7 @@ const SectionHeader = styled.div`
 
 export const MergeReadiness = () => {
   const { formatMessage } = useIntl();
+  const isMobile = useMobileCheck(screenSizes.small);
   const sections = [
     {
       heading: <FormattedMessage defaultMessage="Task 1" />,
@@ -149,12 +153,23 @@ export const MergeReadiness = () => {
       <Alert variant="error" className="mt40">
         <Text>
           <FormattedMessage
-            defaultMessage="{attention} Mainnet total terminal difficulty (TTD) has been set to 5.875e22. Ethereum is estimated to reach this TTD within a day of the 15th of September (follow {link} for latest estimate). Act now to update your node with the latest client releases, and use the steps below to make sure you're prepared."
+            defaultMessage="{attention} Mainnet total terminal difficulty (TTD) has been set to {difficulty}. Ethereum is estimated to reach this TTD within a day of the 15th of September (follow {link} for latest estimate). Act now to update your node with the latest client releases, and use the steps below to make sure you're prepared."
             values={{
               attention: (
                 <strong>
                   <FormattedMessage defaultMessage="Attention:" />
                 </strong>
+              ),
+              difficulty: isMobile ? (
+                <FormattedMessage
+                  defaultMessage="5.875e22"
+                  description="Total terminal difficulty written in scientific notation"
+                />
+              ) : (
+                <FormattedMessage
+                  defaultMessage="58750000000000000000000"
+                  description="Total terminal difficulty written out fully, without commas, so it can be copied easily. "
+                />
               ),
               link: (
                 <Link to="https://bordel.wtf" inline primary>

--- a/src/pages/MergeReadiness/index.tsx
+++ b/src/pages/MergeReadiness/index.tsx
@@ -149,7 +149,7 @@ export const MergeReadiness = () => {
       <Alert variant="error" className="mt40">
         <Text>
           <FormattedMessage
-            defaultMessage="{attention} Mainnet total terminal difficulty (TTD) has been set to 58750000000000000000000. Ethereum is estimated to reach this TTD on the 15h of September, plus-or-minus a few days (Follow {link} for latest estimate). Act now to update your nodes with the latest client releases, and use the steps below to make sure you're prepared."
+            defaultMessage="{attention} Mainnet total terminal difficulty (TTD) has been set to 5.875e22. Ethereum is estimated to reach this TTD within a day of the 15th of September (follow {link} for latest estimate). Act now to update your node with the latest client releases, and use the steps below to make sure you're prepared."
             values={{
               attention: (
                 <strong>

--- a/src/pages/MergeReadiness/index.tsx
+++ b/src/pages/MergeReadiness/index.tsx
@@ -22,10 +22,6 @@ const ChecklistPageStyles = styled.div`
       margin-bottom: 5px;
     }
   }
-  section.pending {
-    filter: grayscale(100%);
-    opacity: 75%;
-  }
   label {
     padding: 1rem;
   }
@@ -80,11 +76,6 @@ const Card = styled.div`
     margin: 0px;
     margin-top: 16px;
   }
-  &.pending {
-    filter: grayscale(75%);
-    opacity: 60%;
-  }
-
   transform: scale(1);
   transition: transform 0.1s;
   &:hover {
@@ -127,7 +118,6 @@ const SectionHeader = styled.div`
 
 export const MergeReadiness = () => {
   const { formatMessage } = useIntl();
-
   const sections = [
     {
       heading: <FormattedMessage defaultMessage="Task 1" />,
@@ -137,21 +127,15 @@ export const MergeReadiness = () => {
     },
     {
       heading: <FormattedMessage defaultMessage="Task 2" />,
-      timing: (
-        <FormattedMessage defaultMessage="Do this after TTD client releases" />
-      ),
+      timing: <FormattedMessage defaultMessage="Do this now" />,
       title: <FormattedMessage defaultMessage="Authenticate Engine API" />,
       id: 'authenticate',
-      pending: true,
     },
     {
       heading: <FormattedMessage defaultMessage="Task 3" />,
-      timing: (
-        <FormattedMessage defaultMessage="Do this after TTD client releases" />
-      ),
+      timing: <FormattedMessage defaultMessage="Do this now" />,
       title: <FormattedMessage defaultMessage="Set fee recipient" />,
       id: 'fee-recipient',
-      pending: true,
     },
     {
       heading: <FormattedMessage defaultMessage="Bonus" />,
@@ -160,24 +144,21 @@ export const MergeReadiness = () => {
     },
   ];
 
-  const TimingWarning = () => (
+  const ActNow = () => (
     <SectionHeader className="m0 pt0">
-      <Alert variant="error" className="m0">
+      <Alert variant="error" className="mt40">
         <Text>
           <FormattedMessage
-            defaultMessage="{note} This step should be performed on {testnetsOnly} until the Mainnet TTD (terminal total difficulty) has been announced and clients have released an update. Info is presented for preparation in the meantime."
+            defaultMessage="{attention} Mainnet total terminal difficulty (TTD) has been set to 58750000000000000000000. Ethereum is estimated to reach this TTD on the 15h of September, plus-or-minus a few days (Follow {link} for latest estimate). Act now to update your nodes with the latest client releases, and use the steps below to make sure you're prepared."
             values={{
-              note: (
+              attention: (
                 <strong>
-                  <FormattedMessage defaultMessage="Note:" />
+                  <FormattedMessage defaultMessage="Attention:" />
                 </strong>
               ),
-              testnetsOnly: (
-                <Link to="#testing-the-merge" inline primary>
-                  <FormattedMessage
-                    defaultMessage="testnets only (e.g. {kiln})"
-                    values={{ kiln: 'Kiln' }}
-                  />
+              link: (
+                <Link to="https://bordel.wtf" inline primary>
+                  <FormattedMessage defaultMessage="bordel.wtf" />
                 </Link>
               ),
             }}
@@ -202,9 +183,9 @@ export const MergeReadiness = () => {
       </Subtitle>
 
       <CardContainer>
-        {sections.map(({ heading, title, timing, pending, id }) => (
+        {sections.map(({ heading, title, timing, id }) => (
           <StyledLink to={`#${id}`} inline isTextLink={false} key={id}>
-            <Card className={pending ? 'pending' : ''}>
+            <Card>
               <div>
                 <Heading level={4} className="mb10">
                   {heading}
@@ -213,7 +194,7 @@ export const MergeReadiness = () => {
                   {title}
                 </BoldGreen>
                 {timing && (
-                  <p className={`timing ${pending ? 'pending' : null}`}>
+                  <p className="timing">
                     <FormattedMessage defaultMessage="Timing:" /> {timing}
                   </p>
                 )}
@@ -223,6 +204,7 @@ export const MergeReadiness = () => {
           </StyledLink>
         ))}
       </CardContainer>
+      <ActNow />
       <ChecklistPageStyles>
         <SectionHeader id={sections[0].id}>
           <Heading level={3}>
@@ -234,7 +216,7 @@ export const MergeReadiness = () => {
             <FormattedMessage defaultMessage="Post-merge, an Ethereum node will be comprised of both an execution client, and a consensus client." />
           </Text>
         </SectionHeader>
-        <section className={sections[0].pending ? 'pending' : ''}>
+        <section>
           <Text className="mt20">
             <FormattedMessage defaultMessage="Since the genesis of the Beacon Chain, many validators running their own consensus client have opted to use third-party services for their execution layer connection. This has been acceptable since the only thing being listened to has been the staking deposit contract." />
           </Text>
@@ -248,21 +230,27 @@ export const MergeReadiness = () => {
             <Text className="mt20">
               <FormattedMessage defaultMessage="If you have not yet done so, be sure your node is running both an EL client, as well as a CL client, to prevent downtime at time of the Merge." />
             </Text>
+            <Text className="mt20">
+              <FormattedMessage defaultMessage="Stakers running their own execution layer is necessary for the decentralization of the network." />
+            </Text>
           </Alert>
           <Text className="mb10">
-            <FormattedMessage defaultMessage="Stakers running their own execution layer is necessary for the decentralization of the network." />
+            <FormattedMessage defaultMessage="All execution and consensus clients have recently released updates including this TTD to be merge-ready. Be sure to update your clients." />
           </Text>
           <CheckBox
             label={
               <Text className="checkbox-label">
-                <FormattedMessage defaultMessage="I am running my own execution client." />
+                <FormattedMessage defaultMessage="I am running my own execution client, and have updated to a merge-ready release." />
               </Text>
             }
           />
+          {/* <Text className="mb10">
+            <FormattedMessage defaultMessage="Bellatrix hard fork is to prepare the consensus layer for the merge" />
+          </Text> */}
           <CheckBox
             label={
               <Text className="checkbox-label">
-                <FormattedMessage defaultMessage="I am running my own consensus client." />
+                <FormattedMessage defaultMessage="I am running my own consensus client, and have updated to a merge-ready release" />
               </Text>
             }
           />
@@ -277,8 +265,7 @@ export const MergeReadiness = () => {
             <FormattedMessage defaultMessage="The execution and consensus layers work together tightly, and require authentication to stay safe. " />
           </Text>
         </SectionHeader>
-        <TimingWarning />
-        <section className={sections[1].pending ? 'pending' : ''}>
+        <section>
           <Text className="mt20">
             <FormattedMessage
               defaultMessage="Communication between the execution layer and consensus layer will occur using the {engineApi}. This is a new set of JSON RPC methods that can be used to communicate between the two client layers."
@@ -412,7 +399,6 @@ export const MergeReadiness = () => {
                 />
               </Text>
             }
-            disabled={sections[1].pending}
           />
         </section>
         <SectionHeader id={sections[2].id}>
@@ -425,8 +411,7 @@ export const MergeReadiness = () => {
             <FormattedMessage defaultMessage="Fees rewards are coming to validators, don't miss out!" />
           </Text>
         </SectionHeader>
-        <TimingWarning />
-        <section className={sections[2].pending ? 'pending' : ''}>
+        <section>
           <Text className="mt20">
             <FormattedMessage defaultMessage="Now that transactions must be processed by validators, the validators that propose blocks including these transactions are eligible to receive the transaction fee tips. These are also known as priority fees, and are the unburnt portion of gas fees." />
           </Text>
@@ -496,7 +481,6 @@ export const MergeReadiness = () => {
                 <FormattedMessage defaultMessage="I understand that I will earn the unburnt transaction fees (tips/priority fees) when I propose a block, and this is accounted for on the execution layer, not my validator balance." />
               </Text>
             }
-            disabled={sections[2].pending}
           />
           <CheckBox
             label={
@@ -504,7 +488,6 @@ export const MergeReadiness = () => {
                 <FormattedMessage defaultMessage="I have provided an Ethereum address to my validator where I would like my fee rewards to be deposited." />
               </Text>
             }
-            disabled={sections[2].pending}
           />
         </section>
         <SectionHeader id={sections[3].id}>
@@ -533,7 +516,7 @@ export const MergeReadiness = () => {
           </Heading>
           <Text className="mt20">
             <FormattedMessage
-              defaultMessage="While waiting for the Mainnet transition to proof-of-stake, stakers are encouraged to participate in {testingTheMerge}. This is a great way to learn more about the Merge, practice going through it before Mainnet, and gain confidence in your setup."
+              defaultMessage="While waiting for the Mainnet transition to proof-of-stake, stakers are encouraged to participate in {testingTheMerge}. Goerli was recently the final public Ethereum testnet to successfully undergo The Merge, and will persist as a longstanding PoS testnet. Setting up a Goerli node can be a great way to learn more about operating a post-merge Ethereum node, and gain confidence in your setup."
               values={{
                 testingTheMerge: (
                   <code>
@@ -545,6 +528,146 @@ export const MergeReadiness = () => {
           </Text>
           <Text className="mt20">
             <FormattedMessage
+              defaultMessage="{networkBold} is a long-standing public testnet that began as a proof-of-authority chain, and has now undergone its transition to proof-of-stake via a successful Merge in August 2022. {network} is open for anyone to interact with, and will continue to be maintained after the Mainnet merge. Try interacting with some contracts or operating a validating node."
+              values={{
+                networkBold: <strong>Goerli</strong>,
+                network: 'Goerli',
+              }}
+            />
+          </Text>
+          <ul className="sub-checklist-item">
+            <li className="py5">
+              <Text>
+                <Link primary inline to="https://goerli.net/">
+                  <FormattedMessage
+                    defaultMessage="{network} homepage"
+                    values={{ network: 'Goerli' }}
+                  />
+                </Link>
+                {' - '}
+                <FormattedMessage defaultMessage="Everything you need to get started with the network, including faucets" />
+              </Text>
+            </li>
+            <li className="py5">
+              <Text>
+                <Link
+                  primary
+                  inline
+                  to="https://notes.ethereum.org/@launchpad/goerli"
+                >
+                  <FormattedMessage
+                    defaultMessage="How to run a node on {network}"
+                    values={{ network: 'Goerli' }}
+                  />
+                </Link>
+                {' - '}
+                <FormattedMessage defaultMessage="Thorough guide to setting up a testnet node" />
+              </Text>
+            </li>
+            <li className="py5">
+              <Text>
+                <Link primary inline to="https://goerli.launchpad.ethereum.org">
+                  <FormattedMessage
+                    defaultMessage="{network} Staking Launchpad"
+                    values={{ network: 'Goerli' }}
+                  />
+                </Link>
+                {' - '}
+                <FormattedMessage
+                  defaultMessage="{network} version of this page"
+                  values={{ network: 'Goerli' }}
+                />
+              </Text>
+            </li>
+            <li className="py5">
+              <Text>
+                <Link
+                  primary
+                  inline
+                  to="https://blog.ethereum.org/2022/07/27/goerli-prater-merge-announcement/"
+                >
+                  <FormattedMessage
+                    defaultMessage="{site} {network} announcement"
+                    values={{
+                      site: <FormattedMessage defaultMessage="EF Blog" />,
+                      network: 'Goerli',
+                    }}
+                  />
+                </Link>
+              </Text>
+            </li>
+          </ul>
+          {/* !!!!!!! */}
+          <Text className="mt20">
+            <FormattedMessage
+              defaultMessage="{networkBold} is a younger public testnet that has already undergone its transition to proof-of-stake after undergoing a successful merge upgrade in March 2022. {network} is open for anyone to interact with, and will continue to be maintained after the Mainnet merge. Try sending some ETH, interacting with some contracts, or deploying your own."
+              values={{ networkBold: <strong>Kiln</strong>, network: 'Kiln' }}
+            />
+          </Text>
+          <ul className="sub-checklist-item">
+            <li className="py5">
+              <Text>
+                <Link primary inline to="https://kiln.themerge.dev/">
+                  <FormattedMessage
+                    defaultMessage="{network} homepage"
+                    values={{ network: 'Kiln' }}
+                  />
+                </Link>
+                {' - '}
+                <FormattedMessage defaultMessage="Everything you need to get started with the network, including a faucet" />
+              </Text>
+            </li>
+            <li className="py5">
+              <Text>
+                <Link
+                  primary
+                  inline
+                  to="https://notes.ethereum.org/@launchpad/kiln"
+                >
+                  <FormattedMessage
+                    defaultMessage="How to run a node on {network}"
+                    values={{ network: 'Kiln' }}
+                  />
+                </Link>
+                {' - '}
+                <FormattedMessage defaultMessage="Thorough guide For those who want more control and less hand-holding" />
+              </Text>
+            </li>
+            <li className="py5">
+              <Text>
+                <Link primary inline to="https://kiln.launchpad.ethereum.org">
+                  <FormattedMessage
+                    defaultMessage="{network} Staking Launchpad"
+                    values={{ network: 'Kiln' }}
+                  />
+                </Link>
+                {' - '}
+                <FormattedMessage
+                  defaultMessage="{network} version of this page"
+                  values={{ network: 'Kiln' }}
+                />
+              </Text>
+            </li>
+            <li className="py5">
+              <Text>
+                <Link
+                  primary
+                  inline
+                  to="https://blog.ethereum.org/2022/03/14/kiln-merge-testnet/"
+                >
+                  <FormattedMessage
+                    defaultMessage="{site} {network} announcement"
+                    values={{
+                      site: <FormattedMessage defaultMessage="EF Blog" />,
+                      network: 'Kiln',
+                    }}
+                  />
+                </Link>
+              </Text>
+            </li>
+          </ul>
+          <Text className="mt20">
+            <FormattedMessage
               defaultMessage="{networkBold} was the first longstanding public testnet to undergo The Merge, which occurred on June 8, 2022. Historically a proof-of-work testnet, {network} has now transitioned to proof-of-stake by merging its historical execution layer with a new beacon chain."
               values={{
                 networkBold: <strong>Ropsten</strong>,
@@ -554,7 +677,7 @@ export const MergeReadiness = () => {
           </Text>
           <Text className="mt20">
             <FormattedMessage
-              defaultMessage="{network} is open for anyone to interact with. Try sending some transactions, running a validator, or see if you can get slashed!"
+              defaultMessage="{network} is open for anyone to interact with, but is being deprecated moving forward and will not undergo any further network updates."
               values={{ network: 'Ropsten' }}
             />
           </Text>
@@ -637,96 +760,6 @@ export const MergeReadiness = () => {
                     values={{
                       site: <FormattedMessage defaultMessage="EF Blog" />,
                       network: 'Ropsten',
-                    }}
-                  />
-                </Link>
-              </Text>
-            </li>
-          </ul>
-          <Text className="mt20">
-            <FormattedMessage
-              defaultMessage="{networkBold} is a younger public testnet that has already undergone its transition to proof-of-stake after undergoing a successful merge upgrade in March 2022. Kiln is open for anyone to interact with. Try sending some ETH, interacting with some contracts, or deploying your own."
-              values={{ networkBold: <strong>Kiln</strong> }}
-            />
-          </Text>
-          <ul className="sub-checklist-item">
-            <li className="py5">
-              <Text>
-                <Link primary inline to="https://kiln.themerge.dev/">
-                  <FormattedMessage
-                    defaultMessage="{network} homepage"
-                    values={{ network: 'Kiln' }}
-                  />
-                </Link>
-                {' - '}
-                <FormattedMessage defaultMessage="Everything you need to get started with the network, including a faucet" />
-              </Text>
-            </li>
-            <li className="py5">
-              <Text className="inline">
-                <Link
-                  primary
-                  inline
-                  to="https://github.com/remyroy/ethstaker/blob/main/merge-devnet.md"
-                >
-                  <FormattedMessage
-                    defaultMessage="{community} {network} guide"
-                    values={{
-                      community: 'EthStaker',
-                      network: 'Kiln',
-                    }}
-                  />
-                </Link>
-                {' - '}
-                <FormattedMessage
-                  defaultMessage="Step-by-step guide for how to spin up a {network} node and validator"
-                  values={{ network: 'Kiln' }}
-                />
-              </Text>
-            </li>
-            <li className="py5">
-              <Text>
-                <Link
-                  primary
-                  inline
-                  to="https://notes.ethereum.org/@launchpad/kiln"
-                >
-                  <FormattedMessage
-                    defaultMessage="How to run a node on {network}"
-                    values={{ network: 'Kiln' }}
-                  />
-                </Link>
-                {' - '}
-                <FormattedMessage defaultMessage="For those who want more control and less hand-holding" />
-              </Text>
-            </li>
-            <li className="py5">
-              <Text>
-                <Link primary inline to="https://kiln.launchpad.ethereum.org">
-                  <FormattedMessage
-                    defaultMessage="{network} Staking Launchpad"
-                    values={{ network: 'Kiln' }}
-                  />
-                </Link>
-                {' - '}
-                <FormattedMessage
-                  defaultMessage="{network} version of this page"
-                  values={{ network: 'Kiln' }}
-                />
-              </Text>
-            </li>
-            <li className="py5">
-              <Text>
-                <Link
-                  primary
-                  inline
-                  to="https://blog.ethereum.org/2022/03/14/kiln-merge-testnet/"
-                >
-                  <FormattedMessage
-                    defaultMessage="{site} {network} announcement"
-                    values={{
-                      site: <FormattedMessage defaultMessage="EF Blog" />,
-                      network: 'Kiln',
                     }}
                   />
                 </Link>


### PR DESCRIPTION
Draft of updates to the Merge Readiness Checklist page. Flips the TTD switch to notify node operators that it is now time to ensure their nodes are fully ready for The Merge.

- Removes "pending" fields and disabled appearance of some cards
- Removes warnings that this is only for the testnet at this time
- Adds note to make sure clients are up-to-date with a merge-ready release
- Adds Goeli links to #TestingTheMerge section, noting this was the final public testnet to undergo the merge.
- Updated wording on this section to take out ability to test _before or going through the merge_ at this point.
- Removed broken tutorial link