### PR TITLE
Add link to mainnet TTD blog announcement

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -6055,6 +6055,12 @@
       "value": "Copied"
     }
   ],
+  "p8CuT9": [
+    {
+      "type": 0,
+      "value": "View EF blog mainnet merge announcement"
+    }
+  ],
   "pA+UVF": [
     {
       "type": 0,

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -2328,6 +2328,9 @@
   "p556q3": {
     "message": "Copied"
   },
+  "p8CuT9": {
+    "message": "View EF blog mainnet merge announcement"
+  },
   "pA+UVF": {
     "message": "If you'd like to see the launchpad in another language, or if you can help translate, {getInTouch}!"
   },

--- a/src/pages/MergeReadiness/index.tsx
+++ b/src/pages/MergeReadiness/index.tsx
@@ -179,6 +179,13 @@ export const MergeReadiness = () => {
             }}
           />
         </Text>
+        <Link
+          primary
+          to="https://blog.ethereum.org/2022/08/24/mainnet-merge-announcement/"
+          className="mt20"
+        >
+          <FormattedMessage defaultMessage="View EF blog mainnet merge announcement" />
+        </Link>
       </Alert>
     </SectionHeader>
   );


### PR DESCRIPTION
Adds a link to the blog post announcing Mainnet TTD on the Merge Readiness page in the initial alert box.