### PR TITLE
Update Lighthouse link

### DIFF
--- a/src/pages/Clients/Consensus/Lighthouse.tsx
+++ b/src/pages/Clients/Consensus/Lighthouse.tsx
@@ -44,7 +44,7 @@ export const LighthouseDetails = ({ shortened }: { shortened?: boolean }) => (
       />
     </Text>
     <Link
-      to="https://lighthouse.sigmaprime.io/update-00.html"
+      to="https://lighthouse-blog.sigmaprime.io/update-00.html"
       primary
       className="mt10"
     >


### PR DESCRIPTION
Heyo :wave: 

The Lighthouse blog has moved from `lighthouse.sigmaprime.io` to `lighthouse-blog.sigmaprime.io`.

I believe this PR makes the appropriate change, however I'm not so familiar with this code-base so some extra eyes would be appreciated :pray: