### PR TITLE
Adds Bellatrix date warning

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -2163,36 +2163,6 @@
       "value": " to connect your consensus node to the JSON RPC endpoint. This will enable the JSON RPC services on the default 8545 port."
     }
   ],
-  "HbCJso": [
-    {
-      "type": 0,
-      "value": "Mainnet total terminal difficulty (TTD) has been set to "
-    },
-    {
-      "type": 1,
-      "value": "difficulty"
-    },
-    {
-      "type": 0,
-      "value": ". Ethereum is estimated to reach this TTD within a few days of "
-    },
-    {
-      "type": 1,
-      "value": "ttdDateTime"
-    },
-    {
-      "type": 0,
-      "value": ", depending on hash rate (follow "
-    },
-    {
-      "type": 1,
-      "value": "link"
-    },
-    {
-      "type": 0,
-      "value": " for latest estimate)."
-    }
-  ],
   "Hczrvs": [
     {
       "type": 0,
@@ -2721,20 +2691,6 @@
       "value": "Connect new wallet"
     }
   ],
-  "MKMIUm": [
-    {
-      "type": 0,
-      "value": "Public testnet progress is underway. When everything is safe and ready, the core developer teams will make this known, so stay tuned to the "
-    },
-    {
-      "type": 1,
-      "value": "blogLink"
-    },
-    {
-      "type": 0,
-      "value": " or other client team communication channels for the latest information."
-    }
-  ],
   "MQTBvH": [
     {
       "type": 0,
@@ -3105,12 +3061,6 @@
     {
       "type": 0,
       "value": "Your network has changed"
-    }
-  ],
-  "Pd0hC/": [
-    {
-      "type": 0,
-      "value": "Ethereum Foundation Blog"
     }
   ],
   "PfoT0C": [
@@ -4711,6 +4661,52 @@
       "value": "Prysm is a Go consensus client implementation of the Ethereum protocol with a focus on usability, security, and reliability."
     }
   ],
+  "dM+izw": [
+    {
+      "type": 0,
+      "value": "Mainnet total terminal difficulty (TTD) has been set to "
+    },
+    {
+      "type": 1,
+      "value": "difficulty"
+    },
+    {
+      "type": 0,
+      "value": ". Ethereum is estimated to reach this TTD between "
+    },
+    {
+      "type": 1,
+      "value": "ttdDateLow"
+    },
+    {
+      "type": 0,
+      "value": " and "
+    },
+    {
+      "type": 1,
+      "value": "ttdDateHigh"
+    },
+    {
+      "type": 0,
+      "value": ", depending on hash rate (follow "
+    },
+    {
+      "type": 1,
+      "value": "linkBordel"
+    },
+    {
+      "type": 0,
+      "value": " and "
+    },
+    {
+      "type": 1,
+      "value": "link797"
+    },
+    {
+      "type": 0,
+      "value": " for latest estimates)."
+    }
+  ],
   "dM/KIM": [
     {
       "type": 0,
@@ -6111,6 +6107,12 @@
     {
       "type": 0,
       "value": "!"
+    }
+  ],
+  "pA2SgX": [
+    {
+      "type": 0,
+      "value": "797.io/themerge"
     }
   ],
   "pHQwsN": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -301,6 +301,36 @@
       "value": "Earn continuous rewards for providing a public good to the community."
     }
   ],
+  "0vW9Qm": [
+    {
+      "type": 0,
+      "value": "Mainnet total terminal difficulty (TTD) has been set to "
+    },
+    {
+      "type": 1,
+      "value": "difficulty"
+    },
+    {
+      "type": 0,
+      "value": ". Ethereum is estimated to reach this TTD within a day of "
+    },
+    {
+      "type": 1,
+      "value": "ttdDateTime"
+    },
+    {
+      "type": 0,
+      "value": " (follow "
+    },
+    {
+      "type": 1,
+      "value": "link"
+    },
+    {
+      "type": 0,
+      "value": " for latest estimate)."
+    }
+  ],
   "122+yR": [
     {
       "type": 0,
@@ -1663,32 +1693,6 @@
       "value": "I've set up a firewall."
     }
   ],
-  "CmbwEn": [
-    {
-      "type": 1,
-      "value": "attention"
-    },
-    {
-      "type": 0,
-      "value": " Mainnet total terminal difficulty (TTD) has been set to "
-    },
-    {
-      "type": 1,
-      "value": "difficulty"
-    },
-    {
-      "type": 0,
-      "value": ". Ethereum is estimated to reach this TTD within a day of the 15th of September (follow "
-    },
-    {
-      "type": 1,
-      "value": "link"
-    },
-    {
-      "type": 0,
-      "value": " for latest estimate). Act now to update your node with the latest client releases, and use the steps below to make sure you're prepared."
-    }
-  ],
   "D0Rigq": [
     {
       "type": 0,
@@ -1887,6 +1891,20 @@
     {
       "type": 0,
       "value": "Staking Launchpad"
+    }
+  ],
+  "Erv97D": [
+    {
+      "type": 0,
+      "value": "The Bellatrix upgrade to the Beacon Chain is scheduled for epoch 144896, set to occur at "
+    },
+    {
+      "type": 1,
+      "value": "bellatrixDateTime"
+    },
+    {
+      "type": 0,
+      "value": "."
     }
   ],
   "FEbVwB": [
@@ -3187,6 +3205,12 @@
       "value": " to max out your effective balance."
     }
   ],
+  "QAhumw": [
+    {
+      "type": 0,
+      "value": "Act now to update your node with the latest client releases."
+    }
+  ],
   "QKFeMq": [
     {
       "type": 0,
@@ -3831,6 +3855,20 @@
     {
       "type": 0,
       "value": "I am certain that the validator I am topping up is my validator."
+    }
+  ],
+  "VkpMgu": [
+    {
+      "type": 0,
+      "value": "Complete the steps below before "
+    },
+    {
+      "type": 1,
+      "value": "bellatrixDateOnly"
+    },
+    {
+      "type": 0,
+      "value": " to make sure you're prepared."
     }
   ],
   "Vp4z/b": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -301,36 +301,6 @@
       "value": "Earn continuous rewards for providing a public good to the community."
     }
   ],
-  "0vW9Qm": [
-    {
-      "type": 0,
-      "value": "Mainnet total terminal difficulty (TTD) has been set to "
-    },
-    {
-      "type": 1,
-      "value": "difficulty"
-    },
-    {
-      "type": 0,
-      "value": ". Ethereum is estimated to reach this TTD within a day of "
-    },
-    {
-      "type": 1,
-      "value": "ttdDateTime"
-    },
-    {
-      "type": 0,
-      "value": " (follow "
-    },
-    {
-      "type": 1,
-      "value": "link"
-    },
-    {
-      "type": 0,
-      "value": " for latest estimate)."
-    }
-  ],
   "122+yR": [
     {
       "type": 0,
@@ -2191,6 +2161,36 @@
     {
       "type": 0,
       "value": " to connect your consensus node to the JSON RPC endpoint. This will enable the JSON RPC services on the default 8545 port."
+    }
+  ],
+  "HbCJso": [
+    {
+      "type": 0,
+      "value": "Mainnet total terminal difficulty (TTD) has been set to "
+    },
+    {
+      "type": 1,
+      "value": "difficulty"
+    },
+    {
+      "type": 0,
+      "value": ". Ethereum is estimated to reach this TTD within a few days of "
+    },
+    {
+      "type": 1,
+      "value": "ttdDateTime"
+    },
+    {
+      "type": 0,
+      "value": ", depending on hash rate (follow "
+    },
+    {
+      "type": 1,
+      "value": "link"
+    },
+    {
+      "type": 0,
+      "value": " for latest estimate)."
     }
   ],
   "Hczrvs": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -118,9 +118,6 @@
   "0uqjBl": {
     "message": "Earn continuous rewards for providing a public good to the community."
   },
-  "0vW9Qm": {
-    "message": "Mainnet total terminal difficulty (TTD) has been set to {difficulty}. Ethereum is estimated to reach this TTD within a day of {ttdDateTime} (follow {link} for latest estimate)."
-  },
   "122+yR": {
     "message": "withdrawal key"
   },
@@ -835,6 +832,9 @@
   "HXvZ2L": {
     "description": "{http} shows '-rpc-http-enabled' terminal command",
     "message": "Use {http} to connect your consensus node to the JSON RPC endpoint. This will enable the JSON RPC services on the default 8545 port."
+  },
+  "HbCJso": {
+    "message": "Mainnet total terminal difficulty (TTD) has been set to {difficulty}. Ethereum is estimated to reach this TTD within a few days of {ttdDateTime}, depending on hash rate (follow {link} for latest estimate)."
   },
   "Hczrvs": {
     "message": "Slashing has two purposes: (1) to make it prohibitively expensive to attack the network, and (2) to stop validators from being lazy by checking that they actually perform their duties. If you're slashed because you've acted in a provably destructive manner, a portion of your stake will be destroyed."

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -118,6 +118,9 @@
   "0uqjBl": {
     "message": "Earn continuous rewards for providing a public good to the community."
   },
+  "0vW9Qm": {
+    "message": "Mainnet total terminal difficulty (TTD) has been set to {difficulty}. Ethereum is estimated to reach this TTD within a day of {ttdDateTime} (follow {link} for latest estimate)."
+  },
   "122+yR": {
     "message": "withdrawal key"
   },
@@ -629,9 +632,6 @@
   "CeeJfw": {
     "message": "I've set up a firewall."
   },
-  "CmbwEn": {
-    "message": "{attention} Mainnet total terminal difficulty (TTD) has been set to {difficulty}. Ethereum is estimated to reach this TTD within a day of the 15th of September (follow {link} for latest estimate). Act now to update your node with the latest client releases, and use the steps below to make sure you're prepared."
-  },
   "D0Rigq": {
     "message": "NO"
   },
@@ -713,6 +713,9 @@
   },
   "EcCME0": {
     "message": "Staking Launchpad"
+  },
+  "Erv97D": {
+    "message": "The Bellatrix upgrade to the Beacon Chain is scheduled for epoch 144896, set to occur at {bellatrixDateTime}."
   },
   "FEbVwB": {
     "message": "The key concept is the following:"
@@ -1222,6 +1225,9 @@
   "Q8P0rZ": {
     "message": "Validators have a maximum effective balance of {PRICE_PER_VALIDATOR} {TICKER_NAME}. You only need to top up {maxTopupValue} {TICKER_NAME} to max out your effective balance."
   },
+  "QAhumw": {
+    "message": "Act now to update your node with the latest client releases."
+  },
   "QKFeMq": {
     "message": "Internet"
   },
@@ -1463,6 +1469,9 @@
   },
   "VctWDX": {
     "message": "I am certain that the validator I am topping up is my validator."
+  },
+  "VkpMgu": {
+    "message": "Complete the steps below before {bellatrixDateOnly} to make sure you're prepared."
   },
   "Vp4z/b": {
     "message": "Stakers running their own execution layer is necessary for the decentralization of the network."

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -833,9 +833,6 @@
     "description": "{http} shows '-rpc-http-enabled' terminal command",
     "message": "Use {http} to connect your consensus node to the JSON RPC endpoint. This will enable the JSON RPC services on the default 8545 port."
   },
-  "HbCJso": {
-    "message": "Mainnet total terminal difficulty (TTD) has been set to {difficulty}. Ethereum is estimated to reach this TTD within a few days of {ttdDateTime}, depending on hash rate (follow {link} for latest estimate)."
-  },
   "Hczrvs": {
     "message": "Slashing has two purposes: (1) to make it prohibitively expensive to attack the network, and (2) to stop validators from being lazy by checking that they actually perform their duties. If you're slashed because you've acted in a provably destructive manner, a portion of your stake will be destroyed."
   },
@@ -1043,9 +1040,6 @@
   "MIsmjW": {
     "message": "Connect new wallet"
   },
-  "MKMIUm": {
-    "message": "Public testnet progress is underway. When everything is safe and ready, the core developer teams will make this known, so stay tuned to the {blogLink} or other client team communication channels for the latest information."
-  },
   "MQTBvH": {
     "message": "Protect yourself against double deposits"
   },
@@ -1190,9 +1184,6 @@
   },
   "P9mVZK": {
     "message": "Your network has changed"
-  },
-  "Pd0hC/": {
-    "message": "Ethereum Foundation Blog"
   },
   "PfoT0C": {
     "message": "This checklist will help you understand the role of a validator and prepare you for the role."
@@ -1804,6 +1795,9 @@
   "dJMce5": {
     "message": "Prysm is a Go consensus client implementation of the Ethereum protocol with a focus on usability, security, and reliability."
   },
+  "dM+izw": {
+    "message": "Mainnet total terminal difficulty (TTD) has been set to {difficulty}. Ethereum is estimated to reach this TTD between {ttdDateLow} and {ttdDateHigh}, depending on hash rate (follow {linkBordel} and {link797} for latest estimates)."
+  },
   "dM/KIM": {
     "message": "What exactly is a validator?"
   },
@@ -2342,6 +2336,9 @@
   },
   "pA+UVF": {
     "message": "If you'd like to see the launchpad in another language, or if you can help translate, {getInTouch}!"
+  },
+  "pA2SgX": {
+    "message": "797.io/themerge"
   },
   "pHQwsN": {
     "message": "Launch the app from your desktop environment by double clicking on it."

--- a/src/pages/MergeReadiness/index.tsx
+++ b/src/pages/MergeReadiness/index.tsx
@@ -120,7 +120,7 @@ const SectionHeader = styled.div`
 `;
 
 export const MergeReadiness = () => {
-  const { formatMessage } = useIntl();
+  const { locale, formatMessage } = useIntl();
   const isMobile = useMobileCheck(screenSizes.small);
   const sections = [
     {
@@ -148,47 +148,90 @@ export const MergeReadiness = () => {
     },
   ];
 
-  const ActNow = () => (
-    <SectionHeader className="m0 pt0">
-      <Alert variant="error" className="mt40">
-        <Text>
-          <FormattedMessage
-            defaultMessage="{attention} Mainnet total terminal difficulty (TTD) has been set to {difficulty}. Ethereum is estimated to reach this TTD within a day of the 15th of September (follow {link} for latest estimate). Act now to update your node with the latest client releases, and use the steps below to make sure you're prepared."
-            values={{
-              attention: (
-                <strong>
-                  <FormattedMessage defaultMessage="Attention:" />
-                </strong>
-              ),
-              difficulty: isMobile ? (
-                <FormattedMessage
-                  defaultMessage="5.875e22"
-                  description="Total terminal difficulty written in scientific notation"
-                />
-              ) : (
-                <FormattedMessage
-                  defaultMessage="58750000000000000000000"
-                  description="Total terminal difficulty written out fully, without commas, so it can be copied easily. "
-                />
-              ),
-              link: (
-                <Link to="https://bordel.wtf" inline primary>
-                  <FormattedMessage defaultMessage="bordel.wtf" />
-                </Link>
-              ),
-            }}
-          />
-        </Text>
-        <Link
-          primary
-          to="https://blog.ethereum.org/2022/08/24/mainnet-merge-announcement/"
-          className="mt20"
-        >
-          <FormattedMessage defaultMessage="View EF blog mainnet merge announcement" />
-        </Link>
-      </Alert>
-    </SectionHeader>
-  );
+  interface DateTimeFormatOptions {
+    formatMatcher?: 'basic' | 'best fit' | 'best fit' | undefined;
+    dateStyle?: 'full' | 'long' | 'medium' | 'short' | undefined;
+    timeStyle?: 'full' | 'long' | 'medium' | 'short' | undefined;
+  }
+  const ActNow = () => {
+    const bellatrixDate = new Date('2022-09-06T11:34:47.000Z');
+    const bellatrixDateTimeOptions: DateTimeFormatOptions = {
+      dateStyle: 'medium',
+      timeStyle: 'medium',
+    };
+    const bellatrixDateTime = new Intl.DateTimeFormat(
+      locale,
+      bellatrixDateTimeOptions
+    ).format(bellatrixDate);
+    const bellatrixDateOnlyOptions: DateTimeFormatOptions = {
+      dateStyle: 'medium',
+    };
+    const bellatrixDateOnly = new Intl.DateTimeFormat(
+      locale,
+      bellatrixDateOnlyOptions
+    ).format(bellatrixDate);
+    const ttdDate = new Date('2022-09-15T04:00:00.000Z');
+    const ttdOptions: DateTimeFormatOptions = { dateStyle: 'medium' };
+    const ttdDateOnly = new Intl.DateTimeFormat(locale, ttdOptions).format(
+      ttdDate
+    );
+    return (
+      <SectionHeader className="m0 pt0">
+        <Alert variant="error" className="mt40">
+          <Text className="mb20">
+            <strong>
+              <FormattedMessage defaultMessage="Attention:" />
+            </strong>
+          </Text>
+          <Text className="mb20">
+            <FormattedMessage
+              defaultMessage="The Bellatrix upgrade to the Beacon Chain is scheduled for epoch 144896, set to occur at {bellatrixDateTime}."
+              values={{ bellatrixDateTime }}
+            />
+          </Text>
+          <Text className="mb20">
+            <FormattedMessage
+              defaultMessage="Mainnet total terminal difficulty (TTD) has been set to {difficulty}. Ethereum is estimated to reach this TTD within a day of {ttdDateTime} (follow {link} for latest estimate)."
+              values={{
+                difficulty: isMobile ? (
+                  <FormattedMessage
+                    defaultMessage="5.875e22"
+                    description="Total terminal difficulty written in scientific notation"
+                  />
+                ) : (
+                  <FormattedMessage
+                    defaultMessage="58750000000000000000000"
+                    description="Total terminal difficulty written out fully, without commas, so it can be copied easily. "
+                  />
+                ),
+                ttdDateTime: ttdDateOnly,
+                link: (
+                  <Link to="https://bordel.wtf" inline primary>
+                    <FormattedMessage defaultMessage="bordel.wtf" />
+                  </Link>
+                ),
+              }}
+            />
+          </Text>
+          <Text className="mb20">
+            <FormattedMessage defaultMessage="Act now to update your node with the latest client releases." />{' '}
+            <strong>
+              <FormattedMessage
+                defaultMessage="Complete the steps below before {bellatrixDateOnly} to make sure you're prepared."
+                values={{ bellatrixDateOnly }}
+              />
+            </strong>
+          </Text>
+          <Link
+            primary
+            to="https://blog.ethereum.org/2022/08/24/mainnet-merge-announcement/"
+          >
+            <FormattedMessage defaultMessage="View EF blog mainnet merge announcement" />
+          </Link>
+        </Alert>
+      </SectionHeader>
+    );
+  };
 
   return (
     <PageTemplate
@@ -266,9 +309,6 @@ export const MergeReadiness = () => {
               </Text>
             }
           />
-          {/* <Text className="mb10">
-            <FormattedMessage defaultMessage="Bellatrix hard fork is to prepare the consensus layer for the merge" />
-          </Text> */}
           <CheckBox
             label={
               <Text className="checkbox-label">
@@ -619,7 +659,6 @@ export const MergeReadiness = () => {
               </Text>
             </li>
           </ul>
-          {/* !!!!!!! */}
           <Text className="mt20">
             <FormattedMessage
               defaultMessage="{networkBold} is a younger public testnet that has already undergone its transition to proof-of-stake after undergoing a successful merge upgrade in March 2022. {network} is open for anyone to interact with, and will continue to be maintained after the Mainnet merge. Try sending some ETH, interacting with some contracts, or deploying your own."

--- a/src/pages/MergeReadiness/index.tsx
+++ b/src/pages/MergeReadiness/index.tsx
@@ -191,7 +191,7 @@ export const MergeReadiness = () => {
           </Text>
           <Text className="mb20">
             <FormattedMessage
-              defaultMessage="Mainnet total terminal difficulty (TTD) has been set to {difficulty}. Ethereum is estimated to reach this TTD within a day of {ttdDateTime} (follow {link} for latest estimate)."
+              defaultMessage="Mainnet total terminal difficulty (TTD) has been set to {difficulty}. Ethereum is estimated to reach this TTD within a few days of {ttdDateTime}, depending on hash rate (follow {link} for latest estimate)."
               values={{
                 difficulty: isMobile ? (
                   <FormattedMessage

--- a/src/pages/MergeReadiness/index.tsx
+++ b/src/pages/MergeReadiness/index.tsx
@@ -148,33 +148,82 @@ export const MergeReadiness = () => {
     },
   ];
 
+  // Set up relevant dates with Intl
   interface DateTimeFormatOptions {
     formatMatcher?: 'basic' | 'best fit' | 'best fit' | undefined;
     dateStyle?: 'full' | 'long' | 'medium' | 'short' | undefined;
     timeStyle?: 'full' | 'long' | 'medium' | 'short' | undefined;
   }
+  const bellatrixDate = new Date('2022-09-06T11:34:47.000Z');
+  const bellatrixDateTimeOptions: DateTimeFormatOptions = {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+  };
+  const bellatrixDateTime = new Intl.DateTimeFormat(
+    locale,
+    bellatrixDateTimeOptions
+  ).format(bellatrixDate);
+  const bellatrixDateOnlyOptions: DateTimeFormatOptions = {
+    dateStyle: 'medium',
+  };
+  const bellatrixDateOnly = new Intl.DateTimeFormat(
+    locale,
+    bellatrixDateOnlyOptions
+  ).format(bellatrixDate);
+  const ttdDateLow = new Date('2022-09-10T12:00:00.000Z');
+  const ttdDateHigh = new Date('2022-09-20T12:00:00.000Z');
+  const ttdOptionsLow: DateTimeFormatOptions = { dateStyle: 'medium' };
+  const ttdOptionsHigh: DateTimeFormatOptions = { dateStyle: 'medium' };
+  const ttdDateOnlyLow = new Intl.DateTimeFormat(locale, ttdOptionsLow).format(
+    ttdDateLow
+  );
+  const ttdDateOnlyHigh = new Intl.DateTimeFormat(
+    locale,
+    ttdOptionsHigh
+  ).format(ttdDateHigh);
+
+  const WhenMerge = () => (
+    <>
+      <Text className="my20">
+        <FormattedMessage
+          defaultMessage="The Bellatrix upgrade to the Beacon Chain is scheduled for epoch 144896, set to occur at {bellatrixDateTime}."
+          values={{ bellatrixDateTime }}
+        />
+      </Text>
+      <Text className="mb20">
+        <FormattedMessage
+          defaultMessage="Mainnet total terminal difficulty (TTD) has been set to {difficulty}. Ethereum is estimated to reach this TTD between {ttdDateLow} and {ttdDateHigh}, depending on hash rate (follow {linkBordel} and {link797} for latest estimates)."
+          values={{
+            difficulty: isMobile ? (
+              <FormattedMessage
+                defaultMessage="5.875e22"
+                description="Total terminal difficulty written in scientific notation"
+              />
+            ) : (
+              <FormattedMessage
+                defaultMessage="58750000000000000000000"
+                description="Total terminal difficulty written out fully, without commas, so it can be copied easily. "
+              />
+            ),
+            ttdDateLow: ttdDateOnlyLow,
+            ttdDateHigh: ttdDateOnlyHigh,
+            linkBordel: (
+              <Link to="https://bordel.wtf" inline primary>
+                <FormattedMessage defaultMessage="bordel.wtf" />
+              </Link>
+            ),
+            link797: (
+              <Link to="https://797.io/themerge/" inline primary>
+                <FormattedMessage defaultMessage="797.io/themerge" />
+              </Link>
+            ),
+          }}
+        />
+      </Text>
+    </>
+  );
+
   const ActNow = () => {
-    const bellatrixDate = new Date('2022-09-06T11:34:47.000Z');
-    const bellatrixDateTimeOptions: DateTimeFormatOptions = {
-      dateStyle: 'medium',
-      timeStyle: 'medium',
-    };
-    const bellatrixDateTime = new Intl.DateTimeFormat(
-      locale,
-      bellatrixDateTimeOptions
-    ).format(bellatrixDate);
-    const bellatrixDateOnlyOptions: DateTimeFormatOptions = {
-      dateStyle: 'medium',
-    };
-    const bellatrixDateOnly = new Intl.DateTimeFormat(
-      locale,
-      bellatrixDateOnlyOptions
-    ).format(bellatrixDate);
-    const ttdDate = new Date('2022-09-15T04:00:00.000Z');
-    const ttdOptions: DateTimeFormatOptions = { dateStyle: 'medium' };
-    const ttdDateOnly = new Intl.DateTimeFormat(locale, ttdOptions).format(
-      ttdDate
-    );
     return (
       <SectionHeader className="m0 pt0">
         <Alert variant="error" className="mt40">
@@ -183,36 +232,7 @@ export const MergeReadiness = () => {
               <FormattedMessage defaultMessage="Attention:" />
             </strong>
           </Text>
-          <Text className="mb20">
-            <FormattedMessage
-              defaultMessage="The Bellatrix upgrade to the Beacon Chain is scheduled for epoch 144896, set to occur at {bellatrixDateTime}."
-              values={{ bellatrixDateTime }}
-            />
-          </Text>
-          <Text className="mb20">
-            <FormattedMessage
-              defaultMessage="Mainnet total terminal difficulty (TTD) has been set to {difficulty}. Ethereum is estimated to reach this TTD within a few days of {ttdDateTime}, depending on hash rate (follow {link} for latest estimate)."
-              values={{
-                difficulty: isMobile ? (
-                  <FormattedMessage
-                    defaultMessage="5.875e22"
-                    description="Total terminal difficulty written in scientific notation"
-                  />
-                ) : (
-                  <FormattedMessage
-                    defaultMessage="58750000000000000000000"
-                    description="Total terminal difficulty written out fully, without commas, so it can be copied easily. "
-                  />
-                ),
-                ttdDateTime: ttdDateOnly,
-                link: (
-                  <Link to="https://bordel.wtf" inline primary>
-                    <FormattedMessage defaultMessage="bordel.wtf" />
-                  </Link>
-                ),
-              }}
-            />
-          </Text>
+          <WhenMerge />
           <Text className="mb20">
             <FormattedMessage defaultMessage="Act now to update your node with the latest client releases." />{' '}
             <strong>
@@ -559,18 +579,13 @@ export const MergeReadiness = () => {
           <Heading level={3}>
             <FormattedMessage defaultMessage="When Merge?" />
           </Heading>
-          <Text className="mt20">
-            <FormattedMessage
-              defaultMessage="Public testnet progress is underway. When everything is safe and ready, the core developer teams will make this known, so stay tuned to the {blogLink} or other client team communication channels for the latest information."
-              values={{
-                blogLink: (
-                  <Link inline primary to="https://blog.ethereum.org">
-                    <FormattedMessage defaultMessage="Ethereum Foundation Blog" />
-                  </Link>
-                ),
-              }}
-            />
-          </Text>
+          <WhenMerge />
+          <Link
+            primary
+            to="https://blog.ethereum.org/2022/08/24/mainnet-merge-announcement/"
+          >
+            <FormattedMessage defaultMessage="View EF blog mainnet merge announcement" />
+          </Link>
         </section>
         <section>
           <Heading level={3} id="testing-the-merge">


### PR DESCRIPTION
<img width="1108" alt="image" src="https://user-images.githubusercontent.com/54227730/186771890-70970f77-4f93-4e29-9ceb-3ea3d1dbd568.png">

The last update to the Merge Readiness page included the TTD and estimated date for Mainnet merge, but did not include a note about the timing of the required Bellatrix upgrade set to occur for the Beacon Chain at epoch 144896. 

- Adds note about upgrading before Bellatrix
- Adds intl support for date/time formatting so these display appropriately in all locales.