### PR TITLE
Fix netlify toml syntax

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,10 @@
-[context.production]
-  environment = { NODE_VERSION = "14.19.2" }
-[context.deploy-preview]
-  environment = { NODE_VERSION = "14.19.2" }
-[context.branch-deploy]
-  environment = { NODE_VERSION = "14.19.2" }
+# https://docs.netlify.com/configure-builds/file-based-configuration/
+
+[context.production.environment]
+  NODE_VERSION = "14.19.2"
+[context.deploy-preview.environment]
+  NODE_VERSION = "14.19.2"
+[context.branch-deploy.environment]
+  NODE_VERSION = "14.19.2"
 [context.dev.environment]
   NODE_VERSION = "14.19.2"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,4 +5,4 @@
 [context.branch-deploy]
   environment = { NODE_VERSION = "14.19.2" }
 [context.dev.environment]
-  environment = { NODE_VERSION = "14.19.2" }
+  NODE_VERSION = "14.19.2"


### PR DESCRIPTION
Remove double `environment` nesting

```
[context.dev.environment]
  environment = { NODE_VERSION = "14.19.2" }
```

This looks like it's resulting in `{ environment: {environment: { NODE_VERSION = "..." } } }`

Changed to:

```
[context.dev.environment]
  NODE_VERSION = "14.19.2"
```

Clean up remaining items to match similar syntax pattern