### PR TITLE
Add link to deploy examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ By default, `dev` acts as the primary base branch which all PRs should merge int
 
 ## Launchpad deployment
 
-- The `master` branch represents the live **testnet** version of the Launchpad. Open a PR to merge `dev` into `master` to deploy a testnet Launchpad (e.g. #517 for https://goerli.launchpad.ethereum.org/ )
-- The `mainnet` branch represents the live **Mainnet** version of the Launchpad. Open a PR to merge `master` into `mainnet` to deploy the Mainnet Launchpad (e.g. #518 for https://launchpad.ethereum.org/)
+- The `master` branch represents the live **testnet** version of the Launchpad. Open a PR to merge `dev` into `master` to deploy a testnet Launchpad (e.g. [#517](https://github.com/ethereum/staking-launchpad/pull/517) for https://goerli.launchpad.ethereum.org/ )
+- The `mainnet` branch represents the live **Mainnet** version of the Launchpad. Open a PR to merge `master` into `mainnet` to deploy the Mainnet Launchpad (e.g. [#518](https://github.com/ethereum/staking-launchpad/pull/518) for https://launchpad.ethereum.org/)
 
 ## Launchpad translation
 


### PR DESCRIPTION
- Adds links to allow users to click on a link to see an example deploy PR instead of having to manually search.