### PR TITLE
Tweak copy to clarify client count

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -3507,6 +3507,12 @@
       "value": "Besu on Goerli documentation"
     }
   ],
+  "XVRQoq": [
+    {
+      "type": 0,
+      "value": "Since the Merge, third-party providers (such as Infura and Alchemy) are no longer viable options to outsource execution layer responsibilities. All stakers must run both an execution and a consensus client to properly attest to the network."
+    }
+  ],
   "XVehvN": [
     {
       "type": 1,
@@ -6349,12 +6355,6 @@
     {
       "type": 0,
       "value": "Staking economics"
-    }
-  ],
-  "zMiMCs": [
-    {
-      "type": 0,
-      "value": "Since the Merge, third-party providers (such as Infura and Alchemy) are no longer viable options to outsource execution layer responsibilities. All stakers must run a pair of both an execution and consensus client to properly attest to the network."
     }
   ],
   "zbEBi9": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -1365,6 +1365,9 @@
     "description": "Link to documentation about execution client Besu, specifically for Goerli testnet",
     "message": "Besu on Goerli documentation"
   },
+  "XVRQoq": {
+    "message": "Since the Merge, third-party providers (such as Infura and Alchemy) are no longer viable options to outsource execution layer responsibilities. All stakers must run both an execution and a consensus client to properly attest to the network."
+  },
   "XVehvN": {
     "description": "{filesPattern} refers to a computer command which will find {keyFile} and\n                {passwordFile} - both files within a computer.",
     "message": "{filesPattern} will expect that the {keyFile} exists, and the file containing the password for it is {passwordFile}."
@@ -2489,9 +2492,6 @@
   },
   "zJicsO": {
     "message": "Staking economics"
-  },
-  "zMiMCs": {
-    "message": "Since the Merge, third-party providers (such as Infura and Alchemy) are no longer viable options to outsource execution layer responsibilities. All stakers must run a pair of both an execution and consensus client to properly attest to the network."
   },
   "zbEBi9": {
     "description": "{mainnet} shows '--config mainnet' terminal command",

--- a/src/pages/Checklist/index.tsx
+++ b/src/pages/Checklist/index.tsx
@@ -515,7 +515,7 @@ export const Checklist = () => {
             </li>
             <li className="py5">
               <Text>
-                <FormattedMessage defaultMessage="Since the Merge, third-party providers (such as Infura and Alchemy) are no longer viable options to outsource execution layer responsibilities. All stakers must run a pair of both an execution and consensus client to properly attest to the network." />
+                <FormattedMessage defaultMessage="Since the Merge, third-party providers (such as Infura and Alchemy) are no longer viable options to outsource execution layer responsibilities. All stakers must run both an execution and a consensus client to properly attest to the network." />
               </Text>
             </li>
             <li className="py5">


### PR DESCRIPTION
Small copy change, LMK what you think @wackerow.

> All stakers must run a pair of both an execution and consensus client

This read to me like stakers must run a pair of each, i.e. 4 clients total.