### PR TITLE
fix: use correct hover state for disabled tile

### DIFF
--- a/src/pages/ConnectWallet/WalletButton.tsx
+++ b/src/pages/ConnectWallet/WalletButton.tsx
@@ -45,7 +45,6 @@ const ConnectingContainer = styled.div`
   justify-content: space-between;
   width: 100%;
   margin: 8px;
-  cursor: pointer;
 `;
 
 export const WalletButton = ({


### PR DESCRIPTION
#### Description

Atm when one of tiles is disabled it still show `pointer` cursor while hovering on the text part.

#### Examples

Before fix:
![CleanShot 2022-12-14 at 17 02 27](https://user-images.githubusercontent.com/1100879/207649937-52802720-978e-4c4b-8e20-37102f8e5621.gif)

After fix:
![CleanShot 2022-12-14 at 17 03 32](https://user-images.githubusercontent.com/1100879/207650000-005552d6-2259-438a-9a26-17666658c4bc.gif)
