### PR TITLE
Wrap client cards early if over four count

### DIFF
--- a/src/pages/SelectClient/SelectClientSection.tsx
+++ b/src/pages/SelectClient/SelectClientSection.tsx
@@ -11,12 +11,13 @@ import { Alert } from '../../components/Alert';
 import { Client } from './index';
 import { ClientId } from '../../store/actions/clientActions';
 
-const ClientOptionContainer = styled.div`
-  width: 100%;
+const ClientOptionContainer = styled.div<{ overFour: boolean }>`
+  width: min(${({ overFour }) => (overFour ? '700' : '1000')}px, 100%);
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
   margin-bottom: 2rem;
+  margin-inline: auto;
 `;
 
 const ClientDescriptionContainer = styled.div`
@@ -61,7 +62,7 @@ const SelectClientSection = ({
       </div>
     )}
     <Box className="flex flex-column space-between mt10">
-      <ClientOptionContainer>
+      <ClientOptionContainer overFour={clients.length > 4}>
         {clients.map(({ clientId, name, imgUrl, language }) => {
           const inputId = `${clientId}-client`;
           const onClick = () => setCurrentClient(clientId);


### PR DESCRIPTION
## Description
- Evens out the visual display of the 4 EL clients and 5 CL clients on the select client pages
- 4 cards fit nicely on desktop, but 5 causes one to wrap. This add logic to put a max-width if there are >4 clients (CL clients) so it wraps after the third card instead

Noted in #586 