### PR TITLE
Add Lodestar to mobile client menu

### DIFF
--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -237,10 +237,10 @@ const _AppBar = ({ location }: RouteComponentProps) => {
                 <DropdownLink to={routesEnum.lighthouse}>
                   Lighthouse
                 </DropdownLink>
+                <DropdownLink to={routesEnum.lodestar}>Lodestar</DropdownLink>
                 <DropdownLink to={routesEnum.nimbus}>Nimbus</DropdownLink>
                 <DropdownLink to={routesEnum.prysm}>Prysm</DropdownLink>
                 <DropdownLink to={routesEnum.teku}>Teku</DropdownLink>
-                <DropdownLink to={routesEnum.lodestar}>Lodestar</DropdownLink>
               </Box>
             </Box>
           }
@@ -355,6 +355,7 @@ const _AppBar = ({ location }: RouteComponentProps) => {
                   <DropdownLink to={routesEnum.lighthouse}>
                     Lighthouse
                   </DropdownLink>
+                  <DropdownLink to={routesEnum.lodestar}>Lodestar</DropdownLink>
                   <DropdownLink to={routesEnum.nimbus}>Nimbus</DropdownLink>
                   <DropdownLink to={routesEnum.prysm}>Prysm</DropdownLink>
                   <DropdownLink to={routesEnum.teku}>Teku</DropdownLink>


### PR DESCRIPTION
## Description
Lodestar recently added to list of CL clients. The link was added to the desktop version but was missed in the mobile version.

- Adds Lodestar to mobile client menu
- Re-establish alphabetical order of clients in both menus