### PR TITLE
Fix top-up where the EL address has only made one deposit 

### DIFF
--- a/src/pages/TopUp/index.tsx
+++ b/src/pages/TopUp/index.tsx
@@ -7,7 +7,7 @@ import { FormPrevious } from 'grommet-icons';
 import { Alert as AlertIcon } from 'grommet-icons/icons';
 import {
   BeaconChainValidator,
-  BeaconChainValidatorResponse,
+  BeaconChainValidatorEth1Deposit,
   Props,
 } from './types';
 import { Text } from '../../components/Text';
@@ -105,7 +105,9 @@ const _TopUpPage: React.FC<Props> = () => {
           ({
             data,
           }: {
-            data: BeaconChainValidatorResponse[] | BeaconChainValidatorResponse;
+            data:
+              | BeaconChainValidatorEth1Deposit[]
+              | BeaconChainValidatorEth1Deposit;
           }) => {
             setShowDepositVerificationWarning(false);
             const response = Array.isArray(data) ? data : [data];
@@ -114,11 +116,6 @@ const _TopUpPage: React.FC<Props> = () => {
               setValidators([]);
               setLoading(false);
               return;
-            }
-
-            if (response.length === 0) {
-              setValidators([]);
-              setLoading(false);
             } else {
               // query by public keys
               const pubKeysCommaDelineated = `${response
@@ -130,13 +127,20 @@ const _TopUpPage: React.FC<Props> = () => {
                 `${BEACONCHAIN_URL}/api/v1/validator/${pubKeysCommaDelineated}`
               )
                 .then(r => r.json())
-                .then(({ data }: { data: BeaconChainValidator[] }) => {
-                  if (data.length === 0) {
-                    setShowDepositVerificationWarning(true);
+                .then(
+                  ({
+                    data,
+                  }: {
+                    data: BeaconChainValidator[] | BeaconChainValidator;
+                  }) => {
+                    const response = Array.isArray(data) ? data : [data];
+                    if (response.length === 0) {
+                      setShowDepositVerificationWarning(true);
+                    }
+                    setValidators(response);
+                    setLoading(false);
                   }
-                  setValidators(data);
-                  setLoading(false);
-                })
+                )
                 .catch(error => {
                   console.log(error);
                   setLoading(false);

--- a/src/pages/TopUp/types.ts
+++ b/src/pages/TopUp/types.ts
@@ -23,7 +23,7 @@ export interface BeaconChainValidatorTransaction {
   withdrawal_credentials: string;
 }
 
-export interface BeaconChainValidatorResponse {
+export interface BeaconChainValidatorEth1Deposit {
   publickey: string;
   valid_signature: boolean;
   validatorindex: number;


### PR DESCRIPTION
It was reported by @barnabasbusa.

### Description
The case is: if the user has only made **one** deposit before, our API response phaser would break. But if the user has made multiple deposits, it's alright.

Test case:
- The EL address has made only one deposit: https://zhejiang.beaconcha.in/api/v1/validator/eth1/0xF9dBc5fc75b5802916C66dae672e0aa124EDcD3e
    - Error: it would go all-blank page once I connect the wallet. 
    - `validators.map` TypeError: a.map is not a function at ValidatorTable.tsx:123:23
- The EL address has made multiple deposits: https://zhejiang.beaconcha.in/api/v1/validator/eth1/0xED6ee41b4Eee71Cc179683C3b90eFe20A1744D44
    - This is all good. 

### How did I fix it
- Rename `BeaconChainValidatorResponse` to `BeaconChainValidatorEth1Deposit` because it was really confusing with `BeaconChainValidator`
- Accept that `data` might be a `BeaconChainValidator` Object rather than a `BeaconChainValidator` Array. And check it with `const response = Array.isArray(data) ? data : [data];`

I fixed it but I'm not really sure why we need it. I simply copied the pattern from the `BeaconChainValidatorEth1Deposit` API call. @wackerow could you help review it? 🙏
