### PR TITLE
Top up data fetching refactor

### DIFF
--- a/src/pages/TopUp/index.tsx
+++ b/src/pages/TopUp/index.tsx
@@ -112,7 +112,6 @@ const _TopUpPage: React.FC<Props> = () => {
         // No validators for that user's wallet address, exit early
         if (dataEth1.length === 0) {
           setValidators([]);
-          setLoading(false);
           return;
         }
         // Prepare comma delimited list of pubKeys for eth1 address provided

--- a/src/pages/TopUp/index.tsx
+++ b/src/pages/TopUp/index.tsx
@@ -91,69 +91,62 @@ const _TopUpPage: React.FC<Props> = () => {
 
   const { formatMessage } = useIntl();
 
-  // an effect that fetches validators from beaconchain when the user connects or changes their wallet
+  // an effect that fetches validators from Beaconcha.in when the user connects or changes their wallet
   useEffect(() => {
     const fetchValidatorsForUserAddress = async () => {
       setLoading(true);
+      setShowDepositVerificationWarning(false);
 
-      // beaconchain API requires two fetches - one that gets the public keys for an Ethereum address, and one that
-      // queries by the validators public keys
-
-      fetch(`${BEACONCHAIN_URL}/api/v1/validator/eth1/${account}`)
-        .then(r => r.json())
-        .then(
-          ({
-            data,
-          }: {
-            data:
-              | BeaconChainValidatorEth1Deposit[]
-              | BeaconChainValidatorEth1Deposit;
-          }) => {
-            setShowDepositVerificationWarning(false);
-            const response = Array.isArray(data) ? data : [data];
-            // no validators for that user's wallet address
-            if (response.length === 0) {
-              setValidators([]);
-              setLoading(false);
-              return;
-            } else {
-              // query by public keys
-              const pubKeysCommaDelineated = `${response
-                .slice(0, 50)
-                .map(validator => validator.publickey)
-                .join(',')}`;
-
-              fetch(
-                `${BEACONCHAIN_URL}/api/v1/validator/${pubKeysCommaDelineated}`
-              )
-                .then(r => r.json())
-                .then(
-                  ({
-                    data,
-                  }: {
-                    data: BeaconChainValidator[] | BeaconChainValidator;
-                  }) => {
-                    const response = Array.isArray(data) ? data : [data];
-                    if (response.length === 0) {
-                      setShowDepositVerificationWarning(true);
-                    }
-                    setValidators(response);
-                    setLoading(false);
-                  }
-                )
-                .catch(error => {
-                  console.log(error);
-                  setLoading(false);
-                  setValidatorLoadError(true);
-                });
-            }
-          }
-        )
-        .catch(error => {
-          console.log(error);
+      // Beaconcha.in API requires two fetches - one that gets the public keys for an Ethereum address,
+      // and one that queries by the validators public keys
+      try {
+        // Fetch list of validator accounts by given eth1 address
+        const resEth1 = await fetch(
+          new URL(`api/v1/validator/eth1/${account}`, BEACONCHAIN_URL).href
+        );
+        // Confirm ok response
+        if (!resEth1.ok) throw new Error(resEth1.statusText);
+        const {
+          data: dataEth1,
+        }: { data: BeaconChainValidatorEth1Deposit[] } = await resEth1.json();
+        // No validators for that user's wallet address, exit early
+        if (dataEth1.length === 0) {
+          setValidators([]);
           setLoading(false);
-          setValidatorLoadError(true);
-        });
+          return;
+        }
+        // Prepare comma delimited list of pubKeys for eth1 address provided
+        const pubKeysCommaDelineated = `${dataEth1
+          .slice(0, 50)
+          .map(({ publickey }) => publickey)
+          .join(',')}`;
+        // Fetch validator details by public key(s)
+        const resPubKeys = await fetch(
+          new URL(`api/v1/validator/${pubKeysCommaDelineated}`, BEACONCHAIN_URL)
+            .href
+        );
+        // Confirm ok response
+        if (!resPubKeys.ok) {
+          setShowDepositVerificationWarning(true);
+          throw new Error(resPubKeys.statusText);
+        }
+        const {
+          data,
+        }: {
+          data: BeaconChainValidator | BeaconChainValidator[];
+        } = await resPubKeys.json();
+        const dataPubKeys: BeaconChainValidator[] = Array.isArray(data)
+          ? data
+          : [data];
+        if (!dataPubKeys.length) setShowDepositVerificationWarning(true);
+        setValidators(dataPubKeys);
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn(error);
+        setValidatorLoadError(true);
+      } finally {
+        setLoading(false);
+      }
     };
 
     const network = NetworkChainId[chainId as number];


### PR DESCRIPTION
Merge requested: `fix-top-up-one-deposit` <- `fix-top-up-one-deposit-refactor`

Following up on @hwwhww's PR #592, realized we could do a fair amount to clean up the fetching logic being performed on this component. Given I overhauled this function, figured I would post as a separate PR instead of as a suggestion on #592, or just committing directly to that branch.

- Switches to async/await syntax
- Uses `new URL()` objects to build dependable URL link
- Uses try/catch/finally block with guard clauses for error handling

These changes help remove the function chaining and nesting of code, and should improve readability and reliability.

Additionally, this cleans up the expected return values for the data we're fetching.
- The first call is fetching all pubKeys for a given eth1 address, and _always_ returns type `BeaconChainValidatorEth1Deposit[]` (an array)
- The second call fetches validator details by pub key... if only one pub key is provided, an object is returned, but if a comma-separated list of pub keys is passed, the response is an array... thus its type would be `BeaconChainValidator | BeaconChainValidator[]`