### PR TITLE
Pre-Shanghai content cleanup

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -339,6 +339,12 @@
       "value": "Testnet practice"
     }
   ],
+  "0U17DC": [
+    {
+      "type": 0,
+      "value": "withdrawal credentials"
+    }
+  ],
   "0c06tl": [
     {
       "type": 0,
@@ -523,6 +529,12 @@
     {
       "type": 0,
       "value": "More on Ethereum staking economics"
+    }
+  ],
+  "1p+pb5": [
+    {
+      "type": 0,
+      "value": "fee recipient"
     }
   ],
   "1pUw7Y": [
@@ -1849,6 +1861,28 @@
     {
       "type": 0,
       "value": "Configure Lighthouse"
+    }
+  ],
+  "C2Jn1z": [
+    {
+      "type": 0,
+      "value": "Note that your "
+    },
+    {
+      "type": 1,
+      "value": "withdrawalCredentials"
+    },
+    {
+      "type": 0,
+      "value": " are not the same as your "
+    },
+    {
+      "type": 1,
+      "value": "feeRecipient"
+    },
+    {
+      "type": 0,
+      "value": ", which receives transaction fees from proposed. These can both be set to the same address, but must each be set separately."
     }
   ],
   "C3jBPI": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -27,6 +27,12 @@
       "value": "Interactive mode"
     }
   ],
+  "+Gj8F4": [
+    {
+      "type": 0,
+      "value": "You can prepare for this by providing a withdrawal address when generating your keys and deposit data."
+    }
+  ],
   "+L0IkF": [
     {
       "type": 0,
@@ -91,6 +97,12 @@
     {
       "type": 0,
       "value": "You can start all the transactions at once, or start them individually."
+    }
+  ],
+  "/4e3mN": [
+    {
+      "type": 0,
+      "value": "Since The Merge, validators will also be responsible for processing transactions, and thus be entitled to unburnt gas fees associated with included transactions when proposing blocks. These fees are accounted for on the execution layer, not the consensus layer, and thus require a traditional Ethereum address to be provided to your client."
     }
   ],
   "/5Hyyf": [
@@ -359,6 +371,12 @@
       "value": "Second, install the dependency packages:"
     }
   ],
+  "0mc/JV": [
+    {
+      "type": 0,
+      "value": "Validating is a commitment"
+    }
+  ],
   "0oNdmk": [
     {
       "type": 0,
@@ -531,6 +549,12 @@
     {
       "type": 0,
       "value": " file"
+    }
+  ],
+  "25IJMT": [
+    {
+      "type": 0,
+      "value": "If a withdrawal address has not been set, and you have lost access to the mnemonic seed phrase, your funds will remain locked in the validator account indefinitely."
     }
   ],
   "25suT4": [
@@ -795,12 +819,6 @@
       "value": " ETH increments, each with its own set of keys and balance."
     }
   ],
-  "3PZq07": [
-    {
-      "type": 0,
-      "value": "As such, it’s a good idea to create your keys from mnemonics which act as another backup. This will be the default for validators who join via this site’s onboarding process."
-    }
-  ],
   "3PbtmF": [
     {
       "type": 0,
@@ -829,6 +847,20 @@
     {
       "type": 0,
       "value": "Geth on Goerli documentation"
+    }
+  ],
+  "3aykgN": [
+    {
+      "type": 0,
+      "value": "Your validator will also receives unburnt gas fees when proposing blocks. Validators are chosen randomly by the protocol to propose blocks, and only one validator can propose a block for each 12-second slot. There are 7200 slots each day, so each validator has 7200 chances-per-day to propose a block. If there are 500,000 validators, each validator will "
+    },
+    {
+      "type": 1,
+      "value": "average"
+    },
+    {
+      "type": 0,
+      "value": " a block proposal every 70 days."
     }
   ],
   "3tR/V9": [
@@ -1011,20 +1043,6 @@
     {
       "type": 0,
       "value": " this is ~1.2-1.3 GB download and ~0.9-1 GB upload per hour, and is likely to increase."
-    }
-  ],
-  "5dG331": [
-    {
-      "type": 0,
-      "value": "Although a validator's vote is weighted by the amount it has at stake, each validators voting weight starts at, and is capped at "
-    },
-    {
-      "type": 1,
-      "value": "pricePerValidator"
-    },
-    {
-      "type": 0,
-      "value": ". It is possible to drop below this with poor node performance, but it is not possible to raise above it."
     }
   ],
   "5hW6Gf": [
@@ -1527,24 +1545,6 @@
       "value": "."
     }
   ],
-  "9xeLhs": [
-    {
-      "type": 0,
-      "value": "Ethereum address withdrawal: If you want to withdraw to your Mainnet wallet address (formerly 'Eth1' address) after the post-merge cleanup upgrade, you can set "
-    },
-    {
-      "type": 1,
-      "value": "ethAddressWithdraw"
-    },
-    {
-      "type": 0,
-      "value": " when running deposit-cli. "
-    },
-    {
-      "type": 1,
-      "value": "boldWarning"
-    }
-  ],
   "9ySJSP": [
     {
       "type": 0,
@@ -1587,6 +1587,26 @@
     {
       "type": 0,
       "value": "For devnet, you can add a param:"
+    }
+  ],
+  "AFzWcM": [
+    {
+      "type": 0,
+      "value": "I understand that keys are my responsibility and that my mnemonic (seed) will be the "
+    },
+    {
+      "type": 1,
+      "value": "onlyWay"
+    },
+    {
+      "type": 0,
+      "value": " to withdraw my funds if I don't provide a withdrawal address with initial deposit data."
+    }
+  ],
+  "AH6XsN": [
+    {
+      "type": 0,
+      "value": "Also be sure you understand how staking withdrawals work before setting up your keys and deposit data."
     }
   ],
   "AJD+66": [
@@ -1685,6 +1705,12 @@
     {
       "type": 0,
       "value": "Top up validator"
+    }
+  ],
+  "AyoE3t": [
+    {
+      "type": 0,
+      "value": "Withdrawing from a validator is not yet possible. This functionality is planned to be included in the Shanghai/Capella upgrade planned for Q1/Q2 2023."
     }
   ],
   "B0BAqm": [
@@ -1789,12 +1815,6 @@
       "value": "days"
     }
   ],
-  "Bf2QKg": [
-    {
-      "type": 0,
-      "value": "Validating is a long-term commitment"
-    }
-  ],
   "Bj5yI5": [
     {
       "type": 0,
@@ -1859,6 +1879,12 @@
     {
       "type": 0,
       "value": "Proof of stake"
+    }
+  ],
+  "CPl2hh": [
+    {
+      "type": 0,
+      "value": "I have reviewed the checklist and understand how withdrawals work."
     }
   ],
   "CT+gEC": [
@@ -2085,6 +2111,12 @@
       "value": " (the minimum allowed by the deposit contract)"
     }
   ],
+  "Ds66AU": [
+    {
+      "type": 0,
+      "value": "To become a validator you'll need to know about managing keys and protecting a mnemonic. If you are not yet familiar with keys and mnemomics, please do not proceed."
+    }
+  ],
   "DsJ/Mk": [
     {
       "type": 0,
@@ -2121,12 +2153,6 @@
     {
       "type": 0,
       "value": "Consensus clients:"
-    }
-  ],
-  "E8t6ru": [
-    {
-      "type": 0,
-      "value": "To become a validator you'll need to know about managing keys and protecting a mnemonic. If you are not yet familiar with keys and mnemomics, please do not proceed. Note that during this process you will not derive the keys needed to withdraw later, so store your mnemonic safely in order to be able to withdraw later."
     }
   ],
   "EFjTSf": [
@@ -2233,6 +2259,24 @@
     {
       "type": 0,
       "value": "I understand that this transaction is not reversible."
+    }
+  ],
+  "FSp9ip": [
+    {
+      "type": 0,
+      "value": "Ethereum address withdrawal: If you want to withdraw to your execution wallet address after the Shanghai/Capella upgrade, you can set "
+    },
+    {
+      "type": 1,
+      "value": "ethAddressWithdraw"
+    },
+    {
+      "type": 0,
+      "value": " when running deposit-cli. "
+    },
+    {
+      "type": 1,
+      "value": "boldWarning"
     }
   ],
   "FU7JYy": [
@@ -2739,12 +2783,6 @@
       "value": "What is your current operating system?"
     }
   ],
-  "K37W0m": [
-    {
-      "type": 0,
-      "value": "With your signing key, you could attempt to quickly exit the validator and then transfer the funds—with the withdrawal key—before the thief."
-    }
-  ],
   "K3uH1C": [
     {
       "type": 0,
@@ -2761,6 +2799,12 @@
     {
       "type": 0,
       "value": "Geth installation documentation"
+    }
+  ],
+  "K6canA": [
+    {
+      "type": 0,
+      "value": "Withdrawal features are planned to be included in the upcoming Shanghai/Capella upgrade. After this functionality is added, your balance can then be withdrawn—with your withdrawal key—after a minimum delay of around a day."
     }
   ],
   "KBSbmP": [
@@ -2909,6 +2953,28 @@
     {
       "type": 0,
       "value": "Lighthouse is a consensus client implementation, written in Rust with a heavy focus on speed and security."
+    }
+  ],
+  "LOtXFT": [
+    {
+      "type": 0,
+      "value": "BLS withdrawal: By default, the deposit-cli would generate withdrawal credentials with the "
+    },
+    {
+      "type": 1,
+      "value": "boldWithdrawalKey"
+    },
+    {
+      "type": 0,
+      "value": " derived via mnemonics in "
+    },
+    {
+      "type": 1,
+      "value": "eip2334"
+    },
+    {
+      "type": 0,
+      "value": " format."
     }
   ],
   "LVy+cS": [
@@ -3197,32 +3263,16 @@
       "value": " flag when generating your keys with the Staking Deposit CLI."
     }
   ],
-  "NTHTCh": [
-    {
-      "type": 0,
-      "value": "Do not deposit more than "
-    },
-    {
-      "type": 1,
-      "value": "pricePerValidator"
-    },
-    {
-      "type": 0,
-      "value": " ETH for a single validator. It will not add to your rewards and will be locked until the planned "
-    },
-    {
-      "type": 1,
-      "value": "shanghai"
-    },
-    {
-      "type": 0,
-      "value": " update."
-    }
-  ],
   "NTWnJC": [
     {
       "type": 0,
       "value": "Download command line app"
+    }
+  ],
+  "NTdFPX": [
+    {
+      "type": 0,
+      "value": "Rewards and penalties are issued every 6.4 minutes—a period of time known as an epoch."
     }
   ],
   "NUCB4G": [
@@ -4097,6 +4147,12 @@
       "value": "Becoming a validator is a big responsibility with important preparation steps. Only start the deposit process when you're ready."
     }
   ],
+  "V+P6OJ": [
+    {
+      "type": 0,
+      "value": "This became a requirement at time of The Merge, so be sure you're running both before staking."
+    }
+  ],
   "V0cb8p": [
     {
       "type": 0,
@@ -4253,12 +4309,6 @@
       "value": "Japanese"
     }
   ],
-  "W6w5Wb": [
-    {
-      "type": 0,
-      "value": "Transfers between validators and withdrawals aren't possible yet. Withdrawal functionality is currently a top priority, and is planned to be rolled out in the next network upgrade, known as the Shanghai upgrade."
-    }
-  ],
   "W8nHSd": [
     {
       "type": 0,
@@ -4303,6 +4353,20 @@
     {
       "type": 0,
       "value": "These steps are optional but are recommended to optimize your node."
+    }
+  ],
+  "WbCafE": [
+    {
+      "type": 0,
+      "value": "If you do not provide a withdrawal address with your initial deposit data, you will need to derive your withdrawal keys from your mnemonic at a later time, so store your mnemonic safely—it will be the ONLY way to withdraw your "
+    },
+    {
+      "type": 1,
+      "value": "TICKER_NAME"
+    },
+    {
+      "type": 0,
+      "value": " when you chose to activate withdrawals."
     }
   ],
   "WdDGn6": [
@@ -4439,6 +4503,12 @@
       "value": "~25 minutes"
     }
   ],
+  "XgOPc8": [
+    {
+      "type": 0,
+      "value": "Note, there are no current plans to enable transfers of ETH between validators."
+    }
+  ],
   "XmddSV": [
     {
       "type": 0,
@@ -4473,12 +4543,6 @@
     {
       "type": 0,
       "value": "Top up"
-    }
-  ],
-  "Y8YLHs": [
-    {
-      "type": 0,
-      "value": "If your signing key is not under the thief’s control, the thief cannot exit your validator."
     }
   ],
   "Y9S0NE": [
@@ -4667,10 +4731,10 @@
       "value": "."
     }
   ],
-  "ZBtnGs": [
+  "ZDI2t3": [
     {
       "type": 0,
-      "value": "I have reviewed the checklist."
+      "value": "Simply being offline with an otherwise healthy network does not result in slashing, but will result in small inactivity penalties."
     }
   ],
   "ZK6NmY": [
@@ -4695,20 +4759,6 @@
     {
       "type": 0,
       "value": "Why is there a wait?"
-    }
-  ],
-  "ZdT9Bs": [
-    {
-      "type": 0,
-      "value": "Your validator will also receive unburnt gas fees when proposing blocks. Validators are chosen randomly by the protocol to propose blocks, and only one validator can propose a block for each 12-second slot. There are 7200 slots each day, so each validator has 7200 chances-per-day to propose a block. If there are 360,000 validators, each validator will "
-    },
-    {
-      "type": 1,
-      "value": "average"
-    },
-    {
-      "type": 0,
-      "value": " a block proposal every 50 days."
     }
   ],
   "ZsXdlw": [
@@ -4835,12 +4885,6 @@
       "value": " ETH staked."
     }
   ],
-  "b4csjU": [
-    {
-      "type": 0,
-      "value": "However, bear in mind that for the foreseeable future, once you’ve exited, there’s no going back."
-    }
-  ],
   "b5LQY1": [
     {
       "type": 0,
@@ -4851,6 +4895,12 @@
     {
       "type": 0,
       "value": "More on client diversity"
+    }
+  ],
+  "bMMVVN": [
+    {
+      "type": 0,
+      "value": "Currently there’s no way for you to re-activate your validator, and you won’t be able to transfer or withdraw your funds until withdrawals are enabled with the Shanghai/Capella upgrade. This means your funds will remain inaccessible at least until then."
     }
   ],
   "bNFkSo": [
@@ -4919,6 +4969,12 @@
     {
       "type": 0,
       "value": "What clients do I need to run?"
+    }
+  ],
+  "bhFma7": [
+    {
+      "type": 0,
+      "value": "More on withdrawals"
     }
   ],
   "bnuvhg": [
@@ -5041,12 +5097,6 @@
     {
       "type": 0,
       "value": "What are withdrawal credentials?"
-    }
-  ],
-  "cyNFM3": [
-    {
-      "type": 0,
-      "value": "Withdrawing your deposit will not be possible until the Shanghai upgrade planned for after the Merge."
     }
   ],
   "cyR7Kh": [
@@ -5175,6 +5225,12 @@
       "value": "code3"
     }
   ],
+  "eD1NDX": [
+    {
+      "type": 0,
+      "value": "Withdrawing your deposit will not be possible until the Shanghai/Capella upgrade planned for Q1/Q2 2023."
+    }
+  ],
   "eKEL/g": [
     {
       "type": 0,
@@ -5193,6 +5249,36 @@
       "value": "It specifies who is staking, who is validating, how much is being staked, and who can withdraw the funds."
     }
   ],
+  "eP2Czm": [
+    {
+      "type": 0,
+      "value": "I understand that I "
+    },
+    {
+      "type": 1,
+      "value": "cannotWithdraw"
+    },
+    {
+      "type": 0,
+      "value": " my stake until the Shanghai/Capella upgrade, and I "
+    },
+    {
+      "type": 1,
+      "value": "cannotTransfer"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "type": 1,
+      "value": "TICKER_NAME"
+    },
+    {
+      "type": 0,
+      "value": " between validators. I understand that if I exit, I will not be able to rejoin until that time. Staking is a commitment."
+    }
+  ],
   "eTenzU": [
     {
       "type": 0,
@@ -5209,6 +5295,12 @@
     {
       "type": 0,
       "value": "To maximize security and efficiency of your node, use dedicated hardware to run your clients. This reduces risk of malware exposure and minimizes competition for computing resources, ensuring your node handles the network load and its validator responsibilities at all times."
+    }
+  ],
+  "eatd1u": [
+    {
+      "type": 0,
+      "value": "We'll help you create a signing key for every validator you want to run. You may choose to provide a withdrawal address for your validator when generating your deposit data, which will permanently set the withdrawal address."
     }
   ],
   "elCkOU": [
@@ -5333,6 +5425,12 @@
     {
       "type": 0,
       "value": "After client installation, ensure you are fully synced before submitting your staking deposit. This can take several days."
+    }
+  ],
+  "fa8Quz": [
+    {
+      "type": 0,
+      "value": "However, bear in mind that until the Shanghai/Capella upgrade planned for Q1/Q2 2023, once you’ve exited, there’s no going back."
     }
   ],
   "fbiteI": [
@@ -5649,12 +5747,6 @@
       "value": "I understand that it is important to keep my validator online and updated."
     }
   ],
-  "i7alIW": [
-    {
-      "type": 0,
-      "value": "This became a requirement at time of the Merge, so be sure you're running both before staking."
-    }
-  ],
   "iCpuph": [
     {
       "type": 0,
@@ -5707,12 +5799,6 @@
       "value": " ETH was chosen as a balance between enabling as many people as possible to stake without inhibiting decentralization by bloating the size of each block with signatures."
     }
   ],
-  "iPRnRG": [
-    {
-      "type": 0,
-      "value": "With transfers disabled for now, you won't be able to voluntarily exit and then restart later. This means you need to be in it for the long haul."
-    }
-  ],
   "iX90gu": [
     {
       "type": 0,
@@ -5763,6 +5849,12 @@
     {
       "type": 0,
       "value": "PegaSys Teku is a Java-based Ethereum consensus client built to meet institutional needs and security requirements."
+    }
+  ],
+  "irh2nI": [
+    {
+      "type": 0,
+      "value": "As such, it’s a good idea to create your keys from mnemonics which act as another backup. This is the default for validators who join via this site’s onboarding process."
     }
   ],
   "isGKnz": [
@@ -6029,12 +6121,6 @@
       "value": "Exited"
     }
   ],
-  "kzGlnG": [
-    {
-      "type": 0,
-      "value": "Rewards and penalties are issued roughly every six and a half minutes—a period of time known as an epoch."
-    }
-  ],
   "l/uCcX": [
     {
       "type": 0,
@@ -6219,28 +6305,6 @@
     {
       "type": 0,
       "value": "Importing from Launchpad documentation"
-    }
-  ],
-  "ljWKM1": [
-    {
-      "type": 0,
-      "value": "BLS withdrawal: By default, deposit-cli would generate withdrawal credentials with the "
-    },
-    {
-      "type": 1,
-      "value": "boldWithdrawalKey"
-    },
-    {
-      "type": 0,
-      "value": " derived via mnemonics in "
-    },
-    {
-      "type": 1,
-      "value": "eip2334"
-    },
-    {
-      "type": 0,
-      "value": " format."
     }
   ],
   "ll/zMW": [
@@ -6519,28 +6583,6 @@
       "value": "EthStaker Knowledge Base"
     }
   ],
-  "oJHeMC": [
-    {
-      "type": 0,
-      "value": "I understand that I "
-    },
-    {
-      "type": 1,
-      "value": "cannotTransfer"
-    },
-    {
-      "type": 0,
-      "value": " my stake for a while, and I "
-    },
-    {
-      "type": 1,
-      "value": "cannotWithdraw"
-    },
-    {
-      "type": 0,
-      "value": " until the Shanghai upgrade. I understand that if I exit, I will not be able to rejoin until that time. This is a long term commitment."
-    }
-  ],
   "oLxfO1": [
     {
       "type": 0,
@@ -6771,18 +6813,6 @@
       "value": "Deposit summary"
     }
   ],
-  "q/ZayM": [
-    {
-      "type": 0,
-      "value": "Withdrawal features are proposed to be included in the upcoming Shanghai upgrade. After this functionality is added, your balance can then be withdrawn—with your withdrawal key—after a minimum delay of around a day."
-    }
-  ],
-  "q2XW/k": [
-    {
-      "type": 0,
-      "value": "If your withdrawal key is stolen, the thief can transfer your validator’s balance, but only once the validator has exited."
-    }
-  ],
   "qB6aU6": [
     {
       "type": 0,
@@ -6793,20 +6823,6 @@
     {
       "type": 0,
       "value": "Exit epoch and withdrawable epoch"
-    }
-  ],
-  "qDvaNm": [
-    {
-      "type": 0,
-      "value": "I understand that keys are my responsibility and that my mnemonic (seed) will be the "
-    },
-    {
-      "type": 1,
-      "value": "onlyWay"
-    },
-    {
-      "type": 0,
-      "value": " to withdraw my funds."
     }
   ],
   "qIDtPw": [
@@ -6885,6 +6901,12 @@
     {
       "type": 0,
       "value": "Save the key files and get the validator file ready"
+    }
+  ],
+  "qntIRb": [
+    {
+      "type": 0,
+      "value": "If this was not provided, the withdrawal keys will be needed to sign a message declaring a withdrawal address. This requires access to the mnemonic used when setting up the keys."
     }
   ],
   "qwh6gM": [
@@ -7031,20 +7053,6 @@
       "value": "Launchpad summary"
     }
   ],
-  "rxttyC": [
-    {
-      "type": 0,
-      "value": "Your mnemonic is the backup for your signing keys and will be the ONLY way to withdraw your "
-    },
-    {
-      "type": 1,
-      "value": "TICKER_NAME"
-    },
-    {
-      "type": 0,
-      "value": " when the time comes and no one can help you recover your mnemonic if you lose it."
-    }
-  ],
   "s6gImC": [
     {
       "type": 0,
@@ -7133,12 +7141,6 @@
     {
       "type": 0,
       "value": "Maximum number of accounts that can be checked in a block. Stops when 16 withdrawals are found. If 16 eligible rewards are not found in the first 16,384 accounts checked, the withdrawal queue for that block will be submitted as is, and the following proposer will pick up where this left off."
-    }
-  ],
-  "taENNR": [
-    {
-      "type": 0,
-      "value": "Currently there’s no way for you to re-activate your validator, and you won’t be able to transfer or withdraw your funds until withdrawals are enabled. This is proposed to be included in the next network upgrade, known as the Shanghai upgrade. This means your funds will remain inaccessible at least until then."
     }
   ],
   "tbYkT4": [
@@ -7241,12 +7243,6 @@
       "value": "After depositing"
     }
   ],
-  "u4em9Z": [
-    {
-      "type": 0,
-      "value": "Since the Merge, validators will also be responsible for processing transactions, and thus be entitled to unburnt gas fees associated with included transactions when proposing blocks. These fees are accounted for on the execution layer, not the consensus layer, and thus require a traditional Ethereum address to be provided to your client."
-    }
-  ],
   "u564LK": [
     {
       "type": 0,
@@ -7287,6 +7283,12 @@
       "value": "Make sure you're aware of how to avoid phishing attacks. We've prepared a list of things to look out for."
     }
   ],
+  "uMpYkE": [
+    {
+      "type": 0,
+      "value": "If you provided a withdrawal address when initially generating your keys, the withdrawal key no longer has any use. The only address that validator funds can be transferred to is this address, and it cannot be changed once set."
+    }
+  ],
   "uNfxNg": [
     {
       "type": 0,
@@ -7307,6 +7309,20 @@
     {
       "type": 0,
       "value": "exit epoch"
+    }
+  ],
+  "uYF99H": [
+    {
+      "type": 0,
+      "value": "Although a validator's vote is weighted by the amount it has at stake, each validators voting weight starts at, and is capped at "
+    },
+    {
+      "type": 1,
+      "value": "PRICE_PER_VALIDATOR"
+    },
+    {
+      "type": 0,
+      "value": ". It is possible to drop below this with poor node performance, but it is not possible to raise above it."
     }
   ],
   "ubKWX8": [
@@ -7441,6 +7457,28 @@
       "value": "Chinese (simplified)"
     }
   ],
+  "vZxdbJ": [
+    {
+      "type": 0,
+      "value": "Once withdrawals are enabled with the Shanghai/Capella update, validators with a maxed our effective balance and a linked execution withdrawal address will have any balance over "
+    },
+    {
+      "type": 1,
+      "value": "PRICE_PER_VALIDATOR"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "type": 1,
+      "value": "TICKER_NAME"
+    },
+    {
+      "type": 0,
+      "value": " automatically withdrawal as excess balance."
+    }
+  ],
   "vbVsqW": [
     {
       "type": 0,
@@ -7465,6 +7503,12 @@
     {
       "type": 0,
       "value": "Run the following command to launch the app"
+    }
+  ],
+  "wDlux8": [
+    {
+      "type": 0,
+      "value": "You are still able to voluntarily exit your validator to be removed from the active validator set, but until withdrawals are enabled these funds would remain locked and unable to be withdrawn or re-staked."
     }
   ],
   "wJ1PbL": [
@@ -7563,28 +7607,6 @@
     {
       "type": 0,
       "value": "We strongly recommended you complete these steps on the current testnet before Mainnet."
-    }
-  ],
-  "x9xppN": [
-    {
-      "type": 0,
-      "value": "With the transition to proof-of-stake complete via the Merge, validators are now responsible for processing transactions and signing off on their validity. This data is "
-    },
-    {
-      "type": 1,
-      "value": "not"
-    },
-    {
-      "type": 0,
-      "value": " available from popular third-party sources since the Merge. Using a third-party provider will result in your validator being offline. When data sharding is implemented, validators will also be at risk of slashing under the "
-    },
-    {
-      "type": 1,
-      "value": "pocGame"
-    },
-    {
-      "type": 0,
-      "value": "."
     }
   ],
   "xDyl3T": [
@@ -7847,6 +7869,28 @@
       "value": "On the other hand, you can be penalized for being offline and behaving maliciously—for example attesting to invalid or contradicting blocks."
     }
   ],
+  "z26FXa": [
+    {
+      "type": 0,
+      "value": "With the transition to proof-of-stake complete via The Merge, validators are now responsible for processing transactions and signing off on their validity. This data is "
+    },
+    {
+      "type": 1,
+      "value": "not"
+    },
+    {
+      "type": 0,
+      "value": " available from popular third-party sources since The Merge. Using a third-party provider will result in your validator being offline. When data sharding is implemented, validators will also be at risk of slashing under the "
+    },
+    {
+      "type": 1,
+      "value": "pocGame"
+    },
+    {
+      "type": 0,
+      "value": "."
+    }
+  ],
   "z63I56": [
     {
       "type": 0,
@@ -7891,6 +7935,20 @@
       "value": "Staking economics"
     }
   ],
+  "zVb+z+": [
+    {
+      "type": 0,
+      "value": "Do not deposit more than "
+    },
+    {
+      "type": 1,
+      "value": "PRICE_PER_VALIDATOR"
+    },
+    {
+      "type": 0,
+      "value": " ETH for a single validator. It will not add to your rewards and will be locked until the planned Shanghai/Capella upgrade."
+    }
+  ],
   "zbEBi9": [
     {
       "type": 0,
@@ -7909,12 +7967,6 @@
     {
       "type": 0,
       "value": "Node security"
-    }
-  ],
-  "zkT9Jx": [
-    {
-      "type": 0,
-      "value": "We'll help you create a signing key for every validator you want to run. Because there are no withdrawals until the Shanghai upgrade planned to follow the Merge, you will not create your withdrawal keys now. When it is possible to withdraw your funds, you can derive your withdrawal keys from your mnemonic."
     }
   ],
   "znyxZv": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -133,6 +133,9 @@
   "0S8/Wo": {
     "message": "Testnet practice"
   },
+  "0U17DC": {
+    "message": "withdrawal credentials"
+  },
   "0c06tl": {
     "message": "Withdrawal Credentials"
   },
@@ -213,6 +216,9 @@
   },
   "1ingnQ": {
     "message": "More on Ethereum staking economics"
+  },
+  "1p+pb5": {
+    "message": "fee recipient"
   },
   "1pUw7Y": {
     "message": "Documentation on running Nethermind"
@@ -700,6 +706,9 @@
   },
   "C/gb74": {
     "message": "Configure Lighthouse"
+  },
+  "C2Jn1z": {
+    "message": "Note that your {withdrawalCredentials} are not the same as your {feeRecipient}, which receives transaction fees from proposed. These can both be set to the same address, but must each be set separately."
   },
   "C3jBPI": {
     "message": "Execution Client"

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -6,6 +6,9 @@
   "+EZ9E/": {
     "message": "Interactive mode"
   },
+  "+Gj8F4": {
+    "message": "You can prepare for this by providing a withdrawal address when generating your keys and deposit data."
+  },
   "+L0IkF": {
     "message": "Step 2: Generate deposit keys using the Ethereum Foundation deposit tool"
   },
@@ -38,6 +41,9 @@
   },
   "//KCTE": {
     "message": "You can start all the transactions at once, or start them individually."
+  },
+  "/4e3mN": {
+    "message": "Since The Merge, validators will also be responsible for processing transactions, and thus be entitled to unburnt gas fees associated with included transactions when proposing blocks. These fees are accounted for on the execution layer, not the consensus layer, and thus require a traditional Ethereum address to be provided to your client."
   },
   "/5Hyyf": {
     "message": "Indonesian"
@@ -139,6 +145,9 @@
   "0lHkrT": {
     "message": "Second, install the dependency packages:"
   },
+  "0mc/JV": {
+    "message": "Validating is a commitment"
+  },
   "0oNdmk": {
     "message": "Validators FAQ"
   },
@@ -214,6 +223,9 @@
   "22EpKq": {
     "description": "{JSON} is filetype extension",
     "message": "This isn't a valid {JSON} file"
+  },
+  "25IJMT": {
+    "message": "If a withdrawal address has not been set, and you have lost access to the mnemonic seed phrase, your funds will remain locked in the validator account indefinitely."
   },
   "25suT4": {
     "description": "The {semicolon} and {colon} variables refer to the keyboard characters ';' and ':'.",
@@ -297,9 +309,6 @@
   "3ODqP9": {
     "message": "Depositing more than {pricePerValidator} ETH to a single set of keys does not increase rewards potential, nor does accumulating rewards above {pricePerValidator} ETH, as each validator is limited to an {effectiveBalance} of {pricePerValidator}. This means that staking is done in {pricePerValidator} ETH increments, each with its own set of keys and balance."
   },
-  "3PZq07": {
-    "message": "As such, it’s a good idea to create your keys from mnemonics which act as another backup. This will be the default for validators who join via this site’s onboarding process."
-  },
   "3PbtmF": {
     "message": "Check the whole address, not just a portion of it. There could be just a few bytes different."
   },
@@ -314,6 +323,9 @@
   },
   "3URRZK": {
     "message": "Geth on Goerli documentation"
+  },
+  "3aykgN": {
+    "message": "Your validator will also receives unburnt gas fees when proposing blocks. Validators are chosen randomly by the protocol to propose blocks, and only one validator can propose a block for each 12-second slot. There are 7200 slots each day, so each validator has 7200 chances-per-day to propose a block. If there are 500,000 validators, each validator will {average} a block proposal every 70 days."
   },
   "3tR/V9": {
     "message": "Section 2 - During setup"
@@ -378,9 +390,6 @@
   },
   "5Vrs8S": {
     "message": "You need enough upload bandwidth too. As of {date} this is ~1.2-1.3 GB download and ~0.9-1 GB upload per hour, and is likely to increase."
-  },
-  "5dG331": {
-    "message": "Although a validator's vote is weighted by the amount it has at stake, each validators voting weight starts at, and is capped at {pricePerValidator}. It is possible to drop below this with poor node performance, but it is not possible to raise above it."
   },
   "5hW6Gf": {
     "message": "Consensus Layer Withdrawal Protection"
@@ -578,9 +587,6 @@
   "9vwGlT": {
     "message": "I've synced my beacon node on {consensusLayerName}."
   },
-  "9xeLhs": {
-    "message": "Ethereum address withdrawal: If you want to withdraw to your Mainnet wallet address (formerly 'Eth1' address) after the post-merge cleanup upgrade, you can set {ethAddressWithdraw} when running deposit-cli. {boldWarning}"
-  },
   "9ySJSP": {
     "description": "{ethClientType} is either \"execution\" or \"consensus\", depending on which step user is on",
     "message": "Choose your {ethClientType} client and set up a node"
@@ -599,6 +605,12 @@
   },
   "AEbKyt": {
     "message": "For devnet, you can add a param:"
+  },
+  "AFzWcM": {
+    "message": "I understand that keys are my responsibility and that my mnemonic (seed) will be the {onlyWay} to withdraw my funds if I don't provide a withdrawal address with initial deposit data."
+  },
+  "AH6XsN": {
+    "message": "Also be sure you understand how staking withdrawals work before setting up your keys and deposit data."
   },
   "AJD+66": {
     "message": "The Ethereum staking deposit contract requires a minimum of {minTopupValue} {TICKER_NAME} to be sent at one time to be accepted."
@@ -640,6 +652,9 @@
   "Aw1mMs": {
     "message": "Top up validator"
   },
+  "AyoE3t": {
+    "message": "Withdrawing from a validator is not yet possible. This functionality is planned to be included in the Shanghai/Capella upgrade planned for Q1/Q2 2023."
+  },
   "B0BAqm": {
     "message": "An {excessBalanceWithdrawal} is processed when an active validator has a maxed out effective balance of 32, and has a total balance over 32. A single validator cannot get rewards on excess balance over 32 ETH, and thus these accounts will have any extra balance automatically withdrawn to their Ethereum address."
   },
@@ -667,9 +682,6 @@
   },
   "Bc20la": {
     "message": "days"
-  },
-  "Bf2QKg": {
-    "message": "Validating is a long-term commitment"
   },
   "Bj5yI5": {
     "message": "Effective balance"
@@ -703,6 +715,9 @@
   },
   "CF9vMR": {
     "message": "Proof of stake"
+  },
+  "CPl2hh": {
+    "message": "I have reviewed the checklist and understand how withdrawals work."
   },
   "CT+gEC": {
     "message": "Upload to Beacon Node {btec} pool"
@@ -785,6 +800,9 @@
     "description": "{minTopupValue} is a number, and {TICKER_NAME} is either ETH or GöETH depending on network",
     "message": "Validator effective balance is currently maxed out. If desired, you may add {minTopupValue} {TICKER_NAME} (the minimum allowed by the deposit contract)"
   },
+  "Ds66AU": {
+    "message": "To become a validator you'll need to know about managing keys and protecting a mnemonic. If you are not yet familiar with keys and mnemomics, please do not proceed."
+  },
   "DsJ/Mk": {
     "message": "Don’t just trust the contract address listed on this website."
   },
@@ -800,9 +818,6 @@
   },
   "E4rtgi": {
     "message": "Consensus clients:"
-  },
-  "E8t6ru": {
-    "message": "To become a validator you'll need to know about managing keys and protecting a mnemonic. If you are not yet familiar with keys and mnemomics, please do not proceed. Note that during this process you will not derive the keys needed to withdraw later, so store your mnemonic safely in order to be able to withdraw later."
   },
   "EFjTSf": {
     "message": "Minor penalties are given for inadvertant actions (or inactions) that hinder consensus."
@@ -849,6 +864,9 @@
   },
   "FSRfSJ": {
     "message": "I understand that this transaction is not reversible."
+  },
+  "FSp9ip": {
+    "message": "Ethereum address withdrawal: If you want to withdraw to your execution wallet address after the Shanghai/Capella upgrade, you can set {ethAddressWithdraw} when running deposit-cli. {boldWarning}"
   },
   "FU7JYy": {
     "description": "{flag} is a terminal command styled as code.",
@@ -1058,9 +1076,6 @@
   "JtAiN/": {
     "message": "What is your current operating system?"
   },
-  "K37W0m": {
-    "message": "With your signing key, you could attempt to quickly exit the validator and then transfer the funds—with the withdrawal key—before the thief."
-  },
   "K3uH1C": {
     "message": "offline"
   },
@@ -1069,6 +1084,9 @@
   },
   "K6+jQ3": {
     "message": "Geth installation documentation"
+  },
+  "K6canA": {
+    "message": "Withdrawal features are planned to be included in the upcoming Shanghai/Capella upgrade. After this functionality is added, your balance can then be withdrawn—with your withdrawal key—after a minimum delay of around a day."
   },
   "KBSbmP": {
     "description": "{reloadYourWallet} is a link labeled 'reload your wallet'",
@@ -1128,6 +1146,9 @@
   },
   "LHPZ+C": {
     "message": "Lighthouse is a consensus client implementation, written in Rust with a heavy focus on speed and security."
+  },
+  "LOtXFT": {
+    "message": "BLS withdrawal: By default, the deposit-cli would generate withdrawal credentials with the {boldWithdrawalKey} derived via mnemonics in {eip2334} format."
   },
   "LVy+cS": {
     "message": "Check with client documentation to ensure the hardware you want to use is sufficient and supported."
@@ -1248,11 +1269,11 @@
   "NSl1Q5": {
     "message": "{stakingDepositCli}: This is done by using the {eth1WithdrawalAddress} flag when generating your keys with the Staking Deposit CLI."
   },
-  "NTHTCh": {
-    "message": "Do not deposit more than {pricePerValidator} ETH for a single validator. It will not add to your rewards and will be locked until the planned {shanghai} update."
-  },
   "NTWnJC": {
     "message": "Download command line app"
+  },
+  "NTdFPX": {
+    "message": "Rewards and penalties are issued every 6.4 minutes—a period of time known as an epoch."
   },
   "NUCB4G": {
     "message": "This {network} validator needs to be configured for withdrawals. Take note of your withdrawal credentials as you'll need this to update your keys."
@@ -1577,6 +1598,9 @@
   "UykRIk": {
     "message": "Becoming a validator is a big responsibility with important preparation steps. Only start the deposit process when you're ready."
   },
+  "V+P6OJ": {
+    "message": "This became a requirement at time of The Merge, so be sure you're running both before staking."
+  },
   "V0cb8p": {
     "message": "If you do not have a testnet folder it is likely you have not built and run Nimbus correctly. Run the make commands again."
   },
@@ -1625,9 +1649,6 @@
   "W3t7Ob": {
     "message": "Japanese"
   },
-  "W6w5Wb": {
-    "message": "Transfers between validators and withdrawals aren't possible yet. Withdrawal functionality is currently a top priority, and is planned to be rolled out in the next network upgrade, known as the Shanghai upgrade."
-  },
   "W8nHSd": {
     "message": "FAQ"
   },
@@ -1642,6 +1663,9 @@
   },
   "WTPUDZ": {
     "message": "These steps are optional but are recommended to optimize your node."
+  },
+  "WbCafE": {
+    "message": "If you do not provide a withdrawal address with your initial deposit data, you will need to derive your withdrawal keys from your mnemonic at a later time, so store your mnemonic safely—it will be the ONLY way to withdraw your {TICKER_NAME} when you chose to activate withdrawals."
   },
   "WdDGn6": {
     "message": "An implementation of the consensus protocol with a focus on usability, security, and reliability. Prysm is developed by Prysmatic Labs, a company with the sole focus on the development of their client."
@@ -1691,6 +1715,9 @@
   "XcItS7": {
     "message": "~25 minutes"
   },
+  "XgOPc8": {
+    "message": "Note, there are no current plans to enable transfers of ETH between validators."
+  },
   "XmddSV": {
     "message": "Build from source"
   },
@@ -1702,9 +1729,6 @@
   },
   "Y47aYU": {
     "message": "Top up"
-  },
-  "Y8YLHs": {
-    "message": "If your signing key is not under the thief’s control, the thief cannot exit your validator."
   },
   "Y9S0NE": {
     "message": "Send last deposit"
@@ -1772,8 +1796,8 @@
     "description": "{greater than 50%} shows 'greater than 50%' and is a link to validator incentives article",
     "message": "Overall, we'd expect your validator to be net profitable as long as your uptime is {greaterThan50Percent}."
   },
-  "ZBtnGs": {
-    "message": "I have reviewed the checklist."
+  "ZDI2t3": {
+    "message": "Simply being offline with an otherwise healthy network does not result in slashing, but will result in small inactivity penalties."
   },
   "ZK6NmY": {
     "message": "Note: the RTC (Real-Time Clock) time may be set to your local timezone instead of UTC, especially in a VM which has its clock configured on Windows."
@@ -1786,9 +1810,6 @@
   },
   "ZTo0Fl": {
     "message": "Why is there a wait?"
-  },
-  "ZdT9Bs": {
-    "message": "Your validator will also receive unburnt gas fees when proposing blocks. Validators are chosen randomly by the protocol to propose blocks, and only one validator can propose a block for each 12-second slot. There are 7200 slots each day, so each validator has 7200 chances-per-day to propose a block. If there are 360,000 validators, each validator will {average} a block proposal every 50 days."
   },
   "ZsXdlw": {
     "message": "Erigon installation documentation"
@@ -1844,14 +1865,14 @@
   "b3J7Pw": {
     "message": "No. There is no advantage to having more than {pricePerValidator} ETH staked."
   },
-  "b4csjU": {
-    "message": "However, bear in mind that for the foreseeable future, once you’ve exited, there’s no going back."
-  },
   "b5LQY1": {
     "message": "Note the “withdrawal” and “BLS-to-execution” queues are independent and do not compete. Each are limited on a per-block basis."
   },
   "b8APBK": {
     "message": "More on client diversity"
+  },
+  "bMMVVN": {
+    "message": "Currently there’s no way for you to re-activate your validator, and you won’t be able to transfer or withdraw your funds until withdrawals are enabled with the Shanghai/Capella upgrade. This means your funds will remain inaccessible at least until then."
   },
   "bNFkSo": {
     "message": "Now follow the instructions presented to you in the terminal window to generate your keys."
@@ -1882,6 +1903,9 @@
   },
   "bgyJfz": {
     "message": "What clients do I need to run?"
+  },
+  "bhFma7": {
+    "message": "More on withdrawals"
   },
   "bnuvhg": {
     "message": "Lighthouse is built in Rust and offered under an Apache 2.0 License."
@@ -1940,9 +1964,6 @@
   "cpxfOR": {
     "message": "What are withdrawal credentials?"
   },
-  "cyNFM3": {
-    "message": "Withdrawing your deposit will not be possible until the Shanghai upgrade planned for after the Merge."
-  },
   "cyR7Kh": {
     "message": "Back"
   },
@@ -1995,6 +2016,9 @@
     "description": "{code} values are terminal outputs and commands.",
     "message": "If {code1} is not {code2}, run: {code3}"
   },
+  "eD1NDX": {
+    "message": "Withdrawing your deposit will not be possible until the Shanghai/Capella upgrade planned for Q1/Q2 2023."
+  },
   "eKEL/g": {
     "message": "Pending"
   },
@@ -2004,6 +2028,9 @@
   "eOpZjd": {
     "message": "It specifies who is staking, who is validating, how much is being staked, and who can withdraw the funds."
   },
+  "eP2Czm": {
+    "message": "I understand that I {cannotWithdraw} my stake until the Shanghai/Capella upgrade, and I {cannotTransfer} {TICKER_NAME} between validators. I understand that if I exit, I will not be able to rejoin until that time. Staking is a commitment."
+  },
   "eTenzU": {
     "message": "activation queue"
   },
@@ -2012,6 +2039,9 @@
   },
   "eaU/aL": {
     "message": "To maximize security and efficiency of your node, use dedicated hardware to run your clients. This reduces risk of malware exposure and minimizes competition for computing resources, ensuring your node handles the network load and its validator responsibilities at all times."
+  },
+  "eatd1u": {
+    "message": "We'll help you create a signing key for every validator you want to run. You may choose to provide a withdrawal address for your validator when generating your deposit data, which will permanently set the withdrawal address."
   },
   "elCkOU": {
     "message": "More on the merge"
@@ -2054,6 +2084,9 @@
   },
   "fZwn+P": {
     "message": "After client installation, ensure you are fully synced before submitting your staking deposit. This can take several days."
+  },
+  "fa8Quz": {
+    "message": "However, bear in mind that until the Shanghai/Capella upgrade planned for Q1/Q2 2023, once you’ve exited, there’s no going back."
   },
   "fbiteI": {
     "message": "only stored on one validator machine"
@@ -2181,9 +2214,6 @@
   "hzLd+/": {
     "message": "I understand that it is important to keep my validator online and updated."
   },
-  "i7alIW": {
-    "message": "This became a requirement at time of the Merge, so be sure you're running both before staking."
-  },
   "iCpuph": {
     "message": "Clients"
   },
@@ -2201,9 +2231,6 @@
   },
   "iN1PPs": {
     "message": "Each {pricePerValidator} ETH deposit activates one set of validator keys. These keys are used to sign off on the state of the network. The lower the ETH requirement, the more resulting signatures must be saved by the network. {pricePerValidator} ETH was chosen as a balance between enabling as many people as possible to stake without inhibiting decentralization by bloating the size of each block with signatures."
-  },
-  "iPRnRG": {
-    "message": "With transfers disabled for now, you won't be able to voluntarily exit and then restart later. This means you need to be in it for the long haul."
   },
   "iX90gu": {
     "message": "I've joined my execution client's Discord server."
@@ -2229,6 +2256,9 @@
   },
   "iqJ3LM": {
     "message": "PegaSys Teku is a Java-based Ethereum consensus client built to meet institutional needs and security requirements."
+  },
+  "irh2nI": {
+    "message": "As such, it’s a good idea to create your keys from mnemonics which act as another backup. This is the default for validators who join via this site’s onboarding process."
   },
   "isGKnz": {
     "message": "Documentation"
@@ -2346,9 +2376,6 @@
   "kv1nqx": {
     "message": "Exited"
   },
-  "kzGlnG": {
-    "message": "Rewards and penalties are issued roughly every six and a half minutes—a period of time known as an epoch."
-  },
   "l/uCcX": {
     "message": "You're on the testnet"
   },
@@ -2408,9 +2435,6 @@
   },
   "lfV1bj": {
     "message": "Importing from Launchpad documentation"
-  },
-  "ljWKM1": {
-    "message": "BLS withdrawal: By default, deposit-cli would generate withdrawal credentials with the {boldWithdrawalKey} derived via mnemonics in {eip2334} format."
   },
   "ll/zMW": {
     "message": "This is a non-reversible transaction."
@@ -2527,9 +2551,6 @@
   "oF6xvJ": {
     "message": "EthStaker Knowledge Base"
   },
-  "oJHeMC": {
-    "message": "I understand that I {cannotTransfer} my stake for a while, and I {cannotWithdraw} until the Shanghai upgrade. I understand that if I exit, I will not be able to rejoin until that time. This is a long term commitment."
-  },
   "oLxfO1": {
     "message": "Now that the keys are imported, all that is left to do (assuming your beacon node is already running) is to run the validator client."
   },
@@ -2625,20 +2646,11 @@
   "pyWt01": {
     "message": "Deposit summary"
   },
-  "q/ZayM": {
-    "message": "Withdrawal features are proposed to be included in the upcoming Shanghai upgrade. After this functionality is added, your balance can then be withdrawn—with your withdrawal key—after a minimum delay of around a day."
-  },
-  "q2XW/k": {
-    "message": "If your withdrawal key is stolen, the thief can transfer your validator’s balance, but only once the validator has exited."
-  },
   "qB6aU6": {
     "message": "What happened to 'Eth2?'"
   },
   "qBorVY": {
     "message": "Exit epoch and withdrawable epoch"
-  },
-  "qDvaNm": {
-    "message": "I understand that keys are my responsibility and that my mnemonic (seed) will be the {onlyWay} to withdraw my funds."
   },
   "qIDtPw": {
     "message": "To enable your Beacon Chain validator(s) to automatically withdraw balances to your {exeuctionAddress}, you can use the {cli} tool to generate the {signed} message JSON file. This message includes the request to change your old BLS withdrawal credentials to the new withdrawal credentials in execution address format."
@@ -2666,6 +2678,9 @@
   },
   "qkhah0": {
     "message": "Save the key files and get the validator file ready"
+  },
+  "qntIRb": {
+    "message": "If this was not provided, the withdrawal keys will be needed to sign a message declaring a withdrawal address. This requires access to the mnemonic used when setting up the keys."
   },
   "qwh6gM": {
     "message": "I understand the early adopter and slashing risks."
@@ -2716,9 +2731,6 @@
   "rswUPu": {
     "message": "Launchpad summary"
   },
-  "rxttyC": {
-    "message": "Your mnemonic is the backup for your signing keys and will be the ONLY way to withdraw your {TICKER_NAME} when the time comes and no one can help you recover your mnemonic if you lose it."
-  },
   "s6gImC": {
     "message": "Teku can also be configured via a YAML file which is passed in via a few different ways."
   },
@@ -2764,9 +2776,6 @@
   "tWoq1e": {
     "message": "Maximum number of accounts that can be checked in a block. Stops when 16 withdrawals are found. If 16 eligible rewards are not found in the first 16,384 accounts checked, the withdrawal queue for that block will be submitted as is, and the following proposer will pick up where this left off."
   },
-  "taENNR": {
-    "message": "Currently there’s no way for you to re-activate your validator, and you won’t be able to transfer or withdraw your funds until withdrawals are enabled. This is proposed to be included in the next network upgrade, known as the Shanghai upgrade. This means your funds will remain inaccessible at least until then."
-  },
   "tbYkT4": {
     "message": "The Ethereum consensus-layer specification"
   },
@@ -2804,9 +2813,6 @@
   "u28qA1": {
     "message": "After depositing"
   },
-  "u4em9Z": {
-    "message": "Since the Merge, validators will also be responsible for processing transactions, and thus be entitled to unburnt gas fees associated with included transactions when proposing blocks. These fees are accounted for on the execution layer, not the consensus layer, and thus require a traditional Ethereum address to be provided to your client."
-  },
   "u564LK": {
     "message": "Portuguese (Brazilian)"
   },
@@ -2819,6 +2825,9 @@
   "uJzGSb": {
     "message": "Make sure you're aware of how to avoid phishing attacks. We've prepared a list of things to look out for."
   },
+  "uMpYkE": {
+    "message": "If you provided a withdrawal address when initially generating your keys, the withdrawal key no longer has any use. The only address that validator funds can be transferred to is this address, and it cannot be changed once set."
+  },
   "uNfxNg": {
     "message": "To continue, {reconnect}"
   },
@@ -2827,6 +2836,9 @@
   },
   "uUkmGX": {
     "message": "exit epoch"
+  },
+  "uYF99H": {
+    "message": "Although a validator's vote is weighted by the amount it has at stake, each validators voting weight starts at, and is capped at {PRICE_PER_VALIDATOR}. It is possible to drop below this with poor node performance, but it is not possible to raise above it."
   },
   "ubKWX8": {
     "message": "Generate key pairs"
@@ -2878,6 +2890,9 @@
   "vYOWYI": {
     "message": "Chinese (simplified)"
   },
+  "vZxdbJ": {
+    "message": "Once withdrawals are enabled with the Shanghai/Capella update, validators with a maxed our effective balance and a linked execution withdrawal address will have any balance over {PRICE_PER_VALIDATOR} {TICKER_NAME} automatically withdrawal as excess balance."
+  },
   "vbVsqW": {
     "description": "{stakerChecklist} = 'Staker Checklist' bolded to draw attention",
     "message": "Be sure to complete the {stakerChecklist} as soon as possible. And join the EthStaker community for support and discussion with fellow validators."
@@ -2887,6 +2902,9 @@
   },
   "w6qYSU": {
     "message": "Run the following command to launch the app"
+  },
+  "wDlux8": {
+    "message": "You are still able to voluntarily exit your validator to be removed from the active validator set, but until withdrawals are enabled these funds would remain locked and unable to be withdrawn or re-staked."
   },
   "wJ1PbL": {
     "description": "Indicates which operating system the instructions are for",
@@ -2927,9 +2945,6 @@
   },
   "x4/9vY": {
     "message": "We strongly recommended you complete these steps on the current testnet before Mainnet."
-  },
-  "x9xppN": {
-    "message": "With the transition to proof-of-stake complete via the Merge, validators are now responsible for processing transactions and signing off on their validity. This data is {not} available from popular third-party sources since the Merge. Using a third-party provider will result in your validator being offline. When data sharding is implemented, validators will also be at risk of slashing under the {pocGame}."
   },
   "xDyl3T": {
     "description": "{ethereumorg} is a link to deposit contract page on ethereum.org",
@@ -3035,6 +3050,9 @@
   "yw4vsX": {
     "message": "On the other hand, you can be penalized for being offline and behaving maliciously—for example attesting to invalid or contradicting blocks."
   },
+  "z26FXa": {
+    "message": "With the transition to proof-of-stake complete via The Merge, validators are now responsible for processing transactions and signing off on their validity. This data is {not} available from popular third-party sources since The Merge. Using a third-party provider will result in your validator being offline. When data sharding is implemented, validators will also be at risk of slashing under the {pocGame}."
+  },
   "z63I56": {
     "message": "validator"
   },
@@ -3054,15 +3072,15 @@
   "zJicsO": {
     "message": "Staking economics"
   },
+  "zVb+z+": {
+    "message": "Do not deposit more than {PRICE_PER_VALIDATOR} ETH for a single validator. It will not add to your rewards and will be locked until the planned Shanghai/Capella upgrade."
+  },
   "zbEBi9": {
     "description": "{mainnet} shows '--config mainnet' terminal command",
     "message": "Use {mainnet} to sync the Ethereum mainnet."
   },
   "zicXn7": {
     "message": "Node security"
-  },
-  "zkT9Jx": {
-    "message": "We'll help you create a signing key for every validator you want to run. Because there are no withdrawals until the Shanghai upgrade planned to follow the Merge, you will not create your withdrawal keys now. When it is possible to withdraw your funds, you can derive your withdrawal keys from your mnemonic."
   },
   "znyxZv": {
     "message": "~27 hours"

--- a/src/pages/Acknowledgements/pageContent.tsx
+++ b/src/pages/Acknowledgements/pageContent.tsx
@@ -75,7 +75,7 @@ export const pageContent = {
           <FormattedMessage defaultMessage="This is a non-reversible transaction." />
         </Text>
         <Text size="medium" className="my20">
-          <FormattedMessage defaultMessage="Withdrawing your deposit will not be possible until the Shanghai upgrade planned for after the Merge." />
+          <FormattedMessage defaultMessage="Withdrawing your deposit will not be possible until the Shanghai/Capella upgrade planned for Q1/Q2 2023." />
         </Text>
         <Link
           to="https://ethereum.org/en/upgrades/merge/"
@@ -131,6 +131,9 @@ export const pageContent = {
               you will be liable to incur a penalty, known as slashing. Running your validator keys simultaneously on two or more machines will result in slashing."
           />
         </Text>
+        <Text size="medium" className="my10">
+          <FormattedMessage defaultMessage="Simply being offline with an otherwise healthy network does not result in slashing, but will result in small inactivity penalties." />
+        </Text>
         <Link
           to="https://github.com/ethereum/consensus-specs"
           className="my10"
@@ -138,7 +141,7 @@ export const pageContent = {
         >
           <FormattedMessage defaultMessage="The Ethereum consensus-layer specification" />
         </Link>
-        <Link shouldOpenNewTab={true} to="/faq" className="my10" primary>
+        <Link shouldOpenNewTab to="/faq" className="my10" primary>
           <FormattedMessage defaultMessage="More on slashing risks" />
         </Link>
       </>
@@ -155,28 +158,26 @@ export const pageContent = {
     content: (
       <>
         <Text size="medium" className="mt10">
-          <FormattedMessage
-            defaultMessage="To become a validator you'll need to know about managing keys and
-              protecting a mnemonic. If you are not yet familiar with keys and mnemomics, please
-              do not proceed. Note that during this process you will not derive the keys needed to
-              withdraw later, so store your mnemonic safely in order to be able to withdraw later."
-          />
+          <FormattedMessage defaultMessage="To become a validator you'll need to know about managing keys and protecting a mnemonic. If you are not yet familiar with keys and mnemomics, please do not proceed." />
         </Text>
-        <Text size="medium" className="mt20">
-          <FormattedMessage defaultMessage="We'll help you create a signing key for every validator you want to run. Because there are no withdrawals until the Shanghai upgrade planned to follow the Merge, you will not create your withdrawal keys now. When it is possible to withdraw your funds, you can derive your withdrawal keys from your mnemonic." />
+        <Text size="medium" className="mt10">
+          <FormattedMessage defaultMessage="We'll help you create a signing key for every validator you want to run. You may choose to provide a withdrawal address for your validator when generating your deposit data, which will permanently set the withdrawal address." />
         </Text>
-        <Text size="medium" className="mt20">
+        <Text size="medium" className="mt10">
           <FormattedMessage
-            defaultMessage="Your mnemonic is the backup for your signing keys and will be the ONLY way to withdraw your {TICKER_NAME} when the time comes and no one can help you recover your mnemonic if you lose it."
+            defaultMessage="If you do not provide a withdrawal address with your initial deposit data, you will need to derive your withdrawal keys from your mnemonic at a later time, so store your mnemonic safely—it will be the ONLY way to withdraw your {TICKER_NAME} when you chose to activate withdrawals."
             values={{ TICKER_NAME }}
           />
         </Text>
+        <Link to="/withdrawals" className="mt10" primary>
+          <FormattedMessage defaultMessage="More on withdrawals" />
+        </Link>
       </>
     ),
     acknowledgementText: (
       <FormattedMessage
         defaultMessage="I understand that keys are my responsibility and that my mnemonic (seed)
-          will be the {onlyWay} to withdraw my funds."
+          will be the {onlyWay} to withdraw my funds if I don't provide a withdrawal address with initial deposit data."
         values={{
           onlyWay: (
             <BoldCaps>
@@ -188,34 +189,29 @@ export const pageContent = {
     ),
   },
   [AcknowledgementIdsEnum.commitment]: {
-    title: (
-      <FormattedMessage defaultMessage="Validating is a long-term commitment" />
-    ),
+    title: <FormattedMessage defaultMessage="Validating is a commitment" />,
     content: (
       <>
         <Text size="medium" className="my10">
-          <FormattedMessage defaultMessage="Transfers between validators and withdrawals aren't possible yet. Withdrawal functionality is currently a top priority, and is planned to be rolled out in the next network upgrade, known as the Shanghai upgrade." />
+          <FormattedMessage defaultMessage="Withdrawing from a validator is not yet possible. This functionality is planned to be included in the Shanghai/Capella upgrade planned for Q1/Q2 2023." />
         </Text>
-        <Link
-          to="https://ethereum.org/en/upgrades/merge"
-          className="my10"
-          primary
-        >
-          <FormattedMessage defaultMessage="More on the merge" />
+        <Text size="medium" className="my10">
+          <FormattedMessage defaultMessage="You can prepare for this by providing a withdrawal address when generating your keys and deposit data." />
+        </Text>
+        <Text size="medium" className="my10">
+          <FormattedMessage defaultMessage="You are still able to voluntarily exit your validator to be removed from the active validator set, but until withdrawals are enabled these funds would remain locked and unable to be withdrawn or re-staked." />
+        </Text>
+        <Link to="/withdrawals" className="my10" primary>
+          <FormattedMessage defaultMessage="More on withdrawals" />
         </Link>
         <Text size="medium" className="my10">
-          <FormattedMessage
-            defaultMessage="With transfers disabled for now, you won't be able to voluntarily exit
-            and then restart later. This means you need to be in it for the long haul."
-          />
+          <FormattedMessage defaultMessage="Note, there are no current plans to enable transfers of ETH between validators." />
         </Text>
       </>
     ),
     acknowledgementText: (
       <FormattedMessage
-        defaultMessage="I understand that I {cannotTransfer} my stake for a while, and I
-          {cannotWithdraw} until the Shanghai upgrade. I understand that if I exit, I
-          will not be able to rejoin until that time. This is a long term commitment."
+        defaultMessage="I understand that I {cannotWithdraw} my stake until the Shanghai/Capella upgrade, and I {cannotTransfer} {TICKER_NAME} between validators. I understand that if I exit, I will not be able to rejoin until that time. Staking is a commitment."
         values={{
           cannotTransfer: (
             <BoldCaps>
@@ -227,6 +223,7 @@ export const pageContent = {
               <FormattedMessage defaultMessage="cannot withdraw" />
             </BoldCaps>
           ),
+          TICKER_NAME,
         }}
       />
     ),
@@ -271,19 +268,25 @@ export const pageContent = {
         <Text size="medium" className="my10">
           <FormattedMessage defaultMessage="Please review the staking checklist prior to proceeding. Use this as a guide to check off tasks as you complete validator setup." />
         </Text>
+        <Link inline shouldOpenNewTab to="/checklist" className="my10" primary>
+          <FormattedMessage defaultMessage="Validator checklist" />
+        </Link>
+        <Text size="medium" className="my20">
+          <FormattedMessage defaultMessage="Also be sure you understand how staking withdrawals work before setting up your keys and deposit data." />
+        </Text>
         <Link
           inline
-          shouldOpenNewTab={true}
-          to="/checklist"
+          shouldOpenNewTab
+          to="/withdrawals"
           className="my10"
           primary
         >
-          <FormattedMessage defaultMessage="Validator checklist" />
+          <FormattedMessage defaultMessage="Staking withdrawals" />
         </Link>
       </>
     ),
     acknowledgementText: (
-      <FormattedMessage defaultMessage="I have reviewed the checklist." />
+      <FormattedMessage defaultMessage="I have reviewed the checklist and understand how withdrawals work." />
     ),
   },
   [AcknowledgementIdsEnum.confirmation]: {
@@ -295,7 +298,7 @@ export const pageContent = {
         </Text>
         <Link
           inline
-          shouldOpenNewTab={true}
+          shouldOpenNewTab
           to="/terms-of-service"
           className="my10"
           primary

--- a/src/pages/Checklist/index.tsx
+++ b/src/pages/Checklist/index.tsx
@@ -1160,7 +1160,7 @@ export const Checklist = () => {
                 <Text className="checkbox-label mb10">
                   <FormattedMessage
                     defaultMessage="If not, I've submitted a {btec} message signed with my BLS withdrawal keys to update my withdrawal credentials (requires Shanghai/Capella upgrade)."
-                    values={{ btec: <Code>BLS_To_Execution_Change</Code> }}
+                    values={{ btec: <Code>BLSToExecutionChange</Code> }}
                   />
                 </Text>
               </div>

--- a/src/pages/FAQ/index.jsx
+++ b/src/pages/FAQ/index.jsx
@@ -6,7 +6,7 @@ import { Link } from '../../components/Link';
 import { PageTemplate } from '../../components/PageTemplate';
 import { Heading } from '../../components/Heading';
 import { Text } from '../../components/Text';
-import { PRICE_PER_VALIDATOR } from '../../utils/envVars';
+import { PRICE_PER_VALIDATOR, TICKER_NAME } from '../../utils/envVars';
 
 const FAQStyles = styled.div`
   section {
@@ -14,6 +14,10 @@ const FAQStyles = styled.div`
   }
   a {
     text-decoration: none;
+  }
+  ul {
+    color: ${p => p.theme.blue.dark};
+    font-family: 'inherit';
   }
 `;
 
@@ -149,6 +153,12 @@ export const FAQ = () => {
                 }}
               />
             </Text>
+            <Text className="mt10">
+              <FormattedMessage
+                defaultMessage="Once withdrawals are enabled with the Shanghai/Capella update, validators with a maxed our effective balance and a linked execution withdrawal address will have any balance over {PRICE_PER_VALIDATOR} {TICKER_NAME} automatically withdrawal as excess balance."
+                values={{ PRICE_PER_VALIDATOR, TICKER_NAME }}
+              />
+            </Text>
           </section>
           <section>
             <Heading level={4}>
@@ -177,29 +187,19 @@ export const FAQ = () => {
             </Text>
             <Text className="mt20 mb20">
               <FormattedMessage
-                defaultMessage="Although a validator's vote is weighted by the amount it has at stake, each validators voting weight starts at, and is capped at {pricePerValidator}. It is possible to drop below this with poor node performance, but it is not possible to raise above it."
-                values={{
-                  pricePerValidator: PRICE_PER_VALIDATOR,
-                }}
+                defaultMessage="Although a validator's vote is weighted by the amount it has at stake, each validators voting weight starts at, and is capped at {PRICE_PER_VALIDATOR}. It is possible to drop below this with poor node performance, but it is not possible to raise above it."
+                values={{ PRICE_PER_VALIDATOR }}
               />
             </Text>
             <Text className="mt10">
               <FormattedMessage
-                defaultMessage="Do not deposit more than {pricePerValidator} ETH for a single validator. It will not add to your rewards and will be locked until the planned {shanghai} update."
-                values={{
-                  pricePerValidator: PRICE_PER_VALIDATOR,
-                  shanghai: (
-                    <Link
-                      inline
-                      primary
-                      to="https://github.com/ethereum/pm/issues/450"
-                    >
-                      Shanghai
-                    </Link>
-                  ),
-                }}
+                defaultMessage="Do not deposit more than {PRICE_PER_VALIDATOR} ETH for a single validator. It will not add to your rewards and will be locked until the planned Shanghai/Capella upgrade."
+                values={{ PRICE_PER_VALIDATOR }}
               />
             </Text>
+            <Link to="/withdrawals" primary className="mt20">
+              <FormattedMessage defaultMessage="More on withdrawals" />
+            </Link>
           </section>
           <section>
             <Heading level={4}>
@@ -280,12 +280,12 @@ export const FAQ = () => {
             </Text>
             <Text className="mt10">
               <FormattedMessage
-                defaultMessage="However, bear in mind that for the foreseeable future, once
+                defaultMessage="However, bear in mind that until the Shanghai/Capella upgrade planned for Q1/Q2 2023, once
                   you’ve exited, there’s no going back."
               />
             </Text>
             <Text className="mt10">
-              <FormattedMessage defaultMessage="Currently there’s no way for you to re-activate your validator, and you won’t be able to transfer or withdraw your funds until withdrawals are enabled. This is proposed to be included in the next network upgrade, known as the Shanghai upgrade. This means your funds will remain inaccessible at least until then." />
+              <FormattedMessage defaultMessage="Currently there’s no way for you to re-activate your validator, and you won’t be able to transfer or withdraw your funds until withdrawals are enabled with the Shanghai/Capella upgrade. This means your funds will remain inaccessible at least until then." />
               <Link
                 className="mt20"
                 to="https://ethereum-magicians.org/t/shanghai-core-eip-consideration/10777"
@@ -293,11 +293,7 @@ export const FAQ = () => {
               >
                 <FormattedMessage defaultMessage="Shanghai Core EIP Consideration" />
               </Link>
-              <Link
-                className="mt20"
-                to="https://github.com/ethereum/pm/issues/450"
-                primary
-              >
+              <Link to="https://github.com/ethereum/pm/issues/450" primary>
                 <FormattedMessage defaultMessage="Shanghai Planning (GitHub issue)" />
               </Link>
             </Text>
@@ -365,8 +361,8 @@ export const FAQ = () => {
               <FormattedMessage defaultMessage="As a staker you are required to maintain and operate a node, running BOTH a consensus client AND an execution client." />
             </Text>
             <BlockQuote>
-              <Text className="mt20 mb20">
-                <FormattedMessage defaultMessage="This became a requirement at time of the Merge, so be sure you're running both before staking." />
+              <Text className="my20">
+                <FormattedMessage defaultMessage="This became a requirement at time of The Merge, so be sure you're running both before staking." />
               </Text>
             </BlockQuote>
             <Link primary to="/checklist">
@@ -387,7 +383,7 @@ export const FAQ = () => {
             </Text>
             <Text className="mt10">
               <FormattedMessage
-                defaultMessage="With the transition to proof-of-stake complete via the Merge, validators are now responsible for processing transactions and signing off on their validity. This data is {not} available from popular third-party sources since the Merge. Using a third-party provider will result in your validator being offline. When data sharding is implemented, validators will also be at risk of slashing under the {pocGame}."
+                defaultMessage="With the transition to proof-of-stake complete via The Merge, validators are now responsible for processing transactions and signing off on their validity. This data is {not} available from popular third-party sources since The Merge. Using a third-party provider will result in your validator being offline. When data sharding is implemented, validators will also be at risk of slashing under the {pocGame}."
                 values={{
                   not: (
                     <em>
@@ -472,8 +468,8 @@ export const FAQ = () => {
               />
             </Text>
             <BlockQuote>
-              <Text className="mt20 mb20">
-                <FormattedMessage defaultMessage="Since the Merge, validators will also be responsible for processing transactions, and thus be entitled to unburnt gas fees associated with included transactions when proposing blocks. These fees are accounted for on the execution layer, not the consensus layer, and thus require a traditional Ethereum address to be provided to your client." />
+              <Text className="my20">
+                <FormattedMessage defaultMessage="Since The Merge, validators will also be responsible for processing transactions, and thus be entitled to unburnt gas fees associated with included transactions when proposing blocks. These fees are accounted for on the execution layer, not the consensus layer, and thus require a traditional Ethereum address to be provided to your client." />
               </Text>
             </BlockQuote>
             <Text className="mt10">
@@ -488,7 +484,7 @@ export const FAQ = () => {
             </Heading>
             <Text className="mt10">
               <FormattedMessage
-                defaultMessage="Rewards and penalties are issued roughly every six and a half minutes—a period of time
+                defaultMessage="Rewards and penalties are issued every 6.4 minutes—a period of time
                   known as an epoch."
               />
             </Text>
@@ -499,9 +495,9 @@ export const FAQ = () => {
               />
             </Text>
             <BlockQuote>
-              <Text className="mt10">
+              <Text className="my20">
                 <FormattedMessage
-                  defaultMessage="Your validator will also receive unburnt gas fees when proposing blocks. Validators are chosen randomly by the protocol to propose blocks, and only one validator can propose a block for each 12-second slot. There are 7200 slots each day, so each validator has 7200 chances-per-day to propose a block. If there are 360,000 validators, each validator will {average} a block proposal every 50 days. "
+                  defaultMessage="Your validator will also receives unburnt gas fees when proposing blocks. Validators are chosen randomly by the protocol to propose blocks, and only one validator can propose a block for each 12-second slot. There are 7200 slots each day, so each validator has 7200 chances-per-day to propose a block. If there are 500,000 validators, each validator will {average} a block proposal every 70 days. "
                   values={{
                     average: (
                       <em>
@@ -541,7 +537,7 @@ export const FAQ = () => {
               />
             </Text>
             <BlockQuote>
-              <Text className="mt10">
+              <Text className="my20">
                 <FormattedMessage
                   defaultMessage="Note however that this scaling mechanism works in a non-obvious
                     way. To understand the precise details of how it works requires
@@ -673,7 +669,7 @@ export const FAQ = () => {
               </li>
             </ol>
             <BlockQuote>
-              <Text className="mt10">
+              <Text className="my20">
                 <FormattedMessage
                   defaultMessage="Note that in the second (unlikely) scenario, you stand to
                     progressively lose up to 50% (16 ETH) of your stake over 21
@@ -787,7 +783,7 @@ export const FAQ = () => {
               <li>
                 <Text className="mt10">
                   <FormattedMessage
-                    defaultMessage="BLS withdrawal: By default, deposit-cli would generate withdrawal credentials with the {boldWithdrawalKey} derived via mnemonics in {eip2334} format."
+                    defaultMessage="BLS withdrawal: By default, the deposit-cli would generate withdrawal credentials with the {boldWithdrawalKey} derived via mnemonics in {eip2334} format."
                     values={{
                       boldWithdrawalKey: (
                         <strong>
@@ -812,7 +808,7 @@ export const FAQ = () => {
               <li>
                 <Text className="mt10">
                   <FormattedMessage
-                    defaultMessage="Ethereum address withdrawal: If you want to withdraw to your Mainnet wallet address (formerly 'Eth1' address) after the post-merge cleanup upgrade, you can set {ethAddressWithdraw} when running deposit-cli. {boldWarning}"
+                    defaultMessage="Ethereum address withdrawal: If you want to withdraw to your execution wallet address after the Shanghai/Capella upgrade, you can set {ethAddressWithdraw} when running deposit-cli. {boldWarning}"
                     values={{
                       ethAddressWithdraw: (
                         <code>
@@ -867,7 +863,7 @@ export const FAQ = () => {
               />
             </Text>
             <BlockQuote>
-              <Text className="mt10">
+              <Text className="my20">
                 <FormattedMessage
                   defaultMessage="However, all is not lost. Assuming you derive your keys
                     using {eip2334} (as per the default onboarding flow) then {strongText}."
@@ -895,10 +891,13 @@ export const FAQ = () => {
               </Text>
             </BlockQuote>
             <Text className="mt10">
-              <FormattedMessage defaultMessage="Withdrawal features are proposed to be included in the upcoming Shanghai upgrade. After this functionality is added, your balance can then be withdrawn—with your withdrawal key—after a minimum delay of around a day." />
+              <FormattedMessage defaultMessage="Withdrawal features are planned to be included in the upcoming Shanghai/Capella upgrade. After this functionality is added, your balance can then be withdrawn—with your withdrawal key—after a minimum delay of around a day." />
+              Withdrawal features are planned ot be included in the upcoming
+              Shanghai/Capella upgrade. After this functionality is addes, your
+              balance
             </Text>
             <BlockQuote>
-              <Text className="mt10">
+              <Text className="my20">
                 <FormattedMessage
                   defaultMessage="Note that this delay can be longer if many others are exiting or
                     being kicked out at the same time."
@@ -919,7 +918,7 @@ export const FAQ = () => {
             <Text className="mt10">
               <FormattedMessage
                 defaultMessage="As such, it’s a good idea to create your keys from mnemonics which
-                  act as another backup. This will be the default for validators who
+                  act as another backup. This is the default for validators who
                   join via this site’s onboarding process."
               />
             </Text>
@@ -929,16 +928,13 @@ export const FAQ = () => {
               <FormattedMessage defaultMessage="What happens if my withdrawal key is stolen?" />
             </Heading>
             <Text className="mt10">
-              <FormattedMessage
-                defaultMessage="If your withdrawal key is stolen, the thief can transfer your
-                  validator’s balance, but only once the validator has exited."
-              />
+              <FormattedMessage defaultMessage="If you provided a withdrawal address when initially generating your keys, the withdrawal key no longer has any use. The only address that validator funds can be transferred to is this address, and it cannot be changed once set." />
             </Text>
             <Text className="mt10">
-              <FormattedMessage defaultMessage="If your signing key is not under the thief’s control, the thief cannot exit your validator." />
+              <FormattedMessage defaultMessage="If this was not provided, the withdrawal keys will be needed to sign a message declaring a withdrawal address. This requires access to the mnemonic used when setting up the keys." />
             </Text>
             <Text className="mt10">
-              <FormattedMessage defaultMessage="With your signing key, you could attempt to quickly exit the validator and then transfer the funds—with the withdrawal key—before the thief." />
+              <FormattedMessage defaultMessage="If a withdrawal address has not been set, and you have lost access to the mnemonic seed phrase, your funds will remain locked in the validator account indefinitely." />
             </Text>
           </section>
           <section>

--- a/src/pages/GenerateKeys/Option1.tsx
+++ b/src/pages/GenerateKeys/Option1.tsx
@@ -142,7 +142,7 @@ export const Option1 = ({
                   })
                 : 'chain'
             } ${NETWORK_NAME.toLowerCase()}`}{' '}
-            {withdrawalAddress.length &&
+            {withdrawalAddress &&
               `--${
                 TRANSLATE_CLI_FLAGS
                   ? formatMessage({

--- a/src/pages/Withdrawals/index.tsx
+++ b/src/pages/Withdrawals/index.tsx
@@ -208,6 +208,23 @@ export const Withdrawals = () => {
                   />
                 </li>
               </ul>
+              <Text className="mt20">
+                <FormattedMessage
+                  defaultMessage="Note that your {withdrawalCredentials} are not the same as your {feeRecipient}, which receives transaction fees from proposed. These can both be set to the same address, but must each be set separately."
+                  values={{
+                    withdrawalCredentials: (
+                      <strong>
+                        <FormattedMessage defaultMessage="withdrawal credentials" />
+                      </strong>
+                    ),
+                    feeRecipient: (
+                      <strong>
+                        <FormattedMessage defaultMessage="fee recipient" />
+                      </strong>
+                    ),
+                  }}
+                />
+              </Text>
             </section>
 
             <section className="actionable">
@@ -270,7 +287,7 @@ export const Withdrawals = () => {
                     defaultMessage="As noted above, this step is completed by signing a message known as {message}.
                     These are accepted into blocks as of the first slot after the Shanghai/Capella
                     upgrade."
-                    values={{ message: <Code>BLS_To_Execution_Change</Code> }}
+                    values={{ message: <Code>BLSToExecutionChange</Code> }}
                   />
                 </Text>
                 <Text className="mb10">


### PR DESCRIPTION
## Description
After adding the staking withdrawals page in #580, this PR addresses the remainder of the website by finding outdated content related to withdrawals and updating with the latest information.

This content is intended to be phrased with Shanghai/Capella still in the future, with noted timing of Q1/Q2 2023. There will be a PR to follow for _post_-Shanghai updates, which will then rephrase content once the upgrade has officially gone live.

- Updates deposit wizard acknowledgments copy
- Updates FAQ copy
- Couple small content patches on `/withdrawals` page
- Patches trailing `0` that was inappropriately rendering when user does not include a withdrawal address

## Related issue
- #577