### PR TITLE
[Patch] check for array type on beaconcha.in response

### DIFF
--- a/src/components/WithdrawalCredentials.tsx
+++ b/src/components/WithdrawalCredentials.tsx
@@ -287,7 +287,9 @@ export const WithdrawalCredentials: FC<IProps> = () => {
     try {
       const response = await fetch(endpoint);
       const { data } = await response.json();
-      const withdrawalCredentials = data.withdrawalcredentials;
+      const withdrawalCredentials = data.length
+        ? data[0].withdrawalcredentials
+        : data.withdrawalcredentials;
       setValidator({
         validatorIndex: parseInt(inputValue, 10),
         withdrawalCredentials,


### PR DESCRIPTION
## Description
Recent change to beaconcha.in API endpoint returns either an object or an array of objects, depending on the network being utilized.

This surfaced on the Zhejiang Withdrawals page in the credentials check widget, where the responses were no longer being parsed properly.

PR checks for `.length` property of `data` to differentiate between and object and an array, then parses out the first item in the case of an array.

## Screenshots
Issue:
<img width="609" alt="image" src="https://user-images.githubusercontent.com/54227730/224123329-39b7aa63-dcbc-45ab-b24f-b27f7b749e39.png">

Patch:
<img width="1026" alt="image" src="https://user-images.githubusercontent.com/54227730/224123573-09644032-1a59-4601-9d8f-d02547e69bb0.png">
