### PR TITLE
Update to "Command line with flags" example

### DIFF
--- a/src/pages/BtecGuide/index.tsx
+++ b/src/pages/BtecGuide/index.tsx
@@ -375,7 +375,7 @@ export const BtecGuide = () => {
                 </span>
                 <br />
                 <span className="dimmed">
-                  --bls_withdrawal_credentials_list="0x00bd0b5a34de5fb17df08410b5e615dda87caf4fb72d0aac91ce5e52fc6aa8de,0x00a75d83f169fa6923f3dd78386d9608fab710d8f7fcf71ba9985893675d5382"
+                  --bls_withdrawal_credentials_list="00bd0b5a34de5fb17df08410b5e615dda87caf4fb72d0aac91ce5e52fc6aa8de,00a75d83f169fa6923f3dd78386d9608fab710d8f7fcf71ba9985893675d5382"
                   \
                 </span>
                 <br />


### PR DESCRIPTION
The example includes the "0x" prefix when specifying the withdrawal credentials - the "0x" prefix should not be included. If the "0x" prefix is included in the credentials list then the user will see an error. Fixes issues #621.