### PR TITLE
Extract missing strings for translation

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -1103,6 +1103,20 @@
       "value": " at any time during your setup for some friendly help!"
     }
   ],
+  "5v36Is": [
+    {
+      "type": 0,
+      "value": "Exiting a "
+    },
+    {
+      "type": 1,
+      "value": "client"
+    },
+    {
+      "type": 0,
+      "value": " validator"
+    }
+  ],
   "63gLLu": [
     {
       "type": 0,
@@ -1833,6 +1847,12 @@
       "value": "Download MetaMask"
     }
   ],
+  "BQXsbH": [
+    {
+      "type": 0,
+      "value": "The key start index in EIP-2334"
+    }
+  ],
   "BUFaRV": [
     {
       "type": 0,
@@ -1873,6 +1893,12 @@
     {
       "type": 0,
       "value": "How to trigger withdrawals, credential change"
+    }
+  ],
+  "Bxe+HB": [
+    {
+      "type": 0,
+      "value": "Genesis validator root"
     }
   ],
   "C/gb74": [
@@ -2359,6 +2385,12 @@
       "value": ", otherwise the deposit will be invalid."
     }
   ],
+  "FZCdw+": [
+    {
+      "type": 0,
+      "value": "Your validator indices"
+    }
+  ],
   "FZa0R+": [
     {
       "type": 0,
@@ -2519,6 +2551,12 @@
       "value": "Make the file you just downloaded executable."
     }
   ],
+  "Ght9ln": [
+    {
+      "type": 0,
+      "value": "Genesis fork version"
+    }
+  ],
   "GlKjxX": [
     {
       "type": 0,
@@ -2635,6 +2673,12 @@
       "value": "Network"
     }
   ],
+  "I3hwdP": [
+    {
+      "type": 0,
+      "value": "Changing withdrawal credentials"
+    }
+  ],
   "I5lWZA": [
     {
       "type": 0,
@@ -2663,6 +2707,12 @@
     {
       "type": 0,
       "value": "Note that in the second (unlikely) scenario, you stand to progressively lose up to 50% (16 ETH) of your stake over 21 days. After 21 days you are ejected out of the validator pool. This ensures that blocks start finalizing again at some point."
+    }
+  ],
+  "IWlazt": [
+    {
+      "type": 0,
+      "value": "full withdrawal"
     }
   ],
   "IYvwsI": [
@@ -2835,6 +2885,12 @@
     {
       "type": 0,
       "value": "What is your current operating system?"
+    }
+  ],
+  "Jvu600": [
+    {
+      "type": 0,
+      "value": "Your mnemonic"
     }
   ],
   "K3uH1C": [
@@ -3435,28 +3491,6 @@
       "value": ")"
     }
   ],
-  "NpIOoJ": [
-    {
-      "type": 0,
-      "value": "To make this message to be included in Mainnet, you will need to upload this message to a beacon node’s "
-    },
-    {
-      "type": 1,
-      "value": "signature"
-    },
-    {
-      "type": 0,
-      "value": " pool "
-    },
-    {
-      "type": 1,
-      "value": "after"
-    },
-    {
-      "type": 0,
-      "value": " Capella/Shanghai hard fork."
-    }
-  ],
   "NwzcYT": [
     {
       "type": 0,
@@ -3649,6 +3683,12 @@
     {
       "type": 0,
       "value": "Your network has changed"
+    }
+  ],
+  "PHZO0L": [
+    {
+      "type": 0,
+      "value": "Launchpad walkthrough tutorial"
     }
   ],
   "PQgBnI": [
@@ -4827,6 +4867,20 @@
       "value": "Why do I need to have funds at stake?"
     }
   ],
+  "ZQo9kO": [
+    {
+      "type": 0,
+      "value": "Exiting a "
+    },
+    {
+      "type": 1,
+      "value": "software"
+    },
+    {
+      "type": 0,
+      "value": " minipool"
+    }
+  ],
   "ZTo0Fl": [
     {
       "type": 0,
@@ -5973,10 +6027,46 @@
       "value": "Formerly known as Artemis, Teku is a consensus client built to meet institutional needs and security requirements. PegaSys is an arm of ConsenSys, dedicated to building enterprise-ready clients and tools for interacting with the core Ethereum platform."
     }
   ],
+  "jBr8vs": [
+    {
+      "type": 0,
+      "value": "The execution address for withdrawals"
+    }
+  ],
   "jGVfQG": [
     {
       "type": 0,
       "value": "Four (4) validator exits are allowed per epoch, plus one (1) more for every 65,536 total active validators over 327,680. As of February 2023 this limit is seven (7), and will increase to eight (8) if/when the validator count reaches 524,288."
+    }
+  ],
+  "jHrZXR": [
+    {
+      "type": 0,
+      "value": "To enable your Beacon Chain validator(s) to automatically withdraw balances to your "
+    },
+    {
+      "type": 1,
+      "value": "exeuctionAddress"
+    },
+    {
+      "type": 0,
+      "value": ", you can use the staking deposit CLI ("
+    },
+    {
+      "type": 1,
+      "value": "cli"
+    },
+    {
+      "type": 0,
+      "value": ") tool to generate the signed BLS-to-execution-change ("
+    },
+    {
+      "type": 1,
+      "value": "signed"
+    },
+    {
+      "type": 0,
+      "value": ") message JSON file. This message includes the request to change your old BLS withdrawal credentials to the new withdrawal credentials in execution address format."
     }
   ],
   "jXer8/": [
@@ -6155,6 +6245,12 @@
     {
       "type": 0,
       "value": "Teku documentation"
+    }
+  ],
+  "ka+Ucy": [
+    {
+      "type": 0,
+      "value": "Network name"
     }
   ],
   "kd/f4u": [
@@ -6391,6 +6487,12 @@
       "value": "Importing from Launchpad documentation"
     }
   ],
+  "ljGIvm": [
+    {
+      "type": 0,
+      "value": "Filename destination"
+    }
+  ],
   "ll/zMW": [
     {
       "type": 0,
@@ -6589,6 +6691,28 @@
     {
       "type": 0,
       "value": "Once you're comfortable, you'll go through generating your keys and depositing your ETH."
+    }
+  ],
+  "nf2aBN": [
+    {
+      "type": 0,
+      "value": "To make this message to be included in Mainnet, you will need to upload this message to a beacon node’s message ("
+    },
+    {
+      "type": 1,
+      "value": "signature"
+    },
+    {
+      "type": 0,
+      "value": ") pool "
+    },
+    {
+      "type": 1,
+      "value": "after"
+    },
+    {
+      "type": 0,
+      "value": " Capella/Shanghai hard fork."
     }
   ],
   "njAU72": [
@@ -6923,36 +7047,6 @@
       "value": "Exit epoch and withdrawable epoch"
     }
   ],
-  "qIDtPw": [
-    {
-      "type": 0,
-      "value": "To enable your Beacon Chain validator(s) to automatically withdraw balances to your "
-    },
-    {
-      "type": 1,
-      "value": "exeuctionAddress"
-    },
-    {
-      "type": 0,
-      "value": ", you can use the "
-    },
-    {
-      "type": 1,
-      "value": "cli"
-    },
-    {
-      "type": 0,
-      "value": " tool to generate the "
-    },
-    {
-      "type": 1,
-      "value": "signed"
-    },
-    {
-      "type": 0,
-      "value": " message JSON file. This message includes the request to change your old BLS withdrawal credentials to the new withdrawal credentials in execution address format."
-    }
-  ],
   "qK4+NQ": [
     {
       "type": 0,
@@ -6999,6 +7093,20 @@
     {
       "type": 0,
       "value": "Save the key files and get the validator file ready"
+    }
+  ],
+  "qlwUud": [
+    {
+      "type": 0,
+      "value": "Exiting a "
+    },
+    {
+      "type": 1,
+      "value": "software"
+    },
+    {
+      "type": 0,
+      "value": " validator"
     }
   ],
   "qntIRb": [
@@ -7957,6 +8065,12 @@
     {
       "type": 0,
       "value": "On the other hand, you can be penalized for being offline and behaving maliciously—for example attesting to invalid or contradicting blocks."
+    }
+  ],
+  "yzvSUC": [
+    {
+      "type": 0,
+      "value": "Your old BLS withdrawal credentials"
     }
   ],
   "z26FXa": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -413,6 +413,9 @@
     "description": "{variables} are social media platform links to Discord and Reddit (do not translate names)",
     "message": "Visit EthStaker on {discord} or {reddit} at any time during your setup for some friendly help!"
   },
+  "5v36Is": {
+    "message": "Exiting a {client} validator"
+  },
   "63gLLu": {
     "message": "average"
   },
@@ -692,6 +695,9 @@
   "BPpnlJ": {
     "message": "Download MetaMask"
   },
+  "BQXsbH": {
+    "message": "The key start index in EIP-2334"
+  },
   "BUFaRV": {
     "message": "EthStaker community"
   },
@@ -712,6 +718,9 @@
   },
   "Bp9Dxf": {
     "message": "How to trigger withdrawals, credential change"
+  },
+  "Bxe+HB": {
+    "message": "Genesis validator root"
   },
   "C/gb74": {
     "message": "Configure Lighthouse"
@@ -893,6 +902,9 @@
     "description": "{flag} is a terminal command styled as code.",
     "message": "Make sure you have set {flag} for {consensusLayerName}, otherwise the deposit will be invalid."
   },
+  "FZCdw+": {
+    "message": "Your validator indices"
+  },
   "FZa0R+": {
     "message": "This scenario is very extreme and unlikely to happen."
   },
@@ -965,6 +977,9 @@
   "GelBd9": {
     "message": "Make the file you just downloaded executable."
   },
+  "Ght9ln": {
+    "message": "Genesis fork version"
+  },
   "GlKjxX": {
     "message": "You should see that you have one keystore per validator. This keystore contains your signing key, encrypted with your password."
   },
@@ -1014,6 +1029,9 @@
   "I3JhPS": {
     "message": "Network"
   },
+  "I3hwdP": {
+    "message": "Changing withdrawal credentials"
+  },
   "I5lWZA": {
     "message": "Can I change the withdrawal credentials of my validator after the first deposit?"
   },
@@ -1028,6 +1046,9 @@
   },
   "IVyWYt": {
     "message": "Note that in the second (unlikely) scenario, you stand to progressively lose up to 50% (16 ETH) of your stake over 21 days. After 21 days you are ejected out of the validator pool. This ensures that blocks start finalizing again at some point."
+  },
+  "IWlazt": {
+    "message": "full withdrawal"
   },
   "IYvwsI": {
     "message": "Tools available for generating key change message"
@@ -1096,6 +1117,9 @@
   },
   "JtAiN/": {
     "message": "What is your current operating system?"
+  },
+  "Jvu600": {
+    "message": "Your mnemonic"
   },
   "K3uH1C": {
     "message": "offline"
@@ -1330,9 +1354,6 @@
   "NkFxlX": {
     "message": "At least {time} (four epochs) from the current epoch before reaching the exit epoch (with no others in the queue, {highlyVariable})"
   },
-  "NpIOoJ": {
-    "message": "To make this message to be included in Mainnet, you will need to upload this message to a beacon node’s {signature} pool {after} Capella/Shanghai hard fork."
-  },
   "NwzcYT": {
     "message": "Teku needs to be pointed at files containing keystores and their associated passwords at startup. There are 3 methods for doing so."
   },
@@ -1396,6 +1417,9 @@
   },
   "P9mVZK": {
     "message": "Your network has changed"
+  },
+  "PHZO0L": {
+    "message": "Launchpad walkthrough tutorial"
   },
   "PQgBnI": {
     "message": "This epoch is determined by the first available epoch that isn't already maxed out with other validators exiting (rate limit depends on total validators on the network), and must be at least four (4) epochs after the exit was initiated."
@@ -1839,6 +1863,10 @@
   },
   "ZOXuIe": {
     "message": "Why do I need to have funds at stake?"
+  },
+  "ZQo9kO": {
+    "description": "A minipool is a Rocket Pool-specific term for a validator that shares stake with others",
+    "message": "Exiting a {software} minipool"
   },
   "ZTo0Fl": {
     "message": "Why is there a wait?"
@@ -2310,8 +2338,14 @@
   "j8GPOH": {
     "message": "Formerly known as Artemis, Teku is a consensus client built to meet institutional needs and security requirements. PegaSys is an arm of ConsenSys, dedicated to building enterprise-ready clients and tools for interacting with the core Ethereum platform."
   },
+  "jBr8vs": {
+    "message": "The execution address for withdrawals"
+  },
   "jGVfQG": {
     "message": "Four (4) validator exits are allowed per epoch, plus one (1) more for every 65,536 total active validators over 327,680. As of February 2023 this limit is seven (7), and will increase to eight (8) if/when the validator count reaches 524,288."
+  },
+  "jHrZXR": {
+    "message": "To enable your Beacon Chain validator(s) to automatically withdraw balances to your {exeuctionAddress}, you can use the staking deposit CLI ({cli}) tool to generate the signed BLS-to-execution-change ({signed}) message JSON file. This message includes the request to change your old BLS withdrawal credentials to the new withdrawal credentials in execution address format."
   },
   "jXer8/": {
     "message": "Prysm documentation"
@@ -2388,6 +2422,9 @@
   },
   "kZ1+zq": {
     "message": "Teku documentation"
+  },
+  "ka+Ucy": {
+    "message": "Network name"
   },
   "kd/f4u": {
     "message": "Key list"
@@ -2473,6 +2510,9 @@
   "lfV1bj": {
     "message": "Importing from Launchpad documentation"
   },
+  "ljGIvm": {
+    "message": "Filename destination"
+  },
   "ll/zMW": {
     "message": "This is a non-reversible transaction."
   },
@@ -2556,6 +2596,9 @@
   },
   "ndhFef": {
     "message": "Once you're comfortable, you'll go through generating your keys and depositing your ETH."
+  },
+  "nf2aBN": {
+    "message": "To make this message to be included in Mainnet, you will need to upload this message to a beacon node’s message ({signature}) pool {after} Capella/Shanghai hard fork."
   },
   "njAU72": {
     "message": "French"
@@ -2692,9 +2735,6 @@
   "qBorVY": {
     "message": "Exit epoch and withdrawable epoch"
   },
-  "qIDtPw": {
-    "message": "To enable your Beacon Chain validator(s) to automatically withdraw balances to your {exeuctionAddress}, you can use the {cli} tool to generate the {signed} message JSON file. This message includes the request to change your old BLS withdrawal credentials to the new withdrawal credentials in execution address format."
-  },
   "qK4+NQ": {
     "message": "The terminal"
   },
@@ -2718,6 +2758,9 @@
   },
   "qkhah0": {
     "message": "Save the key files and get the validator file ready"
+  },
+  "qlwUud": {
+    "message": "Exiting a {software} validator"
   },
   "qntIRb": {
     "message": "If this was not provided, the withdrawal keys will be needed to sign a message declaring a withdrawal address. This requires access to the mnemonic used when setting up the keys."
@@ -3088,6 +3131,9 @@
   },
   "yw4vsX": {
     "message": "On the other hand, you can be penalized for being offline and behaving maliciously—for example attesting to invalid or contradicting blocks."
+  },
+  "yzvSUC": {
+    "message": "Your old BLS withdrawal credentials"
   },
   "z26FXa": {
     "message": "With the transition to proof-of-stake complete via The Merge, validators are now responsible for processing transactions and signing off on their validity. This data is {not} available from popular third-party sources since The Merge. Using a third-party provider will result in your validator being offline. When data sharding is implemented, validators will also be at risk of slashing under the {pocGame}."

--- a/src/pages/BtecGuide/index.tsx
+++ b/src/pages/BtecGuide/index.tsx
@@ -57,6 +57,7 @@ const CodeBlock = styled.code`
   }
   .custom {
     color: ${(p: any) => p.theme.red.medium};
+    text-transform: uppercase;
   }
 `;
 
@@ -142,7 +143,7 @@ export const BtecGuide = () => {
           <Text className="mb10">
             <FormattedMessage
               defaultMessage="To enable your Beacon Chain validator(s) to automatically withdraw balances to your
-              {exeuctionAddress}, you can use the {cli} tool to generate the {signed} message JSON file. This message
+              {exeuctionAddress}, you can use the staking deposit CLI ({cli}) tool to generate the signed BLS-to-execution-change ({signed}) message JSON file. This message
               includes the request to change your old BLS withdrawal credentials to the new withdrawal credentials in
               execution address format."
               values={{
@@ -159,7 +160,7 @@ export const BtecGuide = () => {
           <Text className="mb10">
             <FormattedMessage
               defaultMessage="To make this message to be included in Mainnet, you will need to upload this message to
-              a beacon node’s {signature} pool {after} Capella/Shanghai hard fork."
+              a beacon node’s message ({signature}) pool {after} Capella/Shanghai hard fork."
               values={{
                 signature: <Code>SignedBLSToExecutionChange</Code>,
                 after: (
@@ -327,30 +328,51 @@ export const BtecGuide = () => {
                 <br />
                 <span className="dimmed">
                   --mnemonic="
-                  <span className="custom">{`<YOUR MNEMONIC>`}</span>" \
+                  <span className="custom">
+                    {`<`}
+                    <FormattedMessage defaultMessage="Your mnemonic" />
+                    {`>`}
+                  </span>
+                  " \
                 </span>
                 <br />
                 <span className="dimmed">
                   --bls_withdrawal_credentials_list="
-                  <span className="custom">{`<YOUR OLD BLS WITHDRAWAL>`}</span>"
-                  \
+                  <span className="custom">
+                    {`<`}
+                    <FormattedMessage defaultMessage="Your old BLS withdrawal credentials" />
+                    {`>`}
+                  </span>
+                  " \
                 </span>
                 <br />
                 <span className="dimmed">
                   --validator_start_index=
-                  <span className="custom">{`<THE KEY START INDEX IN EIP-2334>`}</span>{' '}
+                  <span className="custom">
+                    {`<`}
+                    <FormattedMessage defaultMessage="The key start index in EIP-2334" />
+                    {`>`}
+                  </span>{' '}
                   \
                 </span>
                 <br />
                 <span className="dimmed">
                   --validator_indices="
-                  <span className="custom">{`<YOUR VALIDATOR INDICES>`}</span>"
-                  \
+                  <span className="custom">
+                    {`<`}
+                    <FormattedMessage defaultMessage="Your validator indices" />
+                    {`>`}
+                  </span>
+                  " \
                 </span>
                 <br />
                 <span className="dimmed">
                   --execution_address="
-                  <span className="custom">{`<THE EXECUTION ADDRESS FOR WITHDRAWALS>`}</span>
+                  <span className="custom">
+                    {`<`}
+                    <FormattedMessage defaultMessage="The execution address for withdrawals" />
+                    {`>`}
+                  </span>
                   "
                 </span>
                 <br />
@@ -427,30 +449,51 @@ export const BtecGuide = () => {
                 <br />
                 <span className="dimmed">
                   --mnemonic="
-                  <span className="custom">{`<YOUR MNEMONIC>`}</span>" \
+                  <span className="custom">
+                    {`<`}
+                    <FormattedMessage defaultMessage="Your mnemonic" />
+                    {`>`}
+                  </span>
+                  " \
                 </span>
                 <br />
                 <span className="dimmed">
                   --bls_withdrawal_credentials_list="
-                  <span className="custom">{`<YOUR OLD BLS WITHDRAWAL>`}</span>"
-                  \
+                  <span className="custom">
+                    {`<`}
+                    <FormattedMessage defaultMessage="Your old BLS withdrawal credentials" />
+                    {`>`}
+                  </span>
+                  " \
                 </span>
                 <br />
                 <span className="dimmed">
                   --validator_start_index=
-                  <span className="custom">{`<THE KEY START INDEX IN EIP-2334>`}</span>
-                  {` `} \
-                </span>
-                <br />
-                <span className="dimmed">
-                  --validator_indices="
-                  <span className="custom">{`<YOUR VALIDATOR INDICES>`}</span>"
+                  <span className="custom">
+                    {`<`}
+                    <FormattedMessage defaultMessage="The key start index in EIP-2334" />
+                    {`>`}
+                  </span>{' '}
                   \
                 </span>
                 <br />
                 <span className="dimmed">
+                  --validator_indices="
+                  <span className="custom">
+                    {`<`}
+                    <FormattedMessage defaultMessage="Your validator indices" />
+                    {`>`}
+                  </span>
+                  " \
+                </span>
+                <br />
+                <span className="dimmed">
                   --execution_address="
-                  <span className="custom">{`<THE EXECUTION ADDRESS FOR WITHDRAWALS>`}</span>
+                  <span className="custom">
+                    {`<`}
+                    <FormattedMessage defaultMessage="The execution address for withdrawals" />
+                    {`>`}
+                  </span>
                   "
                 </span>
                 <br />
@@ -497,11 +540,25 @@ export const BtecGuide = () => {
                 </Text>
                 <CodeBlock>
                   <span>
-                    {`--devnet_chain_setting='{
-                       "network_name": "<NETWORK_NAME>",
-                       "genesis_fork_version": "<GENESIS_FORK_VERSION>",
-                       "genesis_validator_root": "<GENESIS_VALIDATOR_ROOT>"
-                    }'`}
+                    {`--devnet_chain_setting='{ "network_name": "`}
+                    <span className="custom">
+                      {`<`}
+                      <FormattedMessage defaultMessage="Network name" />
+                      {`>`}
+                    </span>
+                    ", "genesis_fork_version": "
+                    <span className="custom">
+                      {`<`}
+                      <FormattedMessage defaultMessage="Genesis fork version" />
+                      {`>`}
+                    </span>
+                    ", "genesis_validator_root": "
+                    <span className="custom">
+                      {`<`}
+                      <FormattedMessage defaultMessage="Genesis validator root" />
+                      {`>`}
+                    </span>
+                    {`" }'`}
                   </span>
                 </CodeBlock>
                 <Text className="mb10">
@@ -584,7 +641,11 @@ export const BtecGuide = () => {
           <CodeBlock className="indent">
             <span>
               curl -X POST -H “Content-type: application/json” -d @
-              <span className="custom">{`<@FILENAME DESTINATION>`}</span>
+              <span className="custom">
+                {`<@${formatMessage({
+                  defaultMessage: 'Filename destination',
+                })}>`}
+              </span>
               {` `}\
             </span>
             <br />

--- a/src/pages/Withdrawals/index.tsx
+++ b/src/pages/Withdrawals/index.tsx
@@ -235,7 +235,7 @@ export const Withdrawals = () => {
                 <li>
                   <strong>Staking Deposit CLI</strong> -{' '}
                   <Link inline primary to="/btec/">
-                    Launchpad walkthrough tutorial
+                    <FormattedMessage defaultMessage="Launchpad walkthrough tutorial" />
                   </Link>
                 </li>
                 <li>
@@ -245,7 +245,7 @@ export const Withdrawals = () => {
                     primary
                     to="https://github.com/wealdtech/ethdo/blob/master/docs/changingwithdrawalcredentials.md"
                   >
-                    Changing withdrawal credentials
+                    <FormattedMessage defaultMessage="Changing withdrawal credentials" />
                   </Link>
                 </li>
               </ul>
@@ -331,7 +331,9 @@ export const Withdrawals = () => {
                 any extra balance automatically withdrawn to their Ethereum address."
                 values={{
                   excessBalanceWithdrawal: (
-                    <strong>excess balance withdrawal</strong>
+                    <strong>
+                      <FormattedMessage defaultMessage="excess balance withdrawal" />
+                    </strong>
                   ),
                 }}
               />
@@ -358,7 +360,13 @@ export const Withdrawals = () => {
             <Text className="mb10">
               <FormattedMessage
                 defaultMessage="A {fullWithdrawal} is processed for any inactivated validators that are no longer considered to be staking, that have fully exited from their validation responsibilities. Thus for a validator to fully withdraw its balance, it must first complete the process of exiting."
-                values={{ fullWithdrawal: <strong>full withdrawal</strong> }}
+                values={{
+                  fullWithdrawal: (
+                    <strong>
+                      <FormattedMessage defaultMessage="full withdrawal" />
+                    </strong>
+                  ),
+                }}
               />
             </Text>
 
@@ -402,7 +410,10 @@ export const Withdrawals = () => {
                     inline
                     to="https://lighthouse-book.sigmaprime.io/voluntary-exit.html"
                   >
-                    Exiting a Lighthouse validator
+                    <FormattedMessage
+                      defaultMessage="Exiting a {client} validator"
+                      values={{ client: 'Lighthouse' }}
+                    />
                   </Link>
                 </li>
                 <li>
@@ -411,7 +422,10 @@ export const Withdrawals = () => {
                     inline
                     to="https://chainsafe.github.io/lodestar/reference/cli/#validator-voluntary-exit"
                   >
-                    Exiting a Lodestar validator
+                    <FormattedMessage
+                      defaultMessage="Exiting a {client} validator"
+                      values={{ client: 'Lodestar' }}
+                    />
                   </Link>
                 </li>
                 <li>
@@ -420,7 +434,10 @@ export const Withdrawals = () => {
                     inline
                     to="https://nimbus.guide/voluntary-exit.html"
                   >
-                    Exiting a Nimbus validator
+                    <FormattedMessage
+                      defaultMessage="Exiting a {client} validator"
+                      values={{ client: 'Nimbus' }}
+                    />
                   </Link>
                 </li>
                 <li>
@@ -429,7 +446,10 @@ export const Withdrawals = () => {
                     inline
                     to="https://docs.prylabs.network/docs/wallet/exiting-a-validator"
                   >
-                    Exiting a Prysm validator
+                    <FormattedMessage
+                      defaultMessage="Exiting a {client} validator"
+                      values={{ client: 'Prysm' }}
+                    />
                   </Link>
                 </li>
                 <li>
@@ -438,7 +458,10 @@ export const Withdrawals = () => {
                     inline
                     to="https://docs.teku.consensys.net/Reference/CLI/Subcommands/Voluntary-Exit"
                   >
-                    Exiting a Teku validator
+                    <FormattedMessage
+                      defaultMessage="Exiting a {client} validator"
+                      values={{ client: 'Teku' }}
+                    />
                   </Link>
                 </li>
               </ul>
@@ -454,7 +477,10 @@ export const Withdrawals = () => {
                     inline
                     to="https://forum.dappnode.io/t/how-to-exit-an-eth2-validator/786"
                   >
-                    Exiting a DAppNode validator
+                    <FormattedMessage
+                      defaultMessage="Exiting a {software} validator"
+                      values={{ software: 'DAppNode' }}
+                    />
                   </Link>
                 </li>
                 <li>
@@ -463,7 +489,10 @@ export const Withdrawals = () => {
                     inline
                     to="https://eth-docker.net/Support/Exit/"
                   >
-                    Exiting an eth-docker validator
+                    <FormattedMessage
+                      defaultMessage="Exiting a {software} validator"
+                      values={{ software: 'eth-docker' }}
+                    />
                   </Link>
                 </li>
                 <li>
@@ -472,7 +501,11 @@ export const Withdrawals = () => {
                     inline
                     to="https://docs.rocketpool.net/guides/node/cli-intro.html#minipool-commands"
                   >
-                    Exiting a Rocket Pool minipool
+                    <FormattedMessage
+                      defaultMessage="Exiting a {software} minipool"
+                      values={{ software: 'Rocket Pool' }}
+                      description="A minipool is a Rocket Pool-specific term for a validator that shares stake with others"
+                    />
                   </Link>
                 </li>
               </ul>


### PR DESCRIPTION
## Description
- Extracts strings that were missed for translation
- Couple small copy tweaks for clarity in context of translations
  - For example: adding "signed BLS-to-execution-change" (to be translated) before the untranslated variable name `SignedBLSToExecutionChange` is shown, so it reads properly in other languages
- Extracts placeholder text in BTEC walkthrough for translation
  - For example "<YOUR MNEMONIC>" will now get translated instead of remaining in English