### PR TITLE
Add error message for user when ledger fails when attempting to sign

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -5791,28 +5791,6 @@
       "value": "In other words, you maximize your rewards by providing the greatest benefit to the network as a whole."
     }
   ],
-  "hc8EGX": [
-    {
-      "type": 0,
-      "value": "There was a problem trying to sign with your Ledger device. Please verify your Ledger device has both "
-    },
-    {
-      "type": 1,
-      "value": "blindSigning"
-    },
-    {
-      "type": 0,
-      "value": " and "
-    },
-    {
-      "type": 1,
-      "value": "debugData"
-    },
-    {
-      "type": 0,
-      "value": " enabled. These can be accessed by selecting the Ethereum application and then entering the Settings menu."
-    }
-  ],
   "hfXlpq": [
     {
       "type": 0,
@@ -7077,6 +7055,44 @@
     {
       "type": 0,
       "value": "Slashing"
+    }
+  ],
+  "prRNB6": [
+    {
+      "type": 0,
+      "value": "There was a problem trying to sign with your Ledger device. Please verify your Ledger device has both "
+    },
+    {
+      "type": 1,
+      "value": "blindSigning"
+    },
+    {
+      "type": 0,
+      "value": " and "
+    },
+    {
+      "type": 1,
+      "value": "debugData"
+    },
+    {
+      "type": 0,
+      "value": " set to "
+    },
+    {
+      "type": 1,
+      "value": "enabled"
+    },
+    {
+      "type": 0,
+      "value": ". These can be accessed by selecting the Ethereum application and then entering the "
+    },
+    {
+      "type": 1,
+      "value": "settings"
+    },
+    {
+      "type": 0,
+      "value": " menu."
     }
   ],
   "ps8lLk": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -5791,6 +5791,28 @@
       "value": "In other words, you maximize your rewards by providing the greatest benefit to the network as a whole."
     }
   ],
+  "hc8EGX": [
+    {
+      "type": 0,
+      "value": "There was a problem trying to sign with your Ledger device. Please verify your Ledger device has both "
+    },
+    {
+      "type": 1,
+      "value": "blindSigning"
+    },
+    {
+      "type": 0,
+      "value": " and "
+    },
+    {
+      "type": 1,
+      "value": "debugData"
+    },
+    {
+      "type": 0,
+      "value": " enabled. These can be accessed by selecting the Ethereum application and then entering the Settings menu."
+    }
+  ],
   "hfXlpq": [
     {
       "type": 0,

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -2204,9 +2204,6 @@
   "hZrkPB": {
     "message": "In other words, you maximize your rewards by providing the greatest benefit to the network as a whole."
   },
-  "hc8EGX": {
-    "message": "There was a problem trying to sign with your Ledger device. Please verify your Ledger device has both {blindSigning} and {debugData} enabled. These can be accessed by selecting the Ethereum application and then entering the Settings menu."
-  },
   "hfXlpq": {
     "message": "Hungarian"
   },
@@ -2691,6 +2688,9 @@
   },
   "pqC+qt": {
     "message": "Slashing"
+  },
+  "prRNB6": {
+    "message": "There was a problem trying to sign with your Ledger device. Please verify your Ledger device has both {blindSigning} and {debugData} set to {enabled}. These can be accessed by selecting the Ethereum application and then entering the {settings} menu."
   },
   "ps8lLk": {
     "description": "{expected} shows 'This is the expected scenario' and is bolded for emphasis",

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -2204,6 +2204,9 @@
   "hZrkPB": {
     "message": "In other words, you maximize your rewards by providing the greatest benefit to the network as a whole."
   },
+  "hc8EGX": {
+    "message": "There was a problem trying to sign with your Ledger device. Please verify your Ledger device has both {blindSigning} and {debugData} enabled. These can be accessed by selecting the Ethereum application and then entering the Settings menu."
+  },
   "hfXlpq": {
     "message": "Hungarian"
   },

--- a/src/pages/Transactions/Keylist/ActionButton.tsx
+++ b/src/pages/Transactions/Keylist/ActionButton.tsx
@@ -125,7 +125,11 @@ export const ActionButton = ({
     );
   }
 
-  if (transactionStatus === TransactionStatus.REJECTED) {
+  if (
+    [TransactionStatus.REJECTED, TransactionStatus.LEDGER_ERROR].includes(
+      transactionStatus
+    )
+  ) {
     return (
       <Container onClick={onClick}>
         <ButtonText>

--- a/src/pages/Transactions/index.tsx
+++ b/src/pages/Transactions/index.tsx
@@ -9,11 +9,13 @@ import { AbstractConnector } from '@web3-react/abstract-connector';
 import _every from 'lodash/every';
 import _some from 'lodash/some';
 import { DepositKeyInterface, StoreState } from '../../store/reducers';
+import { Alert } from '../../components/Alert';
+import { Button } from '../../components/Button';
 import { Heading } from '../../components/Heading';
+import { Link } from '../../components/Link';
 import { Paper } from '../../components/Paper';
 import { Text } from '../../components/Text';
-import { Button } from '../../components/Button';
-import { Link } from '../../components/Link';
+import { WorkflowPageTemplate } from '../../components/WorkflowPage/WorkflowPageTemplate';
 import { routesEnum } from '../../Routes';
 import { KeyList } from './Keylist';
 import { handleMultipleTransactions } from './transactionUtils';
@@ -21,7 +23,6 @@ import { TARGET_NETWORK_CHAIN_ID } from '../ConnectWallet/web3Utils';
 import { web3ReactInterface } from '../ConnectWallet';
 import { WalletDisconnected } from '../ConnectWallet/WalletDisconnected';
 import { WrongNetwork } from '../ConnectWallet/WrongNetwork';
-import { WorkflowPageTemplate } from '../../components/WorkflowPage/WorkflowPageTemplate';
 import {
   DepositStatus,
   DispatchTransactionStatusUpdateType,
@@ -156,6 +157,21 @@ const _TransactionsPage = ({
       title={formatMessage({ defaultMessage: 'Transactions' })}
     >
       <Paper className="mt20">
+        {depositKeys.find(
+          k => k.transactionStatus === TransactionStatus.LEDGER_ERROR
+        ) && (
+          <Alert variant="error" className="mb20">
+            <FormattedMessage
+              defaultMessage="There was a problem trying to sign with your Ledger device. Please verify your Ledger
+              device has both {blindSigning} and {debugData} enabled. These can be accessed by selecting the Ethereum
+              application and then entering the Settings menu."
+              values={{
+                blindSigning: <b>Blind Signing</b>,
+                debugData: <b>Debug Data</b>,
+              }}
+            />
+          </Alert>
+        )}
         <Heading level={3} size="small" color="blueMedium">
           {depositKeys.length === 1 ? (
             <FormattedMessage defaultMessage="Confirm deposit" />

--- a/src/pages/Transactions/index.tsx
+++ b/src/pages/Transactions/index.tsx
@@ -163,11 +163,13 @@ const _TransactionsPage = ({
           <Alert variant="error" className="mb20">
             <FormattedMessage
               defaultMessage="There was a problem trying to sign with your Ledger device. Please verify your Ledger
-              device has both {blindSigning} and {debugData} enabled. These can be accessed by selecting the Ethereum
-              application and then entering the Settings menu."
+              device has both {blindSigning} and {debugData} set to {enabled}. These can be accessed by selecting
+              the Ethereum application and then entering the {settings} menu."
               values={{
-                blindSigning: <b>Blind Signing</b>,
-                debugData: <b>Debug Data</b>,
+                blindSigning: <strong>Blind Signing</strong>,
+                debugData: <strong>Debug Data</strong>,
+                enabled: <strong>Enabled</strong>,
+                settings: <strong>Settings</strong>,
               }}
             />
           </Alert>

--- a/src/pages/Transactions/transactionUtils.tsx
+++ b/src/pages/Transactions/transactionUtils.tsx
@@ -50,18 +50,9 @@ const isUserRejectionError = (error: any) => {
   return false;
 };
 
-const isLedgerError = (error: any) => {
-  if (error.code === -32603) {
-    // Error message when rejecting from ledger or blind signing and debug not enabled
-    if (
-      error.message.includes('Ledger: Unknown error while signing transaction')
-    ) {
-      return true;
-    }
-  }
-
-  return false;
-};
+// Error message when rejecting from ledger or blind signing and debug not enabled
+const isLedgerError = (error: any) =>
+  error.code === -32603 && error.message.toLowerCase().includes('ledger');
 
 /*
   Recursive func for calling each transaction in succession after

--- a/src/store/actions/depositFileActions.ts
+++ b/src/store/actions/depositFileActions.ts
@@ -10,6 +10,7 @@ export enum TransactionStatus {
   'STARTED',
   'SUCCEEDED',
   'FAILED',
+  'LEDGER_ERROR',
   'REJECTED',
 }
 


### PR DESCRIPTION
## Description

When a user attempts to perform a deposit with a Ledger device, if **Blind Signing** and **Debug Data** is not enabled, the transaction will fail with seemingly no reason. This has been a problem for years and still people ask about it on the EthStaker discord. Though this issue may be resolved by updating the web3-react library from v6 to v8, a brief attempt at doing so resulted in dependency hell and would be quite a drastic change for this one small issue. I had a quick chat with @wackerow about this and we agreed an error message is the best approach. 

The error message will appear if either **Blind Signing** or **Debug Data** are disabled or, sadly, if the user simply rejects from the Ledger device. We have no way to differentiate but I feel the benefit of the guidance outweighs the false positive.

I am a little uncertain on exact wording or if there is a stylistic standard around presenting error messages but happy to update as necessary. 

## Related Issues

- #549 
