### PR TITLE
fix: update link to Lodestar voluntary exit cli

### DIFF
--- a/src/pages/Withdrawals/index.tsx
+++ b/src/pages/Withdrawals/index.tsx
@@ -436,7 +436,7 @@ export const Withdrawals = () => {
                   <Link
                     primary
                     inline
-                    to="https://chainsafe.github.io/lodestar/reference/cli/#validator-voluntary-exit"
+                    to="https://chainsafe.github.io/lodestar/run/validator-management/validator-cli#validator-voluntary-exit"
                   >
                     <FormattedMessage
                       defaultMessage="Exiting a {client} validator"


### PR DESCRIPTION
Previous link just points to our relocated page as we restructured the docs