### PR TITLE
compare fork version hex strings

### DIFF
--- a/src/pages/UploadValidator/index.tsx
+++ b/src/pages/UploadValidator/index.tsx
@@ -231,7 +231,7 @@ const _UploadValidatorPage = ({
               const hasCorrectStructure = checkJsonStructure(fileData[0] || {});
               if (
                 hasCorrectStructure &&
-                forkVersion !== GENESIS_FORK_VERSION.toString()
+                forkVersion !== GENESIS_FORK_VERSION.toString('hex')
               ) {
                 // file doesn't match the correct network
                 handleWrongNetwork();


### PR DESCRIPTION
resolves #638 
Improves the poor error discussed [here](https://github.com/ethereum/staking-launchpad/issues/605#issue-1596639449) and [here](https://github.com/ethereum/staking-launchpad/issues/532#issuecomment-1207453873) but does not fully resolve these issues' underlying problem.

The deposit CLI tool assigns a value of eg "01017000" to a deposit file's fork_version. It's a hex string, no leading "0x", cool.

The staking-launchpad uses an env var such as [0x01017000](https://github.com/ethereum/staking-launchpad/blob/dev/.env.holesky#L6), strips the leading "0x" and [loads it into a buffer as hex data](https://github.com/ethereum/staking-launchpad/blob/dev/src/utils/envVars.ts#L54). Cool.
 
But then, it [compares the value from our deposit file to this buffer cast to a string](https://github.com/ethereum/staking-launchpad/blob/dev/src/pages/UploadValidator/index.tsx#L234). `toString()` defaults to an ascii string instead of a hex string. Not cool.

Ultimately, we're comparing "��p�" to "01017000", which will cause the launchpad to declare "the network isn't right" when there's actually something else wrong with the deposit file.

Fix is very simple: call `toString('hex')` instead.

