### PR TITLE
Removing cli version checker

### DIFF
--- a/.env.holesky
+++ b/.env.holesky
@@ -4,7 +4,6 @@ export REACT_APP_ETH_REQUIREMENT=524288
 export REACT_APP_ETH_DEPOSIT_OFFSET=0
 export REACT_APP_TESTNET_LAUNCHPAD_NAME=Holesky
 export REACT_APP_GENESIS_FORK_VERSION=0x01017000
-export REACT_APP_MIN_DEPOSIT_CLI_VERSION=2.7.0
 export REACT_APP_RPC_URL=https://rpc.holesky.ethpandaops.io
 export REACT_APP_BEACONCHAIN_URL=https://holesky.beaconcha.in
 export REACT_APP_EL_EXPLORER_URL=https://holesky.beaconcha.in

--- a/.env.template
+++ b/.env.template
@@ -20,8 +20,6 @@ REACT_APP_PRICE_PER_VALIDATOR=32
 # Uint8Array such as "0x00000000"
 REACT_APP_GENESIS_FORK_VERSION=0x00000000
 # string
-REACT_APP_MIN_DEPOSIT_CLI_VERSION=1.0.0
-# string
 REACT_APP_LIGHTHOUSE_INSTALLATION_URL=https://lighthouse-book.sigmaprime.io/
 # string
 REACT_APP_NIMBUS_INSTALLATION_URL=https://nimbus.guide/intro.html
@@ -49,7 +47,5 @@ REACT_APP_TUTORIAL_URL=https://notes.ethereum.org/@launchpad/holesky
 REACT_APP_TESTNET_LAUNCHPAD_NAME=Holesky
 # number
 REACT_APP_ETH_DEPOSIT_OFFSET=0
-# string
-REACT_APP_MIN_DEPOSIT_CLI_VERSION=2.7.0
 # string
 REACT_APP_FAUCET_URL=https://www.holeskyfaucet.io/

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "babel-plugin-formatjs": "^9.0.4",
     "babel-plugin-react-require": "^3.1.3",
     "bignumber.js": "^9.0.0",
-    "compare-versions": "^3.6.0",
     "d3": "^5.16.0",
     "eslint-plugin-formatjs": "^2.12.0",
     "ethereumjs-util": "^7.1.5",

--- a/src/pages/UploadValidator/validateDepositKey.ts
+++ b/src/pages/UploadValidator/validateDepositKey.ts
@@ -3,7 +3,6 @@
  */
 import _every from 'lodash/every';
 import { initBLS } from '@chainsafe/bls';
-import compareVersions from 'compare-versions';
 import axios from 'axios';
 import { verifySignature } from '../../utils/verifySignature';
 import { verifyDepositRoots } from '../../utils/SSZ';
@@ -15,7 +14,6 @@ import {
   ETHER_TO_GWEI,
   BEACONCHAIN_URL,
   MIN_DEPOSIT_AMOUNT,
-  MIN_DEPOSIT_CLI_VERSION,
 } from '../../utils/envVars';
 
 const validateFieldFormatting = (
@@ -65,17 +63,6 @@ const validateFieldFormatting = (
   if (
     depositDatum.amount < MIN_DEPOSIT_AMOUNT ||
     depositDatum.amount > 32 * ETHER_TO_GWEI
-  ) {
-    return false;
-  }
-
-  // check the deposit-cli version
-  if (
-    compareVersions.compare(
-      depositDatum.deposit_cli_version,
-      MIN_DEPOSIT_CLI_VERSION,
-      '<'
-    )
   ) {
     return false;
   }

--- a/src/utils/envVars.ts
+++ b/src/utils/envVars.ts
@@ -16,7 +16,6 @@ export const BEACONSCAN_URL             = IS_MAINNET ? 'https://beaconscan.com/v
 export const BEACONCHAIN_URL            = (IS_NON_INFURA_TESTNET && process.env.REACT_APP_BEACONCHAIN_URL) ||  `https://${NETWORK_NAME.toLowerCase()}.beaconcha.in`;
 export const FORTMATIC_KEY              = process.env.REACT_APP_FORTMATIC_KEY       || 'pk_test_D113D979E0D3508F';
 export const CONTRACT_ADDRESS           = IS_MAINNET ? '0x00000000219ab540356cBB839Cbe05303d7705Fa' : process.env.REACT_APP_CONTRACT_ADDRESS;
-export const MIN_DEPOSIT_CLI_VERSION    = process.env.REACT_APP_MIN_DEPOSIT_CLI_VERSION  || '1.0.0';
 export const LIGHTHOUSE_INSTALLATION_URL = process.env.REACT_APP_LIGHTHOUSE_INSTALLATION_URL || 'https://lighthouse-book.sigmaprime.io/';
 export const NIMBUS_INSTALLATION_URL    = process.env.REACT_APP_NIMBUS_INSTALLATION_URL  || 'https://nimbus.guide/quick-start.html';
 export const PRYSM_INSTALLATION_URL     = process.env.REACT_APP_PRYSM_INSTALLATION_URL   || 'https://docs.prylabs.network/docs/install/install-with-script';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5485,7 +5485,7 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
-compare-versions@^3.5.1, compare-versions@^3.6.0:
+compare-versions@^3.5.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
   integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==


### PR DESCRIPTION
When generating a deposit with the [staking-deposit-cli](https://github.com/ethereum/staking-deposit-cli), the resulting deposit file will contain a cli version: `deposit_cli_version`. The launchpad currently verifies this value is above a certain threshold defined in the env file, 2.7.0. 

There are two problems:
- If this check fails, the resulting error presented to the user says there is a problem with the network
- This makes it difficult for multiple tools to exist

To get around these two issues, this PR removes the version check entirely.

As a side effect, `compare-version` is no longer a direct dependency as this was the only location where it it is used but it is still a dependency of `husky`