### PR TITLE
Align with beaconcha.in validator status and remove execution credential filter during consolidation

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -275,6 +275,20 @@
       "value": "If at all possible, consider running another client at this time to help protect yourself and the network."
     }
   ],
+  "/t5Nnj": [
+    {
+      "type": 0,
+      "value": "Balance: "
+    },
+    {
+      "type": 1,
+      "value": "balance"
+    },
+    {
+      "type": 1,
+      "value": "ticker"
+    }
+  ],
   "/tHxib": [
     {
       "type": 0,
@@ -8451,16 +8465,6 @@
       "value": " as soon as possible. And join the EthStaker community for support and discussion with fellow validators."
     }
   ],
-  "vclhrb": [
-    {
-      "type": 0,
-      "value": "Balance: "
-    },
-    {
-      "type": 1,
-      "value": "balance"
-    }
-  ],
   "vj7TN7": [
     {
       "type": 0,
@@ -8487,16 +8491,6 @@
     {
       "type": 0,
       "value": "This occurs 256 epochs after the exit epoch, which takes ~27.3 hours."
-    }
-  ],
-  "w2THbw": [
-    {
-      "type": 0,
-      "value": "Your validator has a balance of "
-    },
-    {
-      "type": 1,
-      "value": "balance"
     }
   ],
   "w6qYSU": [
@@ -8591,6 +8585,20 @@
     {
       "type": 0,
       "value": "Does the site asking you for your deposit have a URL you expect?"
+    }
+  ],
+  "x6sPrj": [
+    {
+      "type": 0,
+      "value": "Your validator has a balance of "
+    },
+    {
+      "type": 1,
+      "value": "balance"
+    },
+    {
+      "type": 1,
+      "value": "ticker"
     }
   ],
   "xDyl3T": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -1443,6 +1443,12 @@
       "value": " is not supported in offline mode."
     }
   ],
+  "7BSUnP": [
+    {
+      "type": 0,
+      "value": "Depositing"
+    }
+  ],
   "7DFXQj": [
     {
       "type": 0,
@@ -6257,6 +6263,12 @@
     {
       "type": 0,
       "value": "More on effective balance"
+    }
+  ],
+  "hnDO7Y": [
+    {
+      "type": 0,
+      "value": "Invalid Deposit"
     }
   ],
   "hrJ1oM": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -102,6 +102,9 @@
   "/rmnC0": {
     "message": "If at all possible, consider running another client at this time to help protect yourself and the network."
   },
+  "/t5Nnj": {
+    "message": "Balance: {balance}{ticker}"
+  },
   "/tHxib": {
     "message": "Geth is one of the three original implementations of the Ethereum protocol, written in Go."
   },
@@ -3186,17 +3189,11 @@
     "description": "{stakerChecklist} = 'Staker Checklist' bolded to draw attention",
     "message": "Be sure to complete the {stakerChecklist} as soon as possible. And join the EthStaker community for support and discussion with fellow validators."
   },
-  "vclhrb": {
-    "message": "Balance: {balance}"
-  },
   "vj7TN7": {
     "message": "This value is known as the maximum effective balance (the maximum amount of ETH that contributes to your stake). Older account types (Type 0, or Type 1) have an effective balance limited to {MIN_ACTIVATION_BALANCE}. In these accounts, any balance over {MIN_ACTIVATION_BALANCE} does not contribute to your principle, nor compound earnings."
   },
   "vz8WK7": {
     "message": "This occurs 256 epochs after the exit epoch, which takes ~27.3 hours."
-  },
-  "w2THbw": {
-    "message": "Your validator has a balance of {balance}"
   },
   "w6qYSU": {
     "message": "Run the following command to launch the app"
@@ -3243,6 +3240,9 @@
   },
   "x4HNJL": {
     "message": "Does the site asking you for your deposit have a URL you expect?"
+  },
+  "x6sPrj": {
+    "message": "Your validator has a balance of {balance}{ticker}"
   },
   "xDyl3T": {
     "description": "{ethereumorg} is a link to deposit contract page on ethereum.org",

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -499,6 +499,9 @@
   "793QlI": {
     "message": "{title} is not supported in offline mode."
   },
+  "7BSUnP": {
+    "message": "Depositing"
+  },
   "7DFXQj": {
     "message": "Switch to {oppositeNetwork} launchpad"
   },
@@ -2372,6 +2375,9 @@
   },
   "hkg3fb": {
     "message": "More on effective balance"
+  },
+  "hnDO7Y": {
+    "message": "Invalid Deposit"
   },
   "hrJ1oM": {
     "message": "You can signal your intent to stop validating by signing a voluntary exit message with your validator at any time."

--- a/src/pages/Actions/components/PartialWithdraw.tsx
+++ b/src/pages/Actions/components/PartialWithdraw.tsx
@@ -86,8 +86,8 @@ const PartialWithdraw: React.FC<Props> = ({ validator }) => {
             </Heading>
             <Text center>
               <FormattedMessage
-                defaultMessage="Your validator has a balance of {balance}"
-                values={{ balance: validator.balanceDisplay }}
+                defaultMessage="Your validator has a balance of {balance}{ticker}"
+                values={{ balance: validator.coinBalance, ticker: TICKER_NAME }}
               />
               {validator.coinBalance <= MIN_VALIDATOR_BALANCE ? (
                 <FormattedMessage

--- a/src/pages/Actions/components/ValidatorActions.tsx
+++ b/src/pages/Actions/components/ValidatorActions.tsx
@@ -8,7 +8,6 @@ import UpgradeCompounding from './UpgradeCompounding';
 
 import { Section } from './Shared';
 import { hasValidatorExited } from '../../../utils/validators';
-import { EXECUTION_CREDENTIALS } from '../../../utils/envVars';
 
 interface Props {
   validator: Validator;
@@ -28,7 +27,6 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
       v =>
         v.withdrawalcredentials.substring(4) ===
           validator.withdrawalcredentials.substring(4) &&
-        v.withdrawalcredentials.substring(0, 4) === EXECUTION_CREDENTIALS &&
         v.pubkey !== validator.pubkey
     );
     setSharedValidators(otherValidatorsSameCredentials);

--- a/src/pages/Actions/components/ValidatorDetails.tsx
+++ b/src/pages/Actions/components/ValidatorDetails.tsx
@@ -7,6 +7,7 @@ import { Text } from '../../../components/Text';
 import { Validator } from '../types';
 
 import { hasValidatorExited } from '../../../utils/validators';
+import { TICKER_NAME } from '../../../utils/envVars';
 import { Section, CopyContainer } from './Shared';
 
 const ValidatorDetails = ({ validator }: { validator: Validator }) => {
@@ -43,8 +44,8 @@ const ValidatorDetails = ({ validator }: { validator: Validator }) => {
       </Text>
       <Text>
         <FormattedMessage
-          defaultMessage="Balance: {balance}"
-          values={{ balance: validator.balanceDisplay }}
+          defaultMessage="Balance: {balance}{ticker}"
+          values={{ balance: validator.coinBalance, ticker: TICKER_NAME }}
         />
       </Text>
       <Text>

--- a/src/pages/Actions/index.tsx
+++ b/src/pages/Actions/index.tsx
@@ -109,7 +109,6 @@ const fetchValidatorsByPubkeys = async (
       )
       .map(v => ({
         ...v,
-        // balanceDisplay: `${coinBalance}${TICKER_NAME}`,
         coinBalance: new BigNumber(v.balance).div(ETHER_TO_GWEI).toNumber(),
       }));
   } catch (error) {

--- a/src/pages/Actions/index.tsx
+++ b/src/pages/Actions/index.tsx
@@ -8,6 +8,7 @@ import BigNumber from 'bignumber.js';
 import {
   BeaconChainValidator,
   BeaconChainValidatorResponse,
+  BeaconChainValidatorStatus,
 } from '../TopUp/types';
 import { Props, Validator } from './types';
 
@@ -98,11 +99,19 @@ const fetchValidatorsByPubkeys = async (
     const data: BeaconChainValidator[] = Array.isArray(json.data)
       ? json.data
       : [json.data];
-    return data.map(v => ({
-      ...v,
-      // balanceDisplay: `${coinBalance}${TICKER_NAME}`,
-      coinBalance: new BigNumber(v.balance).div(ETHER_TO_GWEI).toNumber(),
-    }));
+
+    return data
+      .filter(v =>
+        [
+          BeaconChainValidatorStatus.active_offline,
+          BeaconChainValidatorStatus.active_online,
+        ].includes(v.status)
+      )
+      .map(v => ({
+        ...v,
+        // balanceDisplay: `${coinBalance}${TICKER_NAME}`,
+        coinBalance: new BigNumber(v.balance).div(ETHER_TO_GWEI).toNumber(),
+      }));
   } catch (error) {
     console.warn(
       `Error fetching validators (pubkeys ${pubkeys.join(',')}):`,

--- a/src/pages/Actions/types.ts
+++ b/src/pages/Actions/types.ts
@@ -1,3 +1,5 @@
+import { BeaconChainValidatorStatus } from '../TopUp/types';
+
 export interface OwnProps {}
 export interface StateProps {}
 export interface DispatchProps {}
@@ -15,7 +17,7 @@ export interface Validator {
   name: string;
   pubkey: string;
   slashed: boolean;
-  status: string;
+  status: BeaconChainValidatorStatus;
   validatorindex: number;
   withdrawableepoch: number;
   withdrawalcredentials: string;

--- a/src/pages/Actions/types.ts
+++ b/src/pages/Actions/types.ts
@@ -9,7 +9,6 @@ export interface Validator {
   activationeligibilityepoch: number;
   activationepoch: number;
   balance: number;
-  balanceDisplay?: string;
   coinBalance: number;
   effectivebalance: number;
   exitepoch: number;

--- a/src/pages/TopUp/components/ValidatorTable.tsx
+++ b/src/pages/TopUp/components/ValidatorTable.tsx
@@ -13,7 +13,7 @@ import ReactTooltip from 'react-tooltip';
 import { Wifi, StatusWarning, Refresh, StatusDisabled } from 'grommet-icons';
 import numeral from 'numeral';
 import { styledComponentsTheme as theme } from '../../../styles/styledComponentsTheme';
-import { BeaconChainValidator } from '../types';
+import { BeaconChainValidator, BeaconChainValidatorStatus } from '../types';
 import { Text } from '../../../components/Text';
 import shortenAddress from '../../../utils/shortenAddress';
 import { Button } from '../../../components/Button';
@@ -50,7 +50,27 @@ const ValidatorTable: React.FC<{
     const { status } = validator;
 
     switch (status) {
-      case 'pending': {
+      case BeaconChainValidatorStatus.deposited_invalid: {
+        return (
+          <Item>
+            <StatusWarning color={theme.red.light} />
+            <Text>
+              <FormattedMessage defaultMessage="Invalid Deposit" />
+            </Text>
+          </Item>
+        );
+      }
+      case BeaconChainValidatorStatus.deposited: {
+        return (
+          <Item>
+            <Refresh color="blueLight" />
+            <Text>
+              <FormattedMessage defaultMessage="Depositing" />
+            </Text>
+          </Item>
+        );
+      }
+      case BeaconChainValidatorStatus.pending: {
         return (
           <Item>
             <Refresh color="blueLight" />
@@ -60,7 +80,8 @@ const ValidatorTable: React.FC<{
           </Item>
         );
       }
-      case 'slashing': {
+      case BeaconChainValidatorStatus.slashing_offline:
+      case BeaconChainValidatorStatus.slashing_online: {
         return (
           <Item>
             <StatusWarning color={theme.red.light} />
@@ -70,7 +91,7 @@ const ValidatorTable: React.FC<{
           </Item>
         );
       }
-      case 'slashed': {
+      case BeaconChainValidatorStatus.slashed: {
         return (
           <Item>
             <StatusWarning color={theme.red.light} />
@@ -80,7 +101,8 @@ const ValidatorTable: React.FC<{
           </Item>
         );
       }
-      case 'exiting': {
+      case BeaconChainValidatorStatus.exiting_offline:
+      case BeaconChainValidatorStatus.exiting_online: {
         return (
           <Item>
             <StatusWarning color="yellowDark" />
@@ -90,7 +112,7 @@ const ValidatorTable: React.FC<{
           </Item>
         );
       }
-      case 'exited': {
+      case BeaconChainValidatorStatus.exited: {
         return (
           <Item>
             <StatusDisabled color={theme.gray.medium} />
@@ -100,7 +122,7 @@ const ValidatorTable: React.FC<{
           </Item>
         );
       }
-      case 'active_offline': {
+      case BeaconChainValidatorStatus.active_offline: {
         return (
           <Item>
             <Wifi color={theme.gray.medium} />
@@ -110,7 +132,7 @@ const ValidatorTable: React.FC<{
           </Item>
         );
       }
-      case 'active_online': {
+      case BeaconChainValidatorStatus.active_online: {
         return (
           <Item>
             <Wifi color={theme.green.dark} />
@@ -129,7 +151,8 @@ const ValidatorTable: React.FC<{
     return validators.map(validator => {
       // No top-ups for exited or slashed validators:
       const statusIneligible =
-        validator.status === 'slashed' || validator.status === 'exited';
+        validator.status === BeaconChainValidatorStatus.slashed ||
+        validator.status === BeaconChainValidatorStatus.exited;
 
       const maxEffectiveBalanceEther = statusIneligible
         ? 0

--- a/src/pages/TopUp/types.ts
+++ b/src/pages/TopUp/types.ts
@@ -7,6 +7,20 @@ export interface StateProps {}
 export interface DispatchProps {}
 export type Props = StateProps & DispatchProps & OwnProps;
 
+export enum BeaconChainValidatorStatus {
+  deposited = 'deposited',
+  deposited_invalid = 'deposited_invalid',
+  pending = 'pending',
+  active_online = 'active_online',
+  active_offline = 'active_offline',
+  exiting_online = 'exiting_online',
+  exiting_offline = 'exiting_offline',
+  slashing_online = 'slashing_online',
+  slashing_offline = 'slashing_offline',
+  exited = 'exited',
+  slashed = 'slashed',
+}
+
 export interface BeaconChainValidatorTransaction {
   amount: number;
   block_number: number;
@@ -39,7 +53,7 @@ export interface BeaconChainValidator {
   name: string;
   pubkey: string;
   slashed: boolean;
-  status: string;
+  status: BeaconChainValidatorStatus;
   validatorindex: number;
   withdrawableepoch: number;
   withdrawalcredentials: string;


### PR DESCRIPTION
We need to align with the validator status' from beaconcha.in when displaying certain information such as filtering for only active (online or offline) validators during consolidation requests. 

This contains a minor refactor to use these status' as an enum for consistency and during this refactor it was noted a few status' were not accounted for in ValidatorTable.

Additionally, the previous PR added a filter during consolidation for only execution addresses which was a mistake. You can consolidation with a source of either 0x01 or 0x02. 