### PR TITLE
Updating validator credential prefix logic to use enum

### DIFF
--- a/src/pages/Actions/components/ValidatorActions.tsx
+++ b/src/pages/Actions/components/ValidatorActions.tsx
@@ -2,17 +2,15 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { FormattedMessage } from 'react-intl';
-import { Validator } from '../types';
-import PushConsolidation from './PushConsolidation';
+import { Validator, ValidatorType } from '../types';
 import ForceExit from './ForceExit';
 import PartialWithdraw from './PartialWithdraw';
+import PushConsolidation from './PushConsolidation';
 import UpgradeCompounding from './UpgradeCompounding';
 
 import { Section as SharedSection } from './Shared';
 import { hasValidatorExited } from '../../../utils/validators';
 import {
-  EXECUTION_CREDENTIALS,
-  COMPOUNDING_CREDENTIALS,
   MIN_ACTIVATION_BALANCE,
   TICKER_NAME,
   MAX_EFFECTIVE_BALANCE,
@@ -73,8 +71,7 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
     const potentialSourceValidators = validators.filter(v => {
       const isSameValidator = v.pubkey === validator.pubkey;
       const hasBalance = v.balance > 0;
-      const isExecutionOrLater =
-        +v.withdrawalcredentials.slice(0, 4) >= +EXECUTION_CREDENTIALS;
+      const isExecutionOrLater = v.type >= ValidatorType.Execution;
       // Should be filtered out from API call for validators by withdrawal address; backup check
       const isSameCredentials =
         v.withdrawalcredentials.slice(4) ===
@@ -89,20 +86,17 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
 
     setSourceValidatorSet(potentialSourceValidators);
 
-    const potentialTargetValidators = potentialSourceValidators.filter(v => {
-      const isCompoundingOrLater =
-        +v.withdrawalcredentials.slice(0, 4) >= +COMPOUNDING_CREDENTIALS;
-      return isCompoundingOrLater;
-    });
+    const potentialTargetValidators = potentialSourceValidators.filter(
+      v => v.type >= ValidatorType.Compounding
+    );
 
     setTargetValidatorSet(potentialTargetValidators);
   }, [validator, validators]);
 
-  const accountType = +validator.withdrawalcredentials.slice(0, 4);
   const surplusEther = validator.coinBalance - MIN_ACTIVATION_BALANCE;
   return (
     <Section>
-      {accountType === +EXECUTION_CREDENTIALS && (
+      {validator.type === ValidatorType.Execution && (
         <Row>
           <div style={{ flex: 1 }}>
             <ActionTitle>
@@ -121,7 +115,7 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
         </Row>
       )}
 
-      {accountType >= +COMPOUNDING_CREDENTIALS && (
+      {validator.type >= ValidatorType.Compounding && (
         <Row>
           <div style={{ flex: 1 }}>
             <ActionTitle>
@@ -150,7 +144,7 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
         </Row>
       )}
 
-      {accountType >= +COMPOUNDING_CREDENTIALS && (
+      {validator.type >= ValidatorType.Compounding && (
         <Row>
           <div style={{ flex: 1 }}>
             <ActionTitle>

--- a/src/pages/Actions/components/ValidatorDetails.tsx
+++ b/src/pages/Actions/components/ValidatorDetails.tsx
@@ -6,14 +6,10 @@ import { Heading } from '../../../components/Heading';
 import { Text } from '../../../components/Text';
 import { Section, CopyContainer, Hash } from './Shared';
 
-import { Validator } from '../types';
+import { Validator, ValidatorType } from '../types';
 
 import { hasValidatorExited } from '../../../utils/validators';
-import {
-  TICKER_NAME,
-  COMPOUNDING_CREDENTIALS,
-  EXECUTION_CREDENTIALS,
-} from '../../../utils/envVars';
+import { TICKER_NAME } from '../../../utils/envVars';
 import { epochToDate } from '../../../utils/beaconchain';
 
 const ValidatorDetails = ({ validator }: { validator: Validator }) => {
@@ -27,7 +23,6 @@ const ValidatorDetails = ({ validator }: { validator: Validator }) => {
     }, 2000);
   };
 
-  const prefix = validator.withdrawalcredentials.slice(0, 4);
   const hasExitCompleted =
     hasValidatorExited(validator) &&
     epochToDate(validator.exitepoch).getTime() < Date.now();
@@ -112,13 +107,15 @@ const ValidatorDetails = ({ validator }: { validator: Validator }) => {
 
         <Text>
           <FormattedMessage defaultMessage="Withdrawal credential type" />:{' '}
-          <span style={{ fontFamily: 'monospace' }}>{prefix}</span>{' '}
-          {prefix === COMPOUNDING_CREDENTIALS && (
+          <span style={{ fontFamily: 'monospace' }}>
+            {validator.withdrawalcredentials.slice(0, 4)}
+          </span>{' '}
+          {validator.type === ValidatorType.Compounding && (
             <span>
               <FormattedMessage defaultMessage="(Compounding)" />
             </span>
           )}
-          {prefix === EXECUTION_CREDENTIALS && (
+          {validator.type === ValidatorType.Execution && (
             <span>
               <FormattedMessage defaultMessage="(Regular withdrawals)" />
             </span>

--- a/src/pages/Actions/index.tsx
+++ b/src/pages/Actions/index.tsx
@@ -10,7 +10,7 @@ import {
   BeaconChainValidator,
   BeaconChainValidatorResponse,
 } from '../TopUp/types';
-import { Props, Validator } from './types';
+import { Props, Validator, ValidatorType } from './types';
 
 import ValidatorActions from './components/ValidatorActions';
 
@@ -109,10 +109,11 @@ const fetchValidatorsByPubkeys = async (
     const data: BeaconChainValidator[] = Array.isArray(json.data)
       ? json.data
       : [json.data];
+
     return data.map(v => ({
       ...v,
-      // balanceDisplay: `${coinBalance}${TICKER_NAME}`,
       coinBalance: new BigNumber(v.balance).div(ETHER_TO_GWEI).toNumber(),
+      type: +v.withdrawalcredentials.slice(0, 4) as ValidatorType,
     }));
   } catch (error) {
     console.warn(

--- a/src/pages/Actions/types.ts
+++ b/src/pages/Actions/types.ts
@@ -3,6 +3,12 @@ export interface StateProps {}
 export interface DispatchProps {}
 export type Props = StateProps & DispatchProps & OwnProps;
 
+export enum ValidatorType {
+  BLS = 0,
+  Execution = 1,
+  Compounding = 2,
+}
+
 export interface Validator {
   activationeligibilityepoch: number;
   activationepoch: number;
@@ -16,6 +22,7 @@ export interface Validator {
   pubkey: string;
   slashed: boolean;
   status: string;
+  type: ValidatorType;
   validatorindex: number;
   withdrawableepoch: number;
   withdrawalcredentials: string;


### PR DESCRIPTION
Centralized the validator type logic when calling the API to be able to utilize an enum.