### PR TITLE
Add "Top Up" option to validator actions

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -1349,6 +1349,12 @@
       "value": " validator"
     }
   ],
+  "6/Tl+g": [
+    {
+      "type": 0,
+      "value": "TO"
+    }
+  ],
   "63gLLu": [
     {
       "type": 0,
@@ -3623,6 +3629,12 @@
       "value": "Upload to Beacon Node BLSToExecutionChange pool"
     }
   ],
+  "MAOeyC": [
+    {
+      "type": 0,
+      "value": "Depositing beyond the validators maximum effective balance will result in those excess funds being immediately withdrawn and will not impact the effectiveness of the validator"
+    }
+  ],
   "MAVs3a": [
     {
       "type": 0,
@@ -3759,6 +3771,12 @@
     {
       "type": 0,
       "value": "a few more days"
+    }
+  ],
+  "NB68I4": [
+    {
+      "type": 0,
+      "value": "Add funds to your validator"
     }
   ],
   "NDrMCw": [
@@ -4649,6 +4667,12 @@
     {
       "type": 0,
       "value": "virtualenv would help you to create an isolated Python environment for deposit-cli tool."
+    }
+  ],
+  "TkfeEf": [
+    {
+      "type": 0,
+      "value": "Adding funds to a validator not yet at it's max EB can increase rewards and penalties."
     }
   ],
   "Tpe6yK": [
@@ -8713,6 +8737,12 @@
     {
       "type": 0,
       "value": "Become a validator with Nimbus"
+    }
+  ],
+  "upSHEn": [
+    {
+      "type": 0,
+      "value": "FROM"
     }
   ],
   "v/nu/L": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -483,6 +483,9 @@
   "5v36Is": {
     "message": "Exiting a {client} validator"
   },
+  "6/Tl+g": {
+    "message": "TO"
+  },
   "63gLLu": {
     "message": "average"
   },
@@ -1384,6 +1387,9 @@
   "M35Dz/": {
     "message": "Upload to Beacon Node BLSToExecutionChange pool"
   },
+  "MAOeyC": {
+    "message": "Depositing beyond the validators maximum effective balance will result in those excess funds being immediately withdrawn and will not impact the effectiveness of the validator"
+  },
   "MAVs3a": {
     "message": "*Simply being offline with an otherwise healthy network does not result in slashing, but will result in small inactivity penalties."
   },
@@ -1446,6 +1452,9 @@
   },
   "N6QzJ5": {
     "message": "a few more days"
+  },
+  "NB68I4": {
+    "message": "Add funds to your validator"
   },
   "NDrMCw": {
     "message": "Total number of validator accounts that have eligible withdrawals (variable)"
@@ -1783,6 +1792,9 @@
   },
   "TfNuWP": {
     "message": "virtualenv would help you to create an isolated Python environment for deposit-cli tool."
+  },
+  "TkfeEf": {
+    "message": "Adding funds to a validator not yet at it's max EB can increase rewards and penalties."
   },
   "Tpe6yK": {
     "message": "rpc-http-enabled documentation"
@@ -3291,6 +3303,9 @@
   },
   "ukfwum": {
     "message": "Become a validator with Nimbus"
+  },
+  "upSHEn": {
+    "message": "FROM"
   },
   "v/nu/L": {
     "message": "The Nethermind Ethereum execution client, built on .NET, delivers industry-leading performance in syncing and tip-of-chain processing."

--- a/src/pages/Actions/components/TopUp.tsx
+++ b/src/pages/Actions/components/TopUp.tsx
@@ -1,0 +1,345 @@
+import { ByteVectorType, ContainerType, NumberUintType } from '@chainsafe/ssz';
+import BigNumber from 'bignumber.js';
+import React, { useEffect, useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { Box, Layer, Form } from 'grommet';
+import { Alert as AlertIcon } from 'grommet-icons';
+import Web3 from 'web3';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { SendOptions } from 'web3-eth-contract';
+import { AbstractConnector } from '@web3-react/abstract-connector';
+import { useWeb3React } from '@web3-react/core';
+
+import { Validator, ValidatorType } from '../types';
+
+import { Button } from '../../../components/Button';
+import { NumberInput } from '../../../components/NumberInput';
+import {
+  TransactionStatus,
+  TransactionStatusModal,
+} from '../../../components/TransactionStatusModal';
+import { Text } from '../../../components/Text';
+import { bufferHex } from '../../../utils/SSZ';
+
+import {
+  CONTRACT_ADDRESS,
+  MAX_EFFECTIVE_BALANCE,
+  MIN_ACTIVATION_BALANCE,
+  TICKER_NAME,
+} from '../../../utils/envVars';
+import ModalHeader from './ModalHeader';
+import {
+  ModalBody,
+  ModalContent,
+  Hash,
+  AlertContainer,
+  AlertContent,
+} from './Shared';
+import { Heading } from '../../../components/Heading';
+import { Alert } from '../../../components/Alert';
+import { contractAbi } from '../../../contractAbi';
+import { buf2hex } from '../../../utils/buf2hex';
+
+const depositDataContainer = new ContainerType({
+  fields: {
+    pubkey: new ByteVectorType({
+      length: 48,
+    }),
+    withdrawalCredentials: new ByteVectorType({
+      length: 32,
+    }),
+    amount: new NumberUintType({
+      byteLength: 8,
+    }),
+    signature: new ByteVectorType({
+      length: 96,
+    }),
+  },
+});
+
+interface Props {
+  validator: Validator;
+}
+
+const PartialWithdraw: React.FC<Props> = ({ validator }) => {
+  const { connector, account } = useWeb3React();
+
+  const [amount, setAmount] = useState(0);
+  const [maxAmount, setMaxAmount] = useState(0);
+  const [showInputModal, setShowInputModal] = useState(false);
+  const [showTxModal, setShowTxModal] = useState(false);
+  const [transactionStatus, setTransactionStatus] = useState<TransactionStatus>(
+    'not_started'
+  );
+  const [txHash, setTxHash] = useState<string>('');
+
+  useEffect(() => {
+    setMaxAmount(
+      validator.type >= ValidatorType.Compounding
+        ? MAX_EFFECTIVE_BALANCE
+        : MIN_ACTIVATION_BALANCE
+    );
+  }, [validator]);
+
+  const openInputModal = () => {
+    setAmount(0);
+    setShowInputModal(true);
+  };
+
+  const closeInputModal = () => {
+    setShowInputModal(false);
+    setAmount(0);
+  };
+
+  const handleTxClose = () => {
+    setShowTxModal(false);
+    closeInputModal();
+  };
+
+  const createTopUpTransaction = async () => {
+    if (!amount || !account) return;
+
+    setShowInputModal(false);
+    setTransactionStatus('waiting_user_confirmation');
+    setShowTxModal(true);
+
+    const walletProvider: any = await (connector as AbstractConnector).getProvider();
+    const web3: any = new Web3(walletProvider);
+    const contract = new web3.eth.Contract(contractAbi, CONTRACT_ADDRESS);
+    const bnInput = new BigNumber(amount);
+    const transactionAmount = bnInput.multipliedBy(1e18).toNumber();
+    const reconstructedRootAmount = bnInput.multipliedBy(1e9).toNumber();
+
+    const transactionParameters: SendOptions = {
+      gasPrice: web3.utils.toHex(await web3.eth.getGasPrice()),
+      from: account as string,
+      value: transactionAmount,
+    };
+
+    const reconstructedKeyFile = {
+      pubkey: bufferHex(validator.pubkey.substring(2)),
+      withdrawalCredentials: Buffer.alloc(32),
+      amount: reconstructedRootAmount,
+      signature: Buffer.alloc(96),
+    };
+
+    const byteRoot = depositDataContainer.hashTreeRoot(reconstructedKeyFile);
+    const reconstructedDepositDataRoot = `0x${buf2hex(byteRoot)}`;
+
+    contract.methods
+      .deposit(
+        reconstructedKeyFile.pubkey,
+        reconstructedKeyFile.withdrawalCredentials,
+        reconstructedKeyFile.signature,
+        reconstructedDepositDataRoot
+      )
+      .send(transactionParameters)
+      .on('transactionHash', (hash: string): void => {
+        setTransactionStatus('confirm_on_chain');
+        setTxHash(hash);
+      })
+      .on('confirmation', () => {
+        setTransactionStatus('success');
+      })
+      .on('error', () => {
+        setTransactionStatus('error');
+      });
+  };
+
+  return (
+    <>
+      <Button
+        onClick={openInputModal}
+        label={<FormattedMessage defaultMessage="Top up" />}
+      />
+
+      {showInputModal && (
+        <Layer
+          position="center"
+          onEsc={closeInputModal}
+          onClickOutside={closeInputModal}
+          style={{ background: '#EEEEEE', maxWidth: '40rem' }}
+        >
+          <ModalHeader onClose={closeInputModal}>
+            <FormattedMessage defaultMessage="Top up validator" />
+          </ModalHeader>
+
+          <ModalBody>
+            <AlertContainer>
+              <Alert variant="info">
+                <AlertContent>
+                  <AlertIcon />
+                  <div>
+                    <Text>
+                      <FormattedMessage defaultMessage="Depositing beyond the validators maximum effective balance will result in those excess funds being immediately withdrawn and will not impact the effectiveness of the validator" />
+                    </Text>
+                  </div>
+                </AlertContent>
+              </Alert>
+            </AlertContainer>
+
+            <ModalContent>
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '1rem',
+                }}
+              >
+                <div
+                  style={{
+                    background: '#fff',
+                    padding: '1rem',
+                    maxWidth: '100%',
+                    borderRadius: '8px',
+                  }}
+                >
+                  <Heading
+                    level={3}
+                    style={{
+                      textTransform: 'uppercase',
+                      color: 'darkgreen',
+                    }}
+                  >
+                    <FormattedMessage defaultMessage="FROM" />
+                  </Heading>
+                  <Text>
+                    <strong>
+                      <FormattedMessage defaultMessage="Execution account" />:
+                    </strong>
+                  </Text>
+                  <Text
+                    style={{
+                      fontSize: '14px',
+                      color: '#555',
+                      marginBottom: '0.5rem',
+                    }}
+                  >
+                    <Hash style={{ fontSize: '1rem' }}>{account}</Hash>
+                  </Text>
+                  <Text>
+                    <FormattedMessage defaultMessage="Balance change" />:
+                    <strong>
+                      -{amount} {TICKER_NAME}
+                    </strong>
+                  </Text>
+                </div>
+
+                <div
+                  style={{
+                    background: '#fff',
+                    padding: '1rem',
+                    maxWidth: '100%',
+                    border: '2px solid darkgreen',
+                    borderRadius: '8px',
+                  }}
+                >
+                  <Heading
+                    level={3}
+                    style={{
+                      textTransform: 'uppercase',
+                      color: 'darkgreen',
+                    }}
+                  >
+                    <FormattedMessage defaultMessage="TO" />
+                  </Heading>
+                  <Text>
+                    <strong>
+                      <FormattedMessage defaultMessage="Index" />:{' '}
+                      {validator.validatorindex}
+                    </strong>
+                  </Text>
+                  <Text
+                    style={{
+                      fontSize: '14px',
+                      color: '#555',
+                      marginBottom: '0.5rem',
+                    }}
+                  >
+                    <Hash>{validator.pubkey}</Hash>
+                  </Text>
+                  <Text className="mb10">
+                    <FormattedMessage defaultMessage="Current balance" />:{' '}
+                    {validator.coinBalance} {TICKER_NAME}
+                  </Text>
+                  <Text className="mb10">
+                    <FormattedMessage defaultMessage="Max effective balance" />:{' '}
+                    {maxAmount} {TICKER_NAME}
+                  </Text>
+                  <Text>
+                    <FormattedMessage defaultMessage="Ending balance" />:{' '}
+                    <strong>
+                      {validator.coinBalance + amount} {TICKER_NAME}
+                    </strong>
+                  </Text>
+                </div>
+              </div>
+            </ModalContent>
+          </ModalBody>
+
+          <Box
+            as="footer"
+            gap="small"
+            direction="row"
+            align="center"
+            justify="center"
+            border="top"
+            pad="1rem"
+          >
+            <Form
+              style={{
+                width: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '0.5rem',
+              }}
+            >
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+              <label
+                htmlFor="withdrawal-amount"
+                style={{ marginBottom: '0.25rem' }}
+              >
+                <Text>
+                  <FormattedMessage
+                    defaultMessage="How much {TICKER_NAME} would you like to withdraw?"
+                    values={{ TICKER_NAME }}
+                  />
+                </Text>
+              </label>
+              <NumberInput
+                id="withdrawal-amount"
+                value={amount}
+                setValue={value => {
+                  setAmount(Math.min(value, maxAmount));
+                }}
+                allowDecimals
+                maxValue={maxAmount}
+              />
+              <Button
+                style={{ fontSize: '1rem' }}
+                label="Top up"
+                onClick={createTopUpTransaction}
+                color="dark-3"
+                fullWidth
+                type="submit"
+                disabled={!amount}
+              />
+            </Form>
+          </Box>
+        </Layer>
+      )}
+
+      {showTxModal && (
+        <TransactionStatusModal
+          headerMessage={<FormattedMessage defaultMessage="Top up validator" />}
+          txHash={txHash}
+          transactionStatus={transactionStatus}
+          onClose={handleTxClose}
+          handleRetry={createTopUpTransaction}
+        />
+      )}
+    </>
+  );
+};
+
+export default PartialWithdraw;

--- a/src/pages/Actions/components/ValidatorActions.tsx
+++ b/src/pages/Actions/components/ValidatorActions.tsx
@@ -2,17 +2,15 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { FormattedMessage } from 'react-intl';
-import { Validator } from '../types';
-import PushConsolidation from './PushConsolidation';
+import { Validator, ValidatorType } from '../types';
 import ForceExit from './ForceExit';
 import PartialWithdraw from './PartialWithdraw';
+import PushConsolidation from './PushConsolidation';
 import UpgradeCompounding from './UpgradeCompounding';
 
 import { Section as SharedSection } from './Shared';
 import { hasValidatorExited } from '../../../utils/validators';
 import {
-  EXECUTION_CREDENTIALS,
-  COMPOUNDING_CREDENTIALS,
   MIN_ACTIVATION_BALANCE,
   TICKER_NAME,
   MAX_EFFECTIVE_BALANCE,
@@ -73,8 +71,7 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
     const potentialSourceValidators = validators.filter(v => {
       const isSameValidator = v.pubkey === validator.pubkey;
       const hasBalance = v.balance > 0;
-      const isExecutionOrLater =
-        +v.withdrawalcredentials.slice(0, 4) >= +EXECUTION_CREDENTIALS;
+      const isExecutionOrLater = v.type >= ValidatorType.Execution;
       // Should be filtered out from API call for validators by withdrawal address; backup check
       const isSameCredentials =
         v.withdrawalcredentials.slice(4) ===
@@ -89,20 +86,17 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
 
     setSourceValidatorSet(potentialSourceValidators);
 
-    const potentialTargetValidators = potentialSourceValidators.filter(v => {
-      const isCompoundingOrLater =
-        +v.withdrawalcredentials.slice(0, 4) >= +COMPOUNDING_CREDENTIALS;
-      return isCompoundingOrLater;
-    });
+    const potentialTargetValidators = potentialSourceValidators.filter(
+      v => v.type >= ValidatorType.Compounding
+    );
 
     setTargetValidatorSet(potentialTargetValidators);
   }, [validator, validators]);
 
-  const accountType = +validator.withdrawalcredentials.slice(0, 4);
   const surplusEther = validator.coinBalance - MIN_ACTIVATION_BALANCE;
   return (
     <Section>
-      {accountType === +EXECUTION_CREDENTIALS && (
+      {validator.type === ValidatorType.Execution && (
         <Row>
           <div style={{ flex: 1 }}>
             <ActionTitle>
@@ -121,7 +115,7 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
         </Row>
       )}
 
-      {accountType >= +COMPOUNDING_CREDENTIALS && (
+      {validator.type >= ValidatorType.Compounding && (
         <Row>
           <div style={{ flex: 1 }}>
             <ActionTitle>
@@ -150,7 +144,7 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
         </Row>
       )}
 
-      {accountType >= +COMPOUNDING_CREDENTIALS && (
+      {validator.type >= ValidatorType.Compounding && (
         <Row>
           <div style={{ flex: 1 }}>
             <ActionTitle>

--- a/src/pages/Actions/components/ValidatorActions.tsx
+++ b/src/pages/Actions/components/ValidatorActions.tsx
@@ -6,6 +6,7 @@ import { Validator, ValidatorType } from '../types';
 import ForceExit from './ForceExit';
 import PartialWithdraw from './PartialWithdraw';
 import PushConsolidation from './PushConsolidation';
+import TopUp from './TopUp';
 import UpgradeCompounding from './UpgradeCompounding';
 
 import { Section as SharedSection } from './Shared';
@@ -96,6 +97,16 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
   const surplusEther = validator.coinBalance - MIN_ACTIVATION_BALANCE;
   return (
     <Section>
+      <Row>
+        <div style={{ flex: 1 }}>
+          <ActionTitle>
+            <FormattedMessage defaultMessage="Add funds to your validator" />
+          </ActionTitle>
+          <FormattedMessage defaultMessage="Adding funds to a validator not yet at it's max EB can increase rewards and penalties." />
+        </div>
+        <TopUp validator={validator} />
+      </Row>
+
       {validator.type === ValidatorType.Execution && (
         <Row>
           <div style={{ flex: 1 }}>

--- a/src/pages/Actions/components/ValidatorDetails.tsx
+++ b/src/pages/Actions/components/ValidatorDetails.tsx
@@ -6,14 +6,10 @@ import { Heading } from '../../../components/Heading';
 import { Text } from '../../../components/Text';
 import { Section, CopyContainer, Hash } from './Shared';
 
-import { Validator } from '../types';
+import { Validator, ValidatorType } from '../types';
 
 import { hasValidatorExited } from '../../../utils/validators';
-import {
-  TICKER_NAME,
-  COMPOUNDING_CREDENTIALS,
-  EXECUTION_CREDENTIALS,
-} from '../../../utils/envVars';
+import { TICKER_NAME } from '../../../utils/envVars';
 import { epochToDate } from '../../../utils/beaconchain';
 
 const ValidatorDetails = ({ validator }: { validator: Validator }) => {
@@ -27,7 +23,6 @@ const ValidatorDetails = ({ validator }: { validator: Validator }) => {
     }, 2000);
   };
 
-  const prefix = validator.withdrawalcredentials.slice(0, 4);
   const hasExitCompleted =
     hasValidatorExited(validator) &&
     epochToDate(validator.exitepoch).getTime() < Date.now();
@@ -112,13 +107,15 @@ const ValidatorDetails = ({ validator }: { validator: Validator }) => {
 
         <Text>
           <FormattedMessage defaultMessage="Withdrawal credential type" />:{' '}
-          <span style={{ fontFamily: 'monospace' }}>{prefix}</span>{' '}
-          {prefix === COMPOUNDING_CREDENTIALS && (
+          <span style={{ fontFamily: 'monospace' }}>
+            {validator.withdrawalcredentials.slice(0, 4)}
+          </span>{' '}
+          {validator.type === ValidatorType.Compounding && (
             <span>
               <FormattedMessage defaultMessage="(Compounding)" />
             </span>
           )}
-          {prefix === EXECUTION_CREDENTIALS && (
+          {validator.type === ValidatorType.Execution && (
             <span>
               <FormattedMessage defaultMessage="(Regular withdrawals)" />
             </span>

--- a/src/pages/Actions/index.tsx
+++ b/src/pages/Actions/index.tsx
@@ -10,7 +10,7 @@ import {
   BeaconChainValidator,
   BeaconChainValidatorResponse,
 } from '../TopUp/types';
-import { Props, Validator } from './types';
+import { Props, Validator, ValidatorType } from './types';
 
 import ValidatorActions from './components/ValidatorActions';
 
@@ -109,10 +109,11 @@ const fetchValidatorsByPubkeys = async (
     const data: BeaconChainValidator[] = Array.isArray(json.data)
       ? json.data
       : [json.data];
+
     return data.map(v => ({
       ...v,
-      // balanceDisplay: `${coinBalance}${TICKER_NAME}`,
       coinBalance: new BigNumber(v.balance).div(ETHER_TO_GWEI).toNumber(),
+      type: +v.withdrawalcredentials.slice(0, 4) as ValidatorType,
     }));
   } catch (error) {
     console.warn(

--- a/src/pages/Actions/types.ts
+++ b/src/pages/Actions/types.ts
@@ -3,6 +3,12 @@ export interface StateProps {}
 export interface DispatchProps {}
 export type Props = StateProps & DispatchProps & OwnProps;
 
+export enum ValidatorType {
+  BLS = 0,
+  Execution = 1,
+  Compounding = 2,
+}
+
 export interface Validator {
   activationeligibilityepoch: number;
   activationepoch: number;
@@ -16,6 +22,7 @@ export interface Validator {
   pubkey: string;
   slashed: boolean;
   status: string;
+  type: ValidatorType;
   validatorindex: number;
   withdrawableepoch: number;
   withdrawalcredentials: string;


### PR DESCRIPTION
Duplicates logic from `TopupPage` and `PartialWithdraw` to allow a user to send funds to their validator. 

This is branched off of #728 