### PR TITLE
Hide validator actions modals during transaction submission

### DIFF
--- a/src/components/TransactionStatusModal/TransactionStatusModal.tsx
+++ b/src/components/TransactionStatusModal/TransactionStatusModal.tsx
@@ -11,7 +11,7 @@ import { Button } from '../Button';
 
 interface TopUpTransactionModalProps {
   headerMessage: string | ReactNode;
-  onClose: () => void;
+  onClose: (success: boolean) => void;
   transactionStatus: TransactionStatus;
   txHash: string;
   handleRetry: () => void;
@@ -57,10 +57,14 @@ export const TransactionStatusModal: React.FC<TopUpTransactionModalProps> = ({
     return 'complete';
   }, [transactionStatus]);
 
+  const onCloseModal = () => {
+    onClose(signTxStatus === 'complete');
+  };
+
   return (
-    <Layer position="center" onClickOutside={onClose} onEsc={onClose}>
+    <Layer position="center" onClickOutside={onCloseModal} onEsc={onCloseModal}>
       <Box width="medium">
-        <ModalHeader onClose={onClose}>{headerMessage}</ModalHeader>
+        <ModalHeader onClose={onCloseModal}>{headerMessage}</ModalHeader>
 
         <TransactionProgress
           signTxStatus={signTxStatus}
@@ -97,7 +101,7 @@ export const TransactionStatusModal: React.FC<TopUpTransactionModalProps> = ({
           {signTxStatus === 'complete' && (
             <Button
               label={<FormattedMessage defaultMessage="Finish" />}
-              onClick={onClose}
+              onClick={onCloseModal}
             />
           )}
         </Box>

--- a/src/pages/Actions/components/AddFunds.tsx
+++ b/src/pages/Actions/components/AddFunds.tsx
@@ -101,9 +101,13 @@ const AddFunds: React.FC<Props> = ({ validator }) => {
     setEtherAmount(0);
   };
 
-  const handleTxClose = () => {
+  const handleTxClose = (success: boolean) => {
     setShowTxModal(false);
-    closeInputModal();
+    if (!success) {
+      setShowInputModal(true);
+    } else {
+      closeInputModal();
+    }
   };
 
   const createTopUpTransaction = async () => {

--- a/src/pages/Actions/components/ForceExit.tsx
+++ b/src/pages/Actions/components/ForceExit.tsx
@@ -55,14 +55,18 @@ const ForceExit: React.FC<Props> = ({ validator }) => {
     setUserConfirmationValue('');
   };
 
-  const handleTxModalClose = () => {
+  const handleTxModalClose = (success: boolean) => {
     setShowTxModal(false);
-    closeConfirmationModal();
+
+    if (!success) {
+      openExitModal();
+    }
   };
 
   const createExitTransaction = async () => {
     if (!account) return;
 
+    closeConfirmationModal();
     setTransactionStatus('waiting_user_confirmation');
     setShowTxModal(true);
 

--- a/src/pages/Actions/components/PartialWithdraw.tsx
+++ b/src/pages/Actions/components/PartialWithdraw.tsx
@@ -65,14 +65,19 @@ const PartialWithdraw: React.FC<Props> = ({ validator }) => {
     setEtherAmount(0);
   };
 
-  const handleTxClose = () => {
+  const handleTxClose = (success: boolean) => {
     setShowTxModal(false);
-    closeInputModal();
+    if (success) {
+      closeInputModal();
+    } else {
+      setShowInputModal(true);
+    }
   };
 
   const createWithdrawTransaction = async () => {
     if (!etherAmount || !account) return;
 
+    setShowInputModal(false);
     setTransactionStatus('waiting_user_confirmation');
     setShowTxModal(true);
 

--- a/src/pages/Actions/components/PullConsolidation.tsx
+++ b/src/pages/Actions/components/PullConsolidation.tsx
@@ -50,8 +50,8 @@ const PullConsolidation = ({
   const [txHash, setTxHash] = useState<string>('');
 
   const confirmConsolidate = () => {
-    setShowSelectValidatorModal(true);
     setSourceValidator(null);
+    setShowSelectValidatorModal(true);
   };
 
   const closeSelectValidatorModal = () => {
@@ -62,6 +62,7 @@ const PullConsolidation = ({
   const createConsolidationTransaction = async () => {
     if (!account || !sourceValidator) return;
 
+    setShowSelectValidatorModal(false);
     setTransactionStatus('waiting_user_confirmation');
     setShowTxModal(true);
 
@@ -92,9 +93,13 @@ const PullConsolidation = ({
     }
   };
 
-  const handleClose = () => {
+  const handleClose = (success: boolean) => {
     setShowTxModal(false);
-    closeSelectValidatorModal();
+    if (success) {
+      closeSelectValidatorModal();
+    } else {
+      setShowSelectValidatorModal(true);
+    }
   };
   return (
     <>

--- a/src/pages/Actions/components/PushConsolidation.tsx
+++ b/src/pages/Actions/components/PushConsolidation.tsx
@@ -50,8 +50,8 @@ const PushConsolidation = ({
   const [txHash, setTxHash] = useState<string>('');
 
   const confirmConsolidate = () => {
-    setShowSelectValidatorModal(true);
     setTargetValidator(null);
+    setShowSelectValidatorModal(true);
   };
 
   const closeSelectValidatorModal = () => {
@@ -62,6 +62,7 @@ const PushConsolidation = ({
   const createConsolidationTransaction = async () => {
     if (!account || !targetValidator) return;
 
+    setShowSelectValidatorModal(false);
     setTransactionStatus('waiting_user_confirmation');
     setShowTxModal(true);
 
@@ -92,9 +93,13 @@ const PushConsolidation = ({
     }
   };
 
-  const handleClose = () => {
+  const handleClose = (success: boolean) => {
     setShowTxModal(false);
-    closeSelectValidatorModal();
+    if (success) {
+      closeSelectValidatorModal();
+    } else {
+      setShowSelectValidatorModal(true);
+    }
   };
   return (
     <>

--- a/src/pages/Actions/components/UpgradeCompounding.tsx
+++ b/src/pages/Actions/components/UpgradeCompounding.tsx
@@ -54,9 +54,13 @@ const UpgradeCompounding: React.FC<Props> = ({ validator }) => {
     setShowConfirmationModal(false);
   };
 
-  const handleTxModalClose = () => {
+  const handleTxModalClose = (success: boolean) => {
     setShowTxModal(false);
-    closeConfirmationModal();
+    if (success) {
+      closeConfirmationModal();
+    } else {
+      setShowConfirmationModal(true);
+    }
   };
 
   const createUpgradeMessage = async () => {
@@ -64,6 +68,7 @@ const UpgradeCompounding: React.FC<Props> = ({ validator }) => {
       return;
     }
 
+    setShowConfirmationModal(false);
     setTransactionStatus('waiting_user_confirmation');
     setShowTxModal(true);
 


### PR DESCRIPTION
Having a modal on top of another modal is not ideal and was noticing some UX issues such as a shaking screen and a disabled scrollbar during some instances.

Three options
1) Hide input modal during transaction submission and redisplay if transaction failed
2) Hide input modal during transaction submission and do not redisplay
3) Migrate transaction details into input modal as a second screen

This PR explores option 1