### PR TITLE
feat: guard against EXCESS_INHIBITOR queue

### DIFF
--- a/src/utils/envVars.ts
+++ b/src/utils/envVars.ts
@@ -106,3 +106,5 @@ if(process.env.REACT_APP_MAX_QUERY_LIMIT && Number.isNaN(Number(process.env.REAC
     throw new Error("REACT_APP_MAX_QUERY_LIMIT must be of type: number")
 }
 export const MAX_QUERY_LIMIT            = Number(process.env.REACT_APP_MAX_QUERY_LIMIT) || 100;
+
+export const EXCESS_INHIBITOR           = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";


### PR DESCRIPTION
Fixes bug causing browsers to freeze pre-Pectra-fork since these contracts are returning the 2^255 EXCESS_INHIBITOR value when fetching the queue lengths. This falls back if this is returned and uses a queue length of 0. Will only impact prior to fork.