### PR TITLE
Append to compounding/withdrawal fee

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -679,6 +679,12 @@
       "value": "Check deposit contract details"
     }
   ],
+  "1iI5Ju": [
+    {
+      "type": 0,
+      "value": "Consolidation requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes."
+    }
+  ],
   "1ingnQ": [
     {
       "type": 0,
@@ -1367,12 +1373,6 @@
     {
       "type": 0,
       "value": " validator"
-    }
-  ],
-  "5w6WCG": [
-    {
-      "type": 0,
-      "value": "Withdraw requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount not the amount you request to withdraw."
     }
   ],
   "63gLLu": [
@@ -2625,6 +2625,12 @@
     {
       "type": 0,
       "value": "5. Time to deposit"
+    }
+  ],
+  "ETn48e": [
+    {
+      "type": 0,
+      "value": "Upgrade and consolidation requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes."
     }
   ],
   "EXLB88": [
@@ -4339,6 +4345,12 @@
       "value": "Your network has changed"
     }
   ],
+  "PF61Eu": [
+    {
+      "type": 0,
+      "value": "Exit requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes."
+    }
+  ],
   "PHZO0L": [
     {
       "type": 0,
@@ -5093,6 +5105,12 @@
     {
       "type": 0,
       "value": "I am certain that the validator I am topping up is my validator."
+    }
+  ],
+  "VlItBm": [
+    {
+      "type": 0,
+      "value": "Withdraw requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes."
     }
   ],
   "Vm6cRY": [
@@ -7025,12 +7043,6 @@
       "value": "TICKER_NAME"
     }
   ],
-  "jQ+xag": [
-    {
-      "type": 0,
-      "value": "Consolidation requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount."
-    }
-  ],
   "jVlgXS": [
     {
       "type": 0,
@@ -8049,12 +8061,6 @@
       "value": "Your validators"
     }
   ],
-  "ovXvfi": [
-    {
-      "type": 0,
-      "value": "Exit requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount not the validator balance that is being exited."
-    }
-  ],
   "ox304v": [
     {
       "type": 0,
@@ -8819,12 +8825,6 @@
     {
       "type": 0,
       "value": "Status"
-    }
-  ],
-  "tzr3AP": [
-    {
-      "type": 0,
-      "value": "Upgrading and consolidation requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount."
     }
   ],
   "u/3saa": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -1369,6 +1369,12 @@
       "value": " validator"
     }
   ],
+  "5w6WCG": [
+    {
+      "type": 0,
+      "value": "Withdraw requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount not the amount you request to withdraw."
+    }
+  ],
   "63gLLu": [
     {
       "type": 0,
@@ -7019,6 +7025,12 @@
       "value": "TICKER_NAME"
     }
   ],
+  "jQ+xag": [
+    {
+      "type": 0,
+      "value": "Consolidation requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount."
+    }
+  ],
   "jVlgXS": [
     {
       "type": 0,
@@ -8037,6 +8049,12 @@
       "value": "Your validators"
     }
   ],
+  "ovXvfi": [
+    {
+      "type": 0,
+      "value": "Exit requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount not the validator balance that is being exited."
+    }
+  ],
   "ox304v": [
     {
       "type": 0,
@@ -8801,6 +8819,12 @@
     {
       "type": 0,
       "value": "Status"
+    }
+  ],
+  "tzr3AP": [
+    {
+      "type": 0,
+      "value": "Upgrading and consolidation requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount."
     }
   ],
   "u/3saa": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -260,6 +260,9 @@
   "1fytak": {
     "message": "Check deposit contract details"
   },
+  "1iI5Ju": {
+    "message": "Consolidation requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes."
+  },
   "1ingnQ": {
     "message": "More on Ethereum staking economics"
   },
@@ -488,9 +491,6 @@
   },
   "5v36Is": {
     "message": "Exiting a {client} validator"
-  },
-  "5w6WCG": {
-    "message": "Withdraw requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount not the amount you request to withdraw."
   },
   "63gLLu": {
     "message": "average"
@@ -992,6 +992,9 @@
   },
   "EThT2C": {
     "message": "5. Time to deposit"
+  },
+  "ETn48e": {
+    "message": "Upgrade and consolidation requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes."
   },
   "EXLB88": {
     "message": "This is a test network ⚠️"
@@ -1638,6 +1641,9 @@
   "P9mVZK": {
     "message": "Your network has changed"
   },
+  "PF61Eu": {
+    "message": "Exit requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes."
+  },
   "PHZO0L": {
     "message": "Launchpad walkthrough tutorial"
   },
@@ -1953,6 +1959,9 @@
   },
   "VctWDX": {
     "message": "I am certain that the validator I am topping up is my validator."
+  },
+  "VlItBm": {
+    "message": "Withdraw requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes."
   },
   "Vm6cRY": {
     "message": "This communication is secured using a {jwt} secret, which is a secret key that is shared only between the two clients to authenticate one another. This shared JWT secret must be made available to each client (both execution and consensus clients) to allow them to communicate with one another properly."
@@ -2667,9 +2676,6 @@
   "jM+e2M": {
     "message": "Maximum effective balance of {MAX_EFFECTIVE_BALANCE} {TICKER_NAME}"
   },
-  "jQ+xag": {
-    "message": "Consolidation requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount."
-  },
   "jVlgXS": {
     "message": "Dig deeper into the Ethereum roadmap."
   },
@@ -3067,9 +3073,6 @@
   "ouW9ov": {
     "message": "Your validators"
   },
-  "ovXvfi": {
-    "message": "Exit requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount not the validator balance that is being exited."
-  },
   "ox304v": {
     "message": "An error occurred"
   },
@@ -3350,9 +3353,6 @@
   },
   "tzMNF3": {
     "message": "Status"
-  },
-  "tzr3AP": {
-    "message": "Upgrading and consolidation requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount."
   },
   "u/3saa": {
     "message": "Your wallet is on the wrong Ethereum network. To continue, connect to {executionLayerName}."

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -489,6 +489,9 @@
   "5v36Is": {
     "message": "Exiting a {client} validator"
   },
+  "5w6WCG": {
+    "message": "Withdraw requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount not the amount you request to withdraw."
+  },
   "63gLLu": {
     "message": "average"
   },
@@ -2664,6 +2667,9 @@
   "jM+e2M": {
     "message": "Maximum effective balance of {MAX_EFFECTIVE_BALANCE} {TICKER_NAME}"
   },
+  "jQ+xag": {
+    "message": "Consolidation requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount."
+  },
   "jVlgXS": {
     "message": "Dig deeper into the Ethereum roadmap."
   },
@@ -3061,6 +3067,9 @@
   "ouW9ov": {
     "message": "Your validators"
   },
+  "ovXvfi": {
+    "message": "Exit requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount not the validator balance that is being exited."
+  },
   "ox304v": {
     "message": "An error occurred"
   },
@@ -3341,6 +3350,9 @@
   },
   "tzMNF3": {
     "message": "Status"
+  },
+  "tzr3AP": {
+    "message": "Upgrading and consolidation requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount."
   },
   "u/3saa": {
     "message": "Your wallet is on the wrong Ethereum network. To continue, connect to {executionLayerName}."

--- a/src/pages/Actions/components/ForceExit.tsx
+++ b/src/pages/Actions/components/ForceExit.tsx
@@ -157,6 +157,9 @@ const ForceExit: React.FC<Props> = ({ validator }) => {
                   <Text style={{ fontSize: '1rem' }}>
                     <FormattedMessage defaultMessage="You'll be asked to sign a message with your wallet. Processing of exits is not immediate, so account for up to several days before completion." />
                   </Text>
+                  <Text>
+                    <FormattedMessage defaultMessage="Exit requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount not the validator balance that is being exited." />
+                  </Text>
                   <ul
                     style={{
                       paddingInlineStart: '1.5rem',

--- a/src/pages/Actions/components/ForceExit.tsx
+++ b/src/pages/Actions/components/ForceExit.tsx
@@ -158,7 +158,7 @@ const ForceExit: React.FC<Props> = ({ validator }) => {
                     <FormattedMessage defaultMessage="You'll be asked to sign a message with your wallet. Processing of exits is not immediate, so account for up to several days before completion." />
                   </Text>
                   <Text>
-                    <FormattedMessage defaultMessage="Exit requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount not the validator balance that is being exited." />
+                    <FormattedMessage defaultMessage="Exit requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes." />
                   </Text>
                   <ul
                     style={{

--- a/src/pages/Actions/components/PartialWithdraw.tsx
+++ b/src/pages/Actions/components/PartialWithdraw.tsx
@@ -370,7 +370,7 @@ const PartialWithdraw: React.FC<Props> = ({ validator }) => {
                 </div>
               </div>
 
-              {showTx && (
+              {showTx ? (
                 <TransactionStatusInsert
                   headerMessage={
                     <FormattedMessage
@@ -381,6 +381,10 @@ const PartialWithdraw: React.FC<Props> = ({ validator }) => {
                   txHash={txHash}
                   transactionStatus={txStatus}
                 />
+              ) : (
+                <Text>
+                  <FormattedMessage defaultMessage="Withdraw requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount not the amount you request to withdraw." />
+                </Text>
               )}
             </ModalContent>
           </ModalBody>

--- a/src/pages/Actions/components/PartialWithdraw.tsx
+++ b/src/pages/Actions/components/PartialWithdraw.tsx
@@ -383,7 +383,7 @@ const PartialWithdraw: React.FC<Props> = ({ validator }) => {
                 />
               ) : (
                 <Text>
-                  <FormattedMessage defaultMessage="Withdraw requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount not the amount you request to withdraw." />
+                  <FormattedMessage defaultMessage="Withdraw requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes." />
                 </Text>
               )}
             </ModalContent>

--- a/src/pages/Actions/components/PullConsolidation.tsx
+++ b/src/pages/Actions/components/PullConsolidation.tsx
@@ -438,6 +438,9 @@ const PullConsolidation = ({
                   <Text>
                     <FormattedMessage defaultMessage="You'll be asked to sign a message with your wallet. Processing of exits is not immediate, so account for up to several days before completion." />
                   </Text>
+                  <Text>
+                    <FormattedMessage defaultMessage="Consolidation requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount." />
+                  </Text>
                   <ul style={{ paddingInlineStart: '1.5rem', marginTop: 0 }}>
                     <li>
                       <Text as="span">

--- a/src/pages/Actions/components/PullConsolidation.tsx
+++ b/src/pages/Actions/components/PullConsolidation.tsx
@@ -439,7 +439,7 @@ const PullConsolidation = ({
                     <FormattedMessage defaultMessage="You'll be asked to sign a message with your wallet. Processing of exits is not immediate, so account for up to several days before completion." />
                   </Text>
                   <Text>
-                    <FormattedMessage defaultMessage="Consolidation requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount." />
+                    <FormattedMessage defaultMessage="Consolidation requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes." />
                   </Text>
                   <ul style={{ paddingInlineStart: '1.5rem', marginTop: 0 }}>
                     <li>

--- a/src/pages/Actions/components/PushConsolidation.tsx
+++ b/src/pages/Actions/components/PushConsolidation.tsx
@@ -189,6 +189,9 @@ const PushConsolidation = ({
                   <Text>
                     <FormattedMessage defaultMessage="You'll be asked to sign a message with your wallet. Processing of exits is not immediate, so account for up to several days before completion." />
                   </Text>
+                  <Text>
+                    <FormattedMessage defaultMessage="Consolidation requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount." />
+                  </Text>
                   <ul style={{ paddingInlineStart: '1.5rem', marginTop: 0 }}>
                     <li>
                       <Text as="span">

--- a/src/pages/Actions/components/PushConsolidation.tsx
+++ b/src/pages/Actions/components/PushConsolidation.tsx
@@ -190,7 +190,7 @@ const PushConsolidation = ({
                     <FormattedMessage defaultMessage="You'll be asked to sign a message with your wallet. Processing of exits is not immediate, so account for up to several days before completion." />
                   </Text>
                   <Text>
-                    <FormattedMessage defaultMessage="Consolidation requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount." />
+                    <FormattedMessage defaultMessage="Consolidation requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes." />
                   </Text>
                   <ul style={{ paddingInlineStart: '1.5rem', marginTop: 0 }}>
                     <li>

--- a/src/pages/Actions/components/UpgradeCompounding.tsx
+++ b/src/pages/Actions/components/UpgradeCompounding.tsx
@@ -155,7 +155,7 @@ const UpgradeCompounding: React.FC<Props> = ({ validator }) => {
                     <FormattedMessage defaultMessage="You'll be asked to sign a message with your wallet. Processing of upgrades is not immediate, so account for up to several days before completion." />
                   </Text>
                   <Text>
-                    <FormattedMessage defaultMessage="Upgrading and consolidation requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount." />
+                    <FormattedMessage defaultMessage="Upgrade and consolidation requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes." />
                   </Text>
                   <ul style={{ paddingInlineStart: '1.5rem', marginTop: 0 }}>
                     <li>

--- a/src/pages/Actions/components/UpgradeCompounding.tsx
+++ b/src/pages/Actions/components/UpgradeCompounding.tsx
@@ -154,6 +154,9 @@ const UpgradeCompounding: React.FC<Props> = ({ validator }) => {
                   <Text>
                     <FormattedMessage defaultMessage="You'll be asked to sign a message with your wallet. Processing of upgrades is not immediate, so account for up to several days before completion." />
                   </Text>
+                  <Text>
+                    <FormattedMessage defaultMessage="Upgrading and consolidation requests go into a separate queue, requiring a small fee to join. The fee, which is minimal when the queue is short, will be shown as your transaction's send amount." />
+                  </Text>
                   <ul style={{ paddingInlineStart: '1.5rem', marginTop: 0 }}>
                     <li>
                       <Text as="span">

--- a/src/pages/Actions/utils.ts
+++ b/src/pages/Actions/utils.ts
@@ -4,10 +4,15 @@ import Web3 from 'web3';
 import { TransactionConfig } from 'web3-core';
 import {
   COMPOUNDING_CONTRACT_ADDRESS,
-  WITHDRAWAL_CONTRACT_ADDRESS,
-  TICKER_NAME,
+  COMPOUNDING_FEE_ADDITION,
   EXCESS_INHIBITOR,
+<<<<<<< HEAD
   SHARD_COMMITTEE_PERIOD,
+=======
+  TICKER_NAME,
+  WITHDRAWAL_CONTRACT_ADDRESS,
+  WITHDRAWAL_FEE_ADDITION,
+>>>>>>> 3340b33 (Adding compounding/withdrawal fee addition as env param)
 } from '../../utils/envVars';
 import { BeaconChainValidator } from '../TopUp/types';
 import { currentEpoch } from '../../utils/beaconchain';
@@ -21,9 +26,6 @@ export type TxConfigQueue = {
   transactionParams: TransactionConfig;
   queue: Queue;
 };
-
-const COMPOUNDING_FEE_ADDITION = 3;
-const WITHDRAWAL_FEE_ADDITION = 6;
 
 const getRequiredFee = (queueLength: BigNumber): BigNumber => {
   let i = new BigNumber(1);
@@ -125,7 +127,7 @@ export const generateCompoundParams = async (
     from: address,
     // calldata (96 bytes): sourceValidator.pubkey (48 bytes) + targetValidator.pubkey (48 bytes)
     data: `0x${source.substring(2)}${target.substring(2)}`,
-    value: queue.fee.toString(),
+    value: queue.fee.toFixed(0),
     gas: 200000,
   };
 
@@ -146,7 +148,7 @@ export const generateWithdrawalParams = async (
     from: address,
     // calldata (56 bytes): sourceValidator.pubkey (48 bytes) + amount (8 bytes)
     data: `0x${pubkey.substring(2)}${amount.toString(16).padStart(16, '0')}`,
-    value: queue.fee.toString(),
+    value: queue.fee.toFixed(0),
     gas: 200000,
   };
   return { transactionParams, queue };

--- a/src/pages/Actions/utils.ts
+++ b/src/pages/Actions/utils.ts
@@ -22,6 +22,9 @@ export type TxConfigQueue = {
   queue: Queue;
 };
 
+const COMPOUNDING_FEE_ADDITION = 3;
+const WITHDRAWAL_FEE_ADDITION = 6;
+
 const getRequiredFee = (queueLength: BigNumber): BigNumber => {
   let i = new BigNumber(1);
   let output = new BigNumber(0);
@@ -33,7 +36,7 @@ const getRequiredFee = (queueLength: BigNumber): BigNumber => {
     i = i.plus(1);
   }
 
-  return output.dividedBy(17);
+  return output.dividedToIntegerBy(17);
 };
 
 export const getCompoundingQueueLength = async (
@@ -64,7 +67,10 @@ export const getCompoundingQueueLength = async (
 export const getCompoundingQueue = async (web3: Web3): Promise<Queue> => {
   const length = await getCompoundingQueueLength(web3);
 
-  const fee = getRequiredFee(length);
+  // Add to the queue length to reduce the likelihood of transaction failure
+  const appendedFeeSize = length.plus(COMPOUNDING_FEE_ADDITION);
+
+  const fee = getRequiredFee(appendedFeeSize);
 
   return { length, fee };
 };
@@ -97,7 +103,10 @@ export const getWithdrawalQueueLength = async (
 export const getWithdrawalQueue = async (web3: Web3): Promise<Queue> => {
   const length = await getWithdrawalQueueLength(web3);
 
-  const fee = getRequiredFee(length);
+  // Add to the queue length to reduce the likelihood of transaction failure
+  const appendedFeeSize = length.plus(WITHDRAWAL_FEE_ADDITION);
+
+  const fee = getRequiredFee(appendedFeeSize);
 
   return { length, fee };
 };

--- a/src/pages/Actions/utils.ts
+++ b/src/pages/Actions/utils.ts
@@ -6,13 +6,10 @@ import {
   COMPOUNDING_CONTRACT_ADDRESS,
   COMPOUNDING_FEE_ADDITION,
   EXCESS_INHIBITOR,
-<<<<<<< HEAD
   SHARD_COMMITTEE_PERIOD,
-=======
   TICKER_NAME,
   WITHDRAWAL_CONTRACT_ADDRESS,
   WITHDRAWAL_FEE_ADDITION,
->>>>>>> 3340b33 (Adding compounding/withdrawal fee addition as env param)
 } from '../../utils/envVars';
 import { BeaconChainValidator } from '../TopUp/types';
 import { currentEpoch } from '../../utils/beaconchain';

--- a/src/utils/envVars.ts
+++ b/src/utils/envVars.ts
@@ -109,5 +109,6 @@ if(process.env.REACT_APP_MAX_QUERY_LIMIT && Number.isNaN(Number(process.env.REAC
     throw new Error("REACT_APP_MAX_QUERY_LIMIT must be of type: number")
 }
 export const MAX_QUERY_LIMIT            = Number(process.env.REACT_APP_MAX_QUERY_LIMIT) || 100;
-
+export const COMPOUNDING_FEE_ADDITION   = Number(process.env.REACT_APP_COMPOUNDING_FEE_ADDITION) || 3;
+export const WITHDRAWAL_FEE_ADDITION    = Number(process.env.REACT_APP_WITHDRAWAL_FEE_ADDITION) || 6;
 export const EXCESS_INHIBITOR           = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";


### PR DESCRIPTION
If two transactions with the same fee are processed at the same time, if the fee were to increase after the first transaction is added, the second transaction will fail.  To reduce the likelihood of this we can add a hardcoded fee amount to each compounding and withdrawal requests. This won't work for extreme demand but is a quick and dirty implementation that will drastically reduce the likelihood in every other scenario.

Additionally, a bug was discovered where the fee amount was not returned as a decimal which resulted in failures to submit the transaction.