### PR TITLE
Pectra mismatch consolidation

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -87,6 +87,7 @@ export type SelectProps = {
   options: Option[];
   value: string;
   onChange: (value: string) => void;
+  onSearchChange?: (value: string) => void;
   placeholder?: string;
   searchPlaceholder?: string;
 };
@@ -95,6 +96,7 @@ const Select = ({
   options,
   value,
   onChange,
+  onSearchChange,
   placeholder,
   searchPlaceholder,
 }: SelectProps) => {
@@ -103,10 +105,13 @@ const Select = ({
   const [search, setSearch] = useState('');
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const handleSelect = (choice: string) => {
-    onChange(choice);
+  useEffect(() => {
     setIsOpen(false);
     setSearch('');
+  }, [value]);
+
+  const handleSelect = (choice: string) => {
+    onChange(choice);
   };
 
   const handleClickOutside = (event: MouseEvent) => {
@@ -155,7 +160,15 @@ const Select = ({
           <SearchInput
             type="text"
             value={search}
-            onChange={e => setSearch(e.target.value)}
+            onChange={e => {
+              const newSearchValue = e.target.value;
+              if (newSearchValue !== search) {
+                setSearch(newSearchValue);
+                if (onSearchChange) {
+                  onSearchChange(newSearchValue);
+                }
+              }
+            }}
             placeholder={
               searchPlaceholder ||
               formatMessage({ defaultMessage: 'Type to filter' })

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -1375,6 +1375,12 @@
       "value": " validator"
     }
   ],
+  "6/hnxI": [
+    {
+      "type": 0,
+      "value": "Target validator is not active"
+    }
+  ],
   "63gLLu": [
     {
       "type": 0,
@@ -7819,6 +7825,12 @@
     {
       "type": 0,
       "value": "Exit epoch"
+    }
+  ],
+  "n5y2hu": [
+    {
+      "type": 0,
+      "value": "A validator can only be consolidated to if it is in the proper state of active ongoing."
     }
   ],
   "nBhisA": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -3035,6 +3035,20 @@
       "value": "Configure your execution client"
     }
   ],
+  "HV2kN4": [
+    {
+      "type": 0,
+      "value": "Please type 'I TRANSFER MY FULL VALIDATOR BALANCE TO THE OWNER OF "
+    },
+    {
+      "type": 1,
+      "value": "targetIndex"
+    },
+    {
+      "type": 0,
+      "value": "' to acknowledge you understand where your validator balance is being transferred to."
+    }
+  ],
   "HX93/h": [
     {
       "type": 0,
@@ -4731,12 +4745,6 @@
     {
       "type": 0,
       "value": " withdrawal credentials and has broadcast a voluntary exit, there is no further action required until the processing is complete."
-    }
-  ],
-  "Sa8NCw": [
-    {
-      "type": 0,
-      "value": "No eligible target accounts found."
     }
   ],
   "SaR1pU": [
@@ -6651,20 +6659,6 @@
     {
       "type": 0,
       "value": "Latest Reth Benchmarks"
-    }
-  ],
-  "gddfK3": [
-    {
-      "type": 0,
-      "value": "Please type the target validator index ("
-    },
-    {
-      "type": 1,
-      "value": "targetIndex"
-    },
-    {
-      "type": 0,
-      "value": ") to acknowledge you understand where your validator balance is being transferred to."
     }
   ],
   "gfLdAQ": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -4801,6 +4801,12 @@
       "value": "exiting the validator you choose above"
     }
   ],
+  "Sjv4KR": [
+    {
+      "type": 0,
+      "value": "A validator can only be consolidated to if it is in the proper state of active/online."
+    }
+  ],
   "SqKNq2": [
     {
       "type": 0,
@@ -7825,12 +7831,6 @@
     {
       "type": 0,
       "value": "Exit epoch"
-    }
-  ],
-  "n5y2hu": [
-    {
-      "type": 0,
-      "value": "A validator can only be consolidated to if it is in the proper state of active ongoing."
     }
   ],
   "nBhisA": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -1737,6 +1737,12 @@
       "value": "Configure Teku"
     }
   ],
+  "8J6IfS": [
+    {
+      "type": 0,
+      "value": "Filter your validators by index or pubkey or search by pubkey"
+    }
+  ],
   "8JtiQS": [
     {
       "type": 0,
@@ -1753,6 +1759,12 @@
     {
       "type": 0,
       "value": "Transfer entire balance to another one of your validator accounts, consolidating two accounts into one. Target account must be upgraded to compounding type."
+    }
+  ],
+  "8WAAtu": [
+    {
+      "type": 0,
+      "value": "To upgrade to a Type 2 validator, please go back, select the target validator, and go through the 'Upgrade Validator' flow."
     }
   ],
   "8WtyrD": [
@@ -1823,12 +1835,6 @@
     {
       "type": 0,
       "value": " - epoch at which your validator funds are eligible for a full withdrawal during the next validator sweep."
-    }
-  ],
-  "8uE+mp": [
-    {
-      "type": 0,
-      "value": "Filter by index or pubkey"
     }
   ],
   "8uq59n": [
@@ -2119,6 +2125,12 @@
     {
       "type": 0,
       "value": "Become a validator with Lighthouse"
+    }
+  ],
+  "Atjyqe": [
+    {
+      "type": 0,
+      "value": "Target validator is does not have Type 2 credentials and must be upgraded before funds can be pushed to it."
     }
   ],
   "Aw1mMs": [
@@ -4597,6 +4609,12 @@
       "value": "congratulations"
     }
   ],
+  "Ra6IrH": [
+    {
+      "type": 0,
+      "value": "Target validator is not associated with your current wallet!"
+    }
+  ],
   "RhR6+a": [
     {
       "type": 0,
@@ -6633,6 +6651,20 @@
     {
       "type": 0,
       "value": "Latest Reth Benchmarks"
+    }
+  ],
+  "gddfK3": [
+    {
+      "type": 0,
+      "value": "Please type the target validator index ("
+    },
+    {
+      "type": 1,
+      "value": "targetIndex"
+    },
+    {
+      "type": 0,
+      "value": ") to acknowledge you understand where your validator balance is being transferred to."
     }
   ],
   "gfLdAQ": [
@@ -9025,6 +9057,12 @@
     {
       "type": 0,
       "value": "Generate key pairs"
+    }
+  ],
+  "udj2WS": [
+    {
+      "type": 0,
+      "value": "More on upgrading a validator with Type 0 credentials."
     }
   ],
   "uhapiE": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -1305,6 +1305,20 @@
       "value": "Teku installation documentation"
     }
   ],
+  "5HZBWx": [
+    {
+      "type": 0,
+      "value": "Please type "
+    },
+    {
+      "type": 1,
+      "value": "boldConfirmationMessage"
+    },
+    {
+      "type": 0,
+      "value": " to acknowledge you understand where your validator balance is being transferred to."
+    }
+  ],
   "5UH1sh": [
     {
       "type": 0,
@@ -3057,20 +3071,6 @@
     {
       "type": 0,
       "value": "Configure your execution client"
-    }
-  ],
-  "HV2kN4": [
-    {
-      "type": 0,
-      "value": "Please type 'I TRANSFER MY FULL VALIDATOR BALANCE TO THE OWNER OF "
-    },
-    {
-      "type": 1,
-      "value": "targetIndex"
-    },
-    {
-      "type": 0,
-      "value": "' to acknowledge you understand where your validator balance is being transferred to."
     }
   ],
   "HX93/h": [
@@ -9275,6 +9275,16 @@
     {
       "type": 0,
       "value": "Option 2: source code + virtualenv"
+    }
+  ],
+  "wxaiRj": [
+    {
+      "type": 0,
+      "value": "I TRANSFER MY FULL VALIDATOR BALANCE TO THE OWNER OF "
+    },
+    {
+      "type": 1,
+      "value": "index"
     }
   ],
   "x+fF+M": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -27,6 +27,20 @@
       "value": " (handling proof-of-stake consensus tasks, formerly 'Eth2' or 'Ethereum 2.0')."
     }
   ],
+  "+3Cqbb": [
+    {
+      "type": 0,
+      "value": "To upgrade to a Type 2 validator, please go back, select the target validator, and go through the "
+    },
+    {
+      "type": 1,
+      "value": "boldUpgradeAccount"
+    },
+    {
+      "type": 0,
+      "value": " flow."
+    }
+  ],
   "+3gmIR": [
     {
       "type": 0,
@@ -1761,12 +1775,6 @@
     {
       "type": 0,
       "value": "Transfer entire balance to another one of your validator accounts, consolidating two accounts into one. Target account must be upgraded to compounding type."
-    }
-  ],
-  "8WAAtu": [
-    {
-      "type": 0,
-      "value": "To upgrade to a Type 2 validator, please go back, select the target validator, and go through the 'Upgrade Validator' flow."
     }
   ],
   "8WtyrD": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -1305,20 +1305,6 @@
       "value": "Teku installation documentation"
     }
   ],
-  "5HZBWx": [
-    {
-      "type": 0,
-      "value": "Please type "
-    },
-    {
-      "type": 1,
-      "value": "boldConfirmationMessage"
-    },
-    {
-      "type": 0,
-      "value": " to acknowledge you understand where your validator balance is being transferred to."
-    }
-  ],
   "5UH1sh": [
     {
       "type": 0,
@@ -2237,6 +2223,20 @@
     {
       "type": 0,
       "value": "days"
+    }
+  ],
+  "BeE9pr": [
+    {
+      "type": 0,
+      "value": "Please type "
+    },
+    {
+      "type": 1,
+      "value": "boldConfirmationMessage"
+    },
+    {
+      "type": 0,
+      "value": " to acknowledge you understand your validator is changing ownership."
     }
   ],
   "Bj5yI5": [

--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -4483,6 +4483,12 @@
       "value": "pip documentation"
     }
   ],
+  "Q+4zQ+": [
+    {
+      "type": 0,
+      "value": "Only validators with an active status can receive funds from another validator."
+    }
+  ],
   "Q/HeiY": [
     {
       "type": 0,
@@ -4839,12 +4845,6 @@
     {
       "type": 0,
       "value": "exiting the validator you choose above"
-    }
-  ],
-  "Sjv4KR": [
-    {
-      "type": 0,
-      "value": "A validator can only be consolidated to if it is in the proper state of active/online."
     }
   ],
   "SqKNq2": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -1156,6 +1156,9 @@
   "HMgrdg": {
     "message": "Configure your execution client"
   },
+  "HV2kN4": {
+    "message": "Please type 'I TRANSFER MY FULL VALIDATOR BALANCE TO THE OWNER OF {targetIndex}' to acknowledge you understand where your validator balance is being transferred to."
+  },
   "HX93/h": {
     "message": "Setting a withdrawal address is considered best security practice. If this is not provided now, your deposited funds will remain locked on the Beacon Chain until an address is provided. Unlocking will require signing a message with your BLS withdrawal keys, generated from your mnemonic seed phrase (so keep it safe)."
   },
@@ -1810,9 +1813,6 @@
   },
   "SVUntz": {
     "message": "Note that once a user has {type1} withdrawal credentials and has broadcast a voluntary exit, there is no further action required until the processing is complete."
-  },
-  "Sa8NCw": {
-    "message": "No eligible target accounts found."
   },
   "SaR1pU": {
     "message": "Deposit already exists"
@@ -2530,9 +2530,6 @@
   },
   "gXVf9n": {
     "message": "Latest Reth Benchmarks"
-  },
-  "gddfK3": {
-    "message": "Please type the target validator index ({targetIndex}) to acknowledge you understand where your validator balance is being transferred to."
   },
   "gfLdAQ": {
     "message": "More on the Beacon Chain"

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -492,6 +492,9 @@
   "5v36Is": {
     "message": "Exiting a {client} validator"
   },
+  "6/hnxI": {
+    "message": "Target validator is not active"
+  },
   "63gLLu": {
     "message": "average"
   },
@@ -2963,6 +2966,9 @@
   },
   "n5PQND": {
     "message": "Exit epoch"
+  },
+  "n5y2hu": {
+    "message": "A validator can only be consolidated to if it is in the proper state of active ongoing."
   },
   "nBhisA": {
     "message": "You'll need to run an execution client (formerly 'Eth1') as well as a consensus client (formerly 'Eth2') to become a validator. Take a look at the checklist to prepare yourself and your equipment."

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -6,6 +6,9 @@
     "description": "{executionLayer} is a link labeled 'execution layer'. {consensusLayer} is a link labeled 'consensus layer'",
     "message": "Ethereum consists of the {executionLayer} (handling transactions and execution, formerly 'Eth1'), and the {consensusLayer} (handling proof-of-stake consensus tasks, formerly 'Eth2' or 'Ethereum 2.0')."
   },
+  "+3Cqbb": {
+    "message": "To upgrade to a Type 2 validator, please go back, select the target validator, and go through the {boldUpgradeAccount} flow."
+  },
   "+3gmIR": {
     "message": "Lodestar is a Typescript ecosystem for Ethereum consensus, developed by ChainSafe Systems. Our flagship products are our production-capable beacon chain and validator client. Lodestar’s niche is in its implementation language, TypeScript. Our software and tooling is uniquely situated as the go-to for researchers and developers for rapid prototyping."
   },
@@ -643,9 +646,6 @@
   },
   "8VlOTO": {
     "message": "Transfer entire balance to another one of your validator accounts, consolidating two accounts into one. Target account must be upgraded to compounding type."
-  },
-  "8WAAtu": {
-    "message": "To upgrade to a Type 2 validator, please go back, select the target validator, and go through the 'Upgrade Validator' flow."
   },
   "8WtyrD": {
     "message": "Spanish"

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -476,9 +476,6 @@
   "5HJLBU": {
     "message": "Teku installation documentation"
   },
-  "5HZBWx": {
-    "message": "Please type {boldConfirmationMessage} to acknowledge you understand where your validator balance is being transferred to."
-  },
   "5UH1sh": {
     "message": "Romanian"
   },
@@ -831,6 +828,9 @@
   },
   "Bc20la": {
     "message": "days"
+  },
+  "BeE9pr": {
+    "message": "Please type {boldConfirmationMessage} to acknowledge you understand your validator is changing ownership."
   },
   "Bj5yI5": {
     "message": "Effective balance"

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -623,6 +623,9 @@
   "8HxLGA": {
     "message": "Configure Teku"
   },
+  "8J6IfS": {
+    "message": "Filter your validators by index or pubkey or search by pubkey"
+  },
   "8JtiQS": {
     "message": "Does the contract address listed on the website match?"
   },
@@ -631,6 +634,9 @@
   },
   "8VlOTO": {
     "message": "Transfer entire balance to another one of your validator accounts, consolidating two accounts into one. Target account must be upgraded to compounding type."
+  },
+  "8WAAtu": {
+    "message": "To upgrade to a Type 2 validator, please go back, select the target validator, and go through the 'Upgrade Validator' flow."
   },
   "8WtyrD": {
     "message": "Spanish"
@@ -658,9 +664,6 @@
   },
   "8rxaqc": {
     "message": "{withdrawableEpochLabel} - epoch at which your validator funds are eligible for a full withdrawal during the next validator sweep."
-  },
-  "8uE+mp": {
-    "message": "Filter by index or pubkey"
   },
   "8uq59n": {
     "message": "Signal your intent to exit staking by signing and broadcasting a voluntary exit message to the network using your validator keys and validator client"
@@ -785,6 +788,9 @@
   },
   "Anqi3n": {
     "message": "Become a validator with Lighthouse"
+  },
+  "Atjyqe": {
+    "message": "Target validator is does not have Type 2 credentials and must be upgraded before funds can be pushed to it."
   },
   "Aw1mMs": {
     "message": "Top up validator"
@@ -1750,6 +1756,9 @@
   "RWqrlk": {
     "message": "congratulations"
   },
+  "Ra6IrH": {
+    "message": "Target validator is not associated with your current wallet!"
+  },
   "RhR6+a": {
     "message": "We'll guide you through setting a withdrawal address for your validator. This is considered best-practice, and strongly recommended for safety and security reasons."
   },
@@ -2521,6 +2530,9 @@
   },
   "gXVf9n": {
     "message": "Latest Reth Benchmarks"
+  },
+  "gddfK3": {
+    "message": "Please type the target validator index ({targetIndex}) to acknowledge you understand where your validator balance is being transferred to."
   },
   "gfLdAQ": {
     "message": "More on the Beacon Chain"
@@ -3401,6 +3413,9 @@
   },
   "ubKWX8": {
     "message": "Generate key pairs"
+  },
+  "udj2WS": {
+    "message": "More on upgrading a validator with Type 0 credentials."
   },
   "uhapiE": {
     "message": "Ensure your bandwidth can't be throttled and isn't capped so your node stays in sync and will be ready to validate when called."

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -1704,6 +1704,9 @@
   "Px7wWb": {
     "message": "pip documentation"
   },
+  "Q+4zQ+": {
+    "message": "Only validators with an active status can receive funds from another validator."
+  },
   "Q/HeiY": {
     "message": "Beaconcha.in Broadcast Tool"
   },
@@ -1858,9 +1861,6 @@
   },
   "SepcV5": {
     "message": "exiting the validator you choose above"
-  },
-  "Sjv4KR": {
-    "message": "A validator can only be consolidated to if it is in the proper state of active/online."
   },
   "SqKNq2": {
     "description": "{homebrew} = 'homebrew' and links to the homebrew package manager website documentation",

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -1841,6 +1841,9 @@
   "SepcV5": {
     "message": "exiting the validator you choose above"
   },
+  "Sjv4KR": {
+    "message": "A validator can only be consolidated to if it is in the proper state of active/online."
+  },
   "SqKNq2": {
     "description": "{homebrew} = 'homebrew' and links to the homebrew package manager website documentation",
     "message": "You can install python3 on your macOS device using {homebrew}"
@@ -2966,9 +2969,6 @@
   },
   "n5PQND": {
     "message": "Exit epoch"
-  },
-  "n5y2hu": {
-    "message": "A validator can only be consolidated to if it is in the proper state of active ongoing."
   },
   "nBhisA": {
     "message": "You'll need to run an execution client (formerly 'Eth1') as well as a consensus client (formerly 'Eth2') to become a validator. Take a look at the checklist to prepare yourself and your equipment."

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -476,6 +476,9 @@
   "5HJLBU": {
     "message": "Teku installation documentation"
   },
+  "5HZBWx": {
+    "message": "Please type {boldConfirmationMessage} to acknowledge you understand where your validator balance is being transferred to."
+  },
   "5UH1sh": {
     "message": "Romanian"
   },
@@ -1161,9 +1164,6 @@
   },
   "HMgrdg": {
     "message": "Configure your execution client"
-  },
-  "HV2kN4": {
-    "message": "Please type 'I TRANSFER MY FULL VALIDATOR BALANCE TO THE OWNER OF {targetIndex}' to acknowledge you understand where your validator balance is being transferred to."
   },
   "HX93/h": {
     "message": "Setting a withdrawal address is considered best security practice. If this is not provided now, your deposited funds will remain locked on the Beacon Chain until an address is provided. Unlocking will require signing a message with your BLS withdrawal keys, generated from your mnemonic seed phrase (so keep it safe)."
@@ -3508,6 +3508,9 @@
   },
   "wtwIax": {
     "message": "Option 2: source code + virtualenv"
+  },
+  "wxaiRj": {
+    "message": "I TRANSFER MY FULL VALIDATOR BALANCE TO THE OWNER OF {index}"
   },
   "x+fF+M": {
     "message": "Testnet simulations"

--- a/src/pages/Actions/components/PullConsolidation.tsx
+++ b/src/pages/Actions/components/PullConsolidation.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { Box, Layer } from 'grommet';
+import { Layer } from 'grommet';
 import { Alert as AlertIcon, LinkDown as DownIcon } from 'grommet-icons';
 import Web3 from 'web3';
 import { AbstractConnector } from '@web3-react/abstract-connector';
@@ -143,340 +143,337 @@ const PullConsolidation = ({
           onClickOutside={resetState}
           style={modalLayerStyle}
         >
-          <Box>
-            <ModalHeader onClose={resetState}>
-              <FormattedMessage defaultMessage="Absorb validator" />
-            </ModalHeader>
-            <ModalBody>
-              {!showTx && (
-                <div style={{ marginBottom: '1.5rem' }}>
-                  <div style={{ marginBottom: '0.5rem' }}>
-                    <FormattedMessage
-                      defaultMessage="Which validator would you like to {pullFrom}?"
-                      values={{
-                        pullFrom: (
-                          <strong>
-                            <FormattedMessage defaultMessage="pull full balance from" />
-                          </strong>
-                        ),
-                      }}
-                    />
-                  </div>
-                  <ValidatorSelector
-                    validators={sourceValidatorSet}
-                    selectedValidator={sourceValidator}
-                    setSelectedValidator={setSourceValidator}
+          <ModalHeader onClose={resetState}>
+            <FormattedMessage defaultMessage="Absorb validator" />
+          </ModalHeader>
+          <ModalBody>
+            {!showTx && (
+              <div style={{ marginBottom: '1.5rem' }}>
+                <div style={{ marginBottom: '0.5rem' }}>
+                  <FormattedMessage
+                    defaultMessage="Which validator would you like to {pullFrom}?"
+                    values={{
+                      pullFrom: (
+                        <strong>
+                          <FormattedMessage defaultMessage="pull full balance from" />
+                        </strong>
+                      ),
+                    }}
                   />
                 </div>
-              )}
+                <ValidatorSelector
+                  validators={sourceValidatorSet}
+                  selectedValidator={sourceValidator}
+                  setSelectedValidator={setSourceValidator}
+                />
+              </div>
+            )}
 
-              {sourceValidator && !showTx && (
-                <div style={{ marginBlock: '1.5rem' }}>
-                  <Alert variant="warning">
-                    <AlertContent>
-                      <AlertIcon />
-                      <div>
-                        <Text>
-                          <strong>
-                            <FormattedMessage
-                              defaultMessage="Account {sourceIndex} will be exited from the network, and its full balance will be migrated to validator index {targetIndex}."
-                              values={{
-                                targetIndex: targetValidator.validatorindex,
-                                sourceIndex: sourceValidator.validatorindex,
-                              }}
-                            />
-                          </strong>
-                        </Text>
-                        <Text style={{ fontSize: '1rem' }}>
-                          <FormattedMessage defaultMessage="The exiting validator should remain online until exit epoch is reached." />
-                        </Text>
-                      </div>
-                    </AlertContent>
-                  </Alert>
-                </div>
-              )}
+            {sourceValidator && !showTx && (
+              <div style={{ marginBlock: '1.5rem' }}>
+                <Alert variant="warning">
+                  <AlertContent>
+                    <AlertIcon />
+                    <div>
+                      <Text>
+                        <strong>
+                          <FormattedMessage
+                            defaultMessage="Account {sourceIndex} will be exited from the network, and its full balance will be migrated to validator index {targetIndex}."
+                            values={{
+                              targetIndex: targetValidator.validatorindex,
+                              sourceIndex: sourceValidator.validatorindex,
+                            }}
+                          />
+                        </strong>
+                      </Text>
+                      <Text style={{ fontSize: '1rem' }}>
+                        <FormattedMessage defaultMessage="The exiting validator should remain online until exit epoch is reached." />
+                      </Text>
+                    </div>
+                  </AlertContent>
+                </Alert>
+              </div>
+            )}
 
-              {sourceValidator ? (
-                <ModalContent>
+            {sourceValidator ? (
+              <ModalContent>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                  }}
+                >
+                  <div
+                    style={{
+                      background: '#fff',
+                      padding: '1rem',
+                      maxWidth: '100%',
+                      borderRadius: '8px',
+                      border: '2px solid darkred',
+                    }}
+                  >
+                    <Heading
+                      level={3}
+                      style={{ textTransform: 'uppercase', color: 'darkred' }}
+                    >
+                      <FormattedMessage defaultMessage="Exit" />
+                    </Heading>
+                    <Text>
+                      <strong>
+                        <FormattedMessage defaultMessage="Index" />:{' '}
+                        {sourceValidator.validatorindex}
+                      </strong>
+                    </Text>
+                    <Text
+                      style={{
+                        fontSize: '14px',
+                        color: '#555',
+                        marginBottom: '0.5rem',
+                      }}
+                    >
+                      <Hash>{sourceValidator.pubkey}</Hash>
+                    </Text>
+
+                    <div
+                      style={{
+                        display: 'grid',
+                        gridTemplateColumns: 'repeat(2, 1fr)',
+                      }}
+                    >
+                      <Text
+                        style={{
+                          display: 'grid',
+                          gridColumn: 'span 2',
+                          gridTemplateColumns: 'subgrid',
+                          columnGap: '0.5rem',
+                        }}
+                      >
+                        <div>
+                          <FormattedMessage defaultMessage="Balance" />:
+                        </div>
+                        <div
+                          style={{
+                            textAlign: 'end',
+                            fontFamily: 'monospace',
+                          }}
+                        >
+                          {getEtherBalance(sourceValidator).toFixed(9)}{' '}
+                          {TICKER_NAME}
+                        </div>
+                      </Text>
+
+                      <Text
+                        style={{
+                          display: 'grid',
+                          gridColumn: 'span 2',
+                          gridTemplateColumns: 'subgrid',
+                          columnGap: '0.5rem',
+                        }}
+                      >
+                        <div>
+                          <FormattedMessage defaultMessage="New balance" />:
+                        </div>
+                        <div
+                          style={{
+                            textAlign: 'end',
+                            fontFamily: 'monospace',
+                          }}
+                        >
+                          {(0).toFixed(9)} {TICKER_NAME}
+                        </div>
+                      </Text>
+                    </div>
+                  </div>
+
                   <div
                     style={{
                       display: 'flex',
-                      flexDirection: 'column',
+                      alignItems: 'center',
+                      gap: '0.5rem',
+                      margin: '0.25rem auto',
                     }}
                   >
-                    <div
+                    <DownIcon />
+                    <Text
                       style={{
-                        background: '#fff',
-                        padding: '1rem',
-                        maxWidth: '100%',
-                        borderRadius: '8px',
-                        border: '2px solid darkred',
+                        fontFamily: 'monospace',
+                        fontSize: '1rem',
+                        color: 'darkred',
                       }}
                     >
-                      <Heading
-                        level={3}
-                        style={{ textTransform: 'uppercase', color: 'darkred' }}
-                      >
-                        <FormattedMessage defaultMessage="Exit" />
-                      </Heading>
-                      <Text>
-                        <strong>
-                          <FormattedMessage defaultMessage="Index" />:{' '}
-                          {sourceValidator.validatorindex}
-                        </strong>
-                      </Text>
-                      <Text
-                        style={{
-                          fontSize: '14px',
-                          color: '#555',
-                          marginBottom: '0.5rem',
-                        }}
-                      >
-                        <Hash>{sourceValidator.pubkey}</Hash>
-                      </Text>
-
-                      <div
-                        style={{
-                          display: 'grid',
-                          gridTemplateColumns: 'repeat(2, 1fr)',
-                        }}
-                      >
-                        <Text
-                          style={{
-                            display: 'grid',
-                            gridColumn: 'span 2',
-                            gridTemplateColumns: 'subgrid',
-                            columnGap: '0.5rem',
-                          }}
-                        >
-                          <div>
-                            <FormattedMessage defaultMessage="Balance" />:
-                          </div>
-                          <div
-                            style={{
-                              textAlign: 'end',
-                              fontFamily: 'monospace',
-                            }}
-                          >
-                            {getEtherBalance(sourceValidator).toFixed(9)}{' '}
-                            {TICKER_NAME}
-                          </div>
-                        </Text>
-
-                        <Text
-                          style={{
-                            display: 'grid',
-                            gridColumn: 'span 2',
-                            gridTemplateColumns: 'subgrid',
-                            columnGap: '0.5rem',
-                          }}
-                        >
-                          <div>
-                            <FormattedMessage defaultMessage="New balance" />:
-                          </div>
-                          <div
-                            style={{
-                              textAlign: 'end',
-                              fontFamily: 'monospace',
-                            }}
-                          >
-                            {(0).toFixed(9)} {TICKER_NAME}
-                          </div>
-                        </Text>
-                      </div>
-                    </div>
-
-                    <div
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '0.5rem',
-                        margin: '0.25rem auto',
-                      }}
-                    >
-                      <DownIcon />
-                      <Text
-                        style={{
-                          fontFamily: 'monospace',
-                          fontSize: '1rem',
-                          color: 'darkred',
-                        }}
-                      >
-                        {getEtherBalance(sourceValidator).toFixed(9)}{' '}
-                        {TICKER_NAME}
-                      </Text>
-                    </div>
-
-                    <div
-                      style={{
-                        background: '#fff',
-                        padding: '1rem',
-                        maxWidth: '100%',
-                        borderRadius: '8px',
-                        border: '2px solid darkgreen',
-                      }}
-                    >
-                      <Heading
-                        level={3}
-                        style={{
-                          textTransform: 'uppercase',
-                          color: 'darkgreen',
-                        }}
-                      >
-                        <FormattedMessage defaultMessage="Migrate to" />
-                      </Heading>
-                      <Text>
-                        <strong>
-                          <FormattedMessage defaultMessage="Index" />:{' '}
-                          {targetValidator.validatorindex}
-                        </strong>
-                      </Text>
-                      <Text
-                        style={{
-                          fontSize: '14px',
-                          color: '#555',
-                          marginBottom: '0.5rem',
-                        }}
-                      >
-                        <Hash>{targetValidator.pubkey}</Hash>
-                      </Text>
-                      <div
-                        style={{
-                          display: 'grid',
-                          gridTemplateColumns: 'repeat(2, 1fr)',
-                        }}
-                      >
-                        <Text
-                          style={{
-                            display: 'grid',
-                            gridColumn: 'span 2',
-                            gridTemplateColumns: 'subgrid',
-                            columnGap: '0.5rem',
-                          }}
-                        >
-                          <div>
-                            <FormattedMessage defaultMessage="Current" />:
-                          </div>
-                          <div
-                            style={{
-                              textAlign: 'end',
-                              fontFamily: 'monospace',
-                            }}
-                          >
-                            {getEtherBalance(targetValidator).toFixed(9)}{' '}
-                            {TICKER_NAME}
-                          </div>
-                        </Text>
-
-                        <Text
-                          style={{
-                            display: 'grid',
-                            gridColumn: 'span 2',
-                            gridTemplateColumns: 'subgrid',
-                            columnGap: '0.5rem',
-                          }}
-                        >
-                          <div>
-                            <FormattedMessage defaultMessage="New balance" />:
-                          </div>
-                          <div
-                            style={{
-                              textAlign: 'end',
-                              fontFamily: 'monospace',
-                              color: 'darkgreen',
-                            }}
-                          >
-                            {(
-                              getEtherBalance(targetValidator) +
-                              getEtherBalance(sourceValidator)
-                            ).toFixed(9)}{' '}
-                            {TICKER_NAME}
-                          </div>
-                        </Text>
-                      </div>
-                    </div>
+                      {getEtherBalance(sourceValidator).toFixed(9)}{' '}
+                      {TICKER_NAME}
+                    </Text>
                   </div>
 
-                  {showTx && (
-                    <TransactionStatusInsert
-                      headerMessage={
-                        <>
-                          <span>{sourceValidator.validatorindex}</span>{' '}
-                          <span
-                            style={{
-                              transform: locale === 'ar' ? 'scale(-1)' : '',
-                            }}
-                          >
-                            {String.fromCodePoint(0x27a0)}
-                          </span>
-                          <span>{targetValidator.validatorindex}</span>
-                        </>
-                      }
-                      txHash={txHash}
-                      transactionStatus={txStatus}
-                    />
-                  )}
-                </ModalContent>
-              ) : (
-                <ModalContent>
-                  <Text>
-                    <FormattedMessage
-                      defaultMessage="This will initiate the process of permanently {exiting} from the Ethereum proof-of-stake network."
-                      values={{
-                        exiting: (
-                          <strong>
-                            <FormattedMessage defaultMessage="exiting the validator you choose above" />
-                          </strong>
-                        ),
+                  <div
+                    style={{
+                      background: '#fff',
+                      padding: '1rem',
+                      maxWidth: '100%',
+                      borderRadius: '8px',
+                      border: '2px solid darkgreen',
+                    }}
+                  >
+                    <Heading
+                      level={3}
+                      style={{
+                        textTransform: 'uppercase',
+                        color: 'darkgreen',
                       }}
-                    />
-                  </Text>
-
-                  <Text>
-                    <FormattedMessage defaultMessage="This will initiate the process of permanently exiting the chosen validator from the Ethereum proof-of-stake network." />
-                  </Text>
-                  <Text>
-                    <FormattedMessage defaultMessage="You'll be asked to sign a message with your wallet. Processing of exits is not immediate, so account for up to several days before completion." />
-                  </Text>
-                  <Text>
-                    <FormattedMessage defaultMessage="Consolidation requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes." />
-                  </Text>
-                  <ul style={{ paddingInlineStart: '1.5rem', marginTop: 0 }}>
-                    <li>
-                      <Text as="span">
-                        <FormattedMessage defaultMessage="Action is permanent and irreversible" />
-                      </Text>
-                    </li>
-                    <li>
-                      <Text as="span">
-                        <FormattedMessage defaultMessage="Account still responsible for consensus duties until exit epoch reached (keep validator online)" />
-                      </Text>
-                    </li>
-                    <li>
-                      <Text as="span">
-                        <FormattedMessage
-                          defaultMessage="All remaining funds will be {transferredToDestination} within a few days after exit epoch reached"
-                          values={{
-                            transferredToDestination: (
-                              <strong>
-                                <FormattedMessage
-                                  defaultMessage="transferred to validator index {index}"
-                                  values={{
-                                    index: targetValidator.validatorindex,
-                                  }}
-                                />
-                              </strong>
-                            ),
+                    >
+                      <FormattedMessage defaultMessage="Migrate to" />
+                    </Heading>
+                    <Text>
+                      <strong>
+                        <FormattedMessage defaultMessage="Index" />:{' '}
+                        {targetValidator.validatorindex}
+                      </strong>
+                    </Text>
+                    <Text
+                      style={{
+                        fontSize: '14px',
+                        color: '#555',
+                        marginBottom: '0.5rem',
+                      }}
+                    >
+                      <Hash>{targetValidator.pubkey}</Hash>
+                    </Text>
+                    <div
+                      style={{
+                        display: 'grid',
+                        gridTemplateColumns: 'repeat(2, 1fr)',
+                      }}
+                    >
+                      <Text
+                        style={{
+                          display: 'grid',
+                          gridColumn: 'span 2',
+                          gridTemplateColumns: 'subgrid',
+                          columnGap: '0.5rem',
+                        }}
+                      >
+                        <div>
+                          <FormattedMessage defaultMessage="Current" />:
+                        </div>
+                        <div
+                          style={{
+                            textAlign: 'end',
+                            fontFamily: 'monospace',
                           }}
-                        />
+                        >
+                          {getEtherBalance(targetValidator).toFixed(9)}{' '}
+                          {TICKER_NAME}
+                        </div>
                       </Text>
-                    </li>
-                  </ul>
-                </ModalContent>
-              )}
-            </ModalBody>
-          </Box>
 
+                      <Text
+                        style={{
+                          display: 'grid',
+                          gridColumn: 'span 2',
+                          gridTemplateColumns: 'subgrid',
+                          columnGap: '0.5rem',
+                        }}
+                      >
+                        <div>
+                          <FormattedMessage defaultMessage="New balance" />:
+                        </div>
+                        <div
+                          style={{
+                            textAlign: 'end',
+                            fontFamily: 'monospace',
+                            color: 'darkgreen',
+                          }}
+                        >
+                          {(
+                            getEtherBalance(targetValidator) +
+                            getEtherBalance(sourceValidator)
+                          ).toFixed(9)}{' '}
+                          {TICKER_NAME}
+                        </div>
+                      </Text>
+                    </div>
+                  </div>
+                </div>
+
+                {showTx && (
+                  <TransactionStatusInsert
+                    headerMessage={
+                      <>
+                        <span>{sourceValidator.validatorindex}</span>{' '}
+                        <span
+                          style={{
+                            transform: locale === 'ar' ? 'scale(-1)' : '',
+                          }}
+                        >
+                          {String.fromCodePoint(0x27a0)}
+                        </span>
+                        <span>{targetValidator.validatorindex}</span>
+                      </>
+                    }
+                    txHash={txHash}
+                    transactionStatus={txStatus}
+                  />
+                )}
+              </ModalContent>
+            ) : (
+              <ModalContent>
+                <Text>
+                  <FormattedMessage
+                    defaultMessage="This will initiate the process of permanently {exiting} from the Ethereum proof-of-stake network."
+                    values={{
+                      exiting: (
+                        <strong>
+                          <FormattedMessage defaultMessage="exiting the validator you choose above" />
+                        </strong>
+                      ),
+                    }}
+                  />
+                </Text>
+
+                <Text>
+                  <FormattedMessage defaultMessage="This will initiate the process of permanently exiting the chosen validator from the Ethereum proof-of-stake network." />
+                </Text>
+                <Text>
+                  <FormattedMessage defaultMessage="You'll be asked to sign a message with your wallet. Processing of exits is not immediate, so account for up to several days before completion." />
+                </Text>
+                <Text>
+                  <FormattedMessage defaultMessage="Consolidation requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes." />
+                </Text>
+                <ul style={{ paddingInlineStart: '1.5rem', marginTop: 0 }}>
+                  <li>
+                    <Text as="span">
+                      <FormattedMessage defaultMessage="Action is permanent and irreversible" />
+                    </Text>
+                  </li>
+                  <li>
+                    <Text as="span">
+                      <FormattedMessage defaultMessage="Account still responsible for consensus duties until exit epoch reached (keep validator online)" />
+                    </Text>
+                  </li>
+                  <li>
+                    <Text as="span">
+                      <FormattedMessage
+                        defaultMessage="All remaining funds will be {transferredToDestination} within a few days after exit epoch reached"
+                        values={{
+                          transferredToDestination: (
+                            <strong>
+                              <FormattedMessage
+                                defaultMessage="transferred to validator index {index}"
+                                values={{
+                                  index: targetValidator.validatorindex,
+                                }}
+                              />
+                            </strong>
+                          ),
+                        }}
+                      />
+                    </Text>
+                  </li>
+                </ul>
+              </ModalContent>
+            )}
+          </ModalBody>
           <ModalFooter>
             <QueueWarning queue={queue} />
 

--- a/src/pages/Actions/components/PushConsolidation.tsx
+++ b/src/pages/Actions/components/PushConsolidation.tsx
@@ -155,7 +155,7 @@ const PushConsolidation = ({
     }
   }, [targetValidator]);
 
-  const validValidatorState = useMemo(() => {
+  const validValidatorStatus = useMemo(() => {
     // Handle both dora and beaconcha.in status'
     return (
       targetValidator &&
@@ -285,71 +285,75 @@ const PushConsolidation = ({
               </ModalContent>
             )}
 
-            {/* eslint-disable-next-line no-nested-ternary */}
-            {targetValidator && !validValidatorState ? (
-              <div style={{ marginBottom: '1.5rem' }}>
-                <Alert variant="error">
-                  <AlertContent>
-                    <AlertIcon />
-                    <div>
-                      <Text
-                        style={{ marginBottom: '1rem' }}
-                        className="text-bold"
-                      >
-                        <FormattedMessage defaultMessage="Target validator is not active" />
-                      </Text>
-                      <Text>
-                        <FormattedMessage defaultMessage="A validator can only be consolidated to if it is in the proper state of active/online." />
-                      </Text>
-                    </div>
-                  </AlertContent>
-                </Alert>
-              </div>
-            ) : targetValidator && validCredentials === false ? (
-              <div style={{ marginBottom: '1.5rem' }}>
-                <Alert variant="error">
-                  <AlertContent>
-                    <AlertIcon />
-                    <div>
-                      <Text
-                        style={{ marginBottom: '1rem' }}
-                        className="text-bold"
-                      >
-                        <FormattedMessage defaultMessage="Target validator is does not have Type 2 credentials and must be upgraded before funds can be pushed to it." />
-                      </Text>
-                      {getCredentialType(targetValidator) ===
-                        ValidatorType.BLS && (
-                        <Text>
-                          <Link inline primary to="/withdrawals">
-                            <FormattedMessage defaultMessage="More on upgrading a validator with Type 0 credentials." />
-                          </Link>
-                        </Text>
-                      )}
-                      {getCredentialType(targetValidator) ===
-                        ValidatorType.Execution && (
-                        <Text>
-                          <FormattedMessage
-                            defaultMessage="To upgrade to a Type 2 validator, please go back, select the target validator, and go through the {boldUpgradeAccount} flow."
-                            values={{
-                              boldUpgradeAccount: (
-                                <strong className="text-bold">
-                                  Upgrade Account
-                                </strong>
-                              ),
-                            }}
-                          />
-                        </Text>
-                      )}
-                    </div>
-                  </AlertContent>
-                </Alert>
-              </div>
-            ) : null}
+            {targetValidator && (
+              <>
+                {!validValidatorStatus && (
+                  <div style={{ marginBottom: '1.5rem' }}>
+                    <Alert variant="error">
+                      <AlertContent>
+                        <AlertIcon />
+                        <div>
+                          <Text
+                            style={{ marginBottom: '1rem' }}
+                            className="text-bold"
+                          >
+                            <FormattedMessage defaultMessage="Target validator is not active" />
+                          </Text>
+                          <Text>
+                            <FormattedMessage defaultMessage="Only validators with an active status can receive funds from another validator." />
+                          </Text>
+                        </div>
+                      </AlertContent>
+                    </Alert>
+                  </div>
+                )}
+                {validValidatorStatus && !validCredentials && (
+                  <div style={{ marginBottom: '1.5rem' }}>
+                    <Alert variant="error">
+                      <AlertContent>
+                        <AlertIcon />
+                        <div>
+                          <Text
+                            style={{ marginBottom: '1rem' }}
+                            className="text-bold"
+                          >
+                            <FormattedMessage defaultMessage="Target validator is does not have Type 2 credentials and must be upgraded before funds can be pushed to it." />
+                          </Text>
+                          {getCredentialType(targetValidator) ===
+                            ValidatorType.BLS && (
+                            <Text>
+                              <Link inline primary to="/withdrawals">
+                                <FormattedMessage defaultMessage="More on upgrading a validator with Type 0 credentials." />
+                              </Link>
+                            </Text>
+                          )}
+                          {getCredentialType(targetValidator) ===
+                            ValidatorType.Execution && (
+                            <Text>
+                              <FormattedMessage
+                                defaultMessage="To upgrade to a Type 2 validator, please go back, select the target validator, and go through the {boldUpgradeAccount} flow."
+                                values={{
+                                  boldUpgradeAccount: (
+                                    <strong className="text-bold">
+                                      Upgrade Account
+                                    </strong>
+                                  ),
+                                }}
+                              />
+                            </Text>
+                          )}
+                        </div>
+                      </AlertContent>
+                    </Alert>
+                  </div>
+                )}
+              </>
+            )}
 
             {targetValidator &&
               !showTx &&
               validCredentials &&
-              validValidatorState && (
+              validValidatorStatus && (
                 <div style={{ marginBottom: '1.5rem' }}>
                   <Alert variant={matchingCredentials ? 'warning' : 'error'}>
                     <AlertContent>
@@ -381,7 +385,7 @@ const PushConsolidation = ({
                 </div>
               )}
 
-            {targetValidator && (
+            {targetValidator && validValidatorStatus && (
               <ModalContent>
                 <div
                   style={{
@@ -600,7 +604,7 @@ const PushConsolidation = ({
               </ModalContent>
             )}
           </ModalBody>
-          {targetValidator && validCredentials && validValidatorState && (
+          {targetValidator && validCredentials && validValidatorStatus && (
             <ModalFooter>
               <QueueWarning queue={queue} />
 

--- a/src/pages/Actions/components/PushConsolidation.tsx
+++ b/src/pages/Actions/components/PushConsolidation.tsx
@@ -156,7 +156,11 @@ const PushConsolidation = ({
   }, [targetValidator]);
 
   const validValidatorState = useMemo(() => {
-    return targetValidator && targetValidator.status === 'active_ongoing';
+    // Handle both dora and beaconcha.in status'
+    return (
+      targetValidator &&
+      ['active_online', 'active_ongoing'].includes(targetValidator.status)
+    );
   }, [targetValidator]);
 
   const validConfirmationMessage = useMemo(() => {
@@ -281,7 +285,7 @@ const PushConsolidation = ({
                         </strong>
                       </Text>
                       <Text>
-                        <FormattedMessage defaultMessage="A validator can only be consolidated to if it is in the proper state of active ongoing." />
+                        <FormattedMessage defaultMessage="A validator can only be consolidated to if it is in the proper state of active/online." />
                       </Text>
                     </div>
                   </AlertContent>

--- a/src/pages/Actions/components/PushConsolidation.tsx
+++ b/src/pages/Actions/components/PushConsolidation.tsx
@@ -45,7 +45,7 @@ const PushConsolidation = ({
   sourceValidator,
   targetValidatorSet,
 }: PushConsolidationProps) => {
-  const { locale } = useIntl();
+  const { locale, formatMessage } = useIntl();
   const { connector, account } = useWeb3React();
   const {
     resetTxModal,
@@ -165,15 +165,21 @@ const PushConsolidation = ({
     );
   }, [targetValidator]);
 
-  const validConfirmationMessage = useMemo(() => {
-    if (targetValidator && !matchingCredentials) {
-      return (
-        userConfirmationValue.trim().toLowerCase() ===
-        `i transfer my full validator balance to the owner of ${targetValidator.validatorindex}`
-      );
-    }
+  const CONFIRMATION_MESSAGE = formatMessage(
+    {
+      defaultMessage:
+        'I TRANSFER MY FULL VALIDATOR BALANCE TO THE OWNER OF {index}',
+    },
+    { index: targetValidator?.validatorindex }
+  );
 
-    return true;
+  const validConfirmationMessage = useMemo(() => {
+    if (!targetValidator) return false;
+    if (matchingCredentials) return true;
+    return (
+      userConfirmationValue.trim().toLowerCase() ===
+      CONFIRMATION_MESSAGE.toLowerCase()
+    );
   }, [matchingCredentials, userConfirmationValue, targetValidator]);
 
   return (
@@ -560,7 +566,7 @@ const PushConsolidation = ({
 
                 {showTx && (
                   <TransactionStatusInsert
-                    headerMessage={(
+                    headerMessage={
                       <>
                         <span>{sourceValidator.validatorindex}</span>{' '}
                         <span
@@ -572,7 +578,7 @@ const PushConsolidation = ({
                         </span>
                         <span>{targetValidator.validatorindex}</span>
                       </>
-                    )}
+                    }
                     txHash={txHash}
                     transactionStatus={txStatus}
                   />
@@ -599,9 +605,16 @@ const PushConsolidation = ({
                   >
                     <Text>
                       <FormattedMessage
-                        defaultMessage="Please type 'I TRANSFER MY FULL VALIDATOR BALANCE TO THE OWNER OF {targetIndex}' to acknowledge you understand where your validator balance is being transferred to."
+                        defaultMessage="Please type {boldConfirmationMessage} to acknowledge you understand where your validator balance is being transferred to."
                         values={{
-                          targetIndex: targetValidator.validatorindex,
+                          boldConfirmationMessage: (
+                            <strong
+                              className="text-bold"
+                              style={{ textTransform: 'uppercase' }}
+                            >
+                              {CONFIRMATION_MESSAGE}
+                            </strong>
+                          ),
                         }}
                       />
                     </Text>
@@ -611,7 +624,8 @@ const PushConsolidation = ({
                     name="confirm-push-input"
                     value={userConfirmationValue}
                     onChange={event =>
-                      setUserConfirmationValue(event.target.value)}
+                      setUserConfirmationValue(event.target.value)
+                    }
                     style={{ background: 'white', border: '1px solid #ccc' }}
                   />
                 </Form>

--- a/src/pages/Actions/components/PushConsolidation.tsx
+++ b/src/pages/Actions/components/PushConsolidation.tsx
@@ -159,7 +159,9 @@ const PushConsolidation = ({
     // Handle both dora and beaconcha.in status'
     return (
       targetValidator &&
-      ['active_online', 'active_ongoing'].includes(targetValidator.status)
+      ['active_online', 'active_offline', 'active_ongoing'].includes(
+        targetValidator.status
+      )
     );
   }, [targetValidator]);
 

--- a/src/pages/Actions/components/PushConsolidation.tsx
+++ b/src/pages/Actions/components/PushConsolidation.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import React, { useEffect, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { Box, Form, Layer, TextInput } from 'grommet';
+import { Form, Layer, TextInput } from 'grommet';
 import { Alert as AlertIcon, LinkDown as DownIcon } from 'grommet-icons';
 import Web3 from 'web3';
 import { AbstractConnector } from '@web3-react/abstract-connector';
@@ -158,7 +158,8 @@ const PushConsolidation = ({
   const validConfirmationMessage = useMemo(() => {
     if (targetValidator && !matchingCredentials) {
       return (
-        userConfirmationValue.trim() === `${targetValidator.validatorindex}`
+        userConfirmationValue.trim().toLowerCase() ===
+        `i transfer my full validator balance to the owner of ${targetValidator.validatorindex}`
       );
     }
 
@@ -170,7 +171,6 @@ const PushConsolidation = ({
       <Button
         label={<FormattedMessage defaultMessage="Migrate funds" />}
         destructive
-        disabled={targetValidatorSet.length < 1}
         onClick={handleOpen}
       />
 
@@ -181,377 +181,376 @@ const PushConsolidation = ({
           onClickOutside={resetState}
           style={modalLayerStyle}
         >
-          <Box>
-            <ModalHeader onClose={resetState}>
-              <FormattedMessage defaultMessage="Migrate and exit validator" />
-            </ModalHeader>
-            <ModalBody>
-              {!showTx && (
-                <div style={{ marginBottom: '1.5rem' }}>
-                  <div style={{ marginBottom: '0.5rem' }}>
-                    <FormattedMessage
-                      defaultMessage="Which validator would you like to {migrateFundsTo}?"
-                      description="{migrateFundsTo} indicates the direction funds will be transferred, and is emphasized visually"
-                      values={{
-                        migrateFundsTo: (
-                          <strong>
-                            <FormattedMessage defaultMessage="migrate funds to" />
-                          </strong>
-                        ),
-                      }}
-                    />
-                  </div>
-                  <ValidatorSelector
-                    allowSearch
-                    validators={targetValidatorSet}
-                    selectedValidator={targetValidator}
-                    setSelectedValidator={setTargetValidator}
+          <ModalHeader onClose={resetState}>
+            <FormattedMessage defaultMessage="Migrate and exit validator" />
+          </ModalHeader>
+          <ModalBody>
+            {!showTx && (
+              <div style={{ marginBottom: '1.5rem' }}>
+                <div style={{ marginBottom: '0.5rem' }}>
+                  <FormattedMessage
+                    defaultMessage="Which validator would you like to {migrateFundsTo}?"
+                    description="{migrateFundsTo} indicates the direction funds will be transferred, and is emphasized visually"
+                    values={{
+                      migrateFundsTo: (
+                        <strong>
+                          <FormattedMessage defaultMessage="migrate funds to" />
+                        </strong>
+                      ),
+                    }}
                   />
                 </div>
-              )}
+                <ValidatorSelector
+                  allowSearch
+                  autoSelect={false}
+                  validators={targetValidatorSet}
+                  selectedValidator={targetValidator}
+                  setSelectedValidator={setTargetValidator}
+                />
+              </div>
+            )}
 
-              {!targetValidator && (
-                <ModalContent>
-                  <Text>
-                    <FormattedMessage
-                      defaultMessage="This will initiate the process of permanently {exiting} from the Ethereum proof-of-stake network."
-                      values={{
-                        exiting: (
-                          <strong>
-                            <FormattedMessage
-                              defaultMessage="exiting index {sourceIndex}"
-                              values={{
-                                sourceIndex: sourceValidator.validatorindex,
-                              }}
-                            />
-                          </strong>
-                        ),
-                      }}
-                    />
-                  </Text>
-                  <Text>
-                    <FormattedMessage defaultMessage="You'll be asked to sign a message with your wallet. Processing of exits is not immediate, so account for up to several days before completion." />
-                  </Text>
-                  <Text>
-                    <FormattedMessage defaultMessage="Consolidation requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes." />
-                  </Text>
-                  <ul style={{ paddingInlineStart: '1.5rem', marginTop: 0 }}>
-                    <li>
-                      <Text as="span">
-                        <FormattedMessage defaultMessage="Action is permanent and irreversible" />
-                      </Text>
-                    </li>
-                    <li>
-                      <Text as="span">
-                        <FormattedMessage defaultMessage="Account still responsible for consensus duties until exit epoch reached (keep validator online)" />
-                      </Text>
-                    </li>
-                    <li>
-                      <Text as="span">
-                        <FormattedMessage
-                          defaultMessage="All remaining funds will be {transferredToDestination} within a few days after exit epoch reached"
-                          values={{
-                            transferredToDestination: (
-                              <strong>
-                                <FormattedMessage defaultMessage="transferred to the validator you select above" />
-                              </strong>
-                            ),
-                          }}
-                        />
-                      </Text>
-                    </li>
-                  </ul>
-                </ModalContent>
-              )}
+            {!targetValidator && (
+              <ModalContent>
+                <Text>
+                  <FormattedMessage
+                    defaultMessage="This will initiate the process of permanently {exiting} from the Ethereum proof-of-stake network."
+                    values={{
+                      exiting: (
+                        <strong>
+                          <FormattedMessage
+                            defaultMessage="exiting index {sourceIndex}"
+                            values={{
+                              sourceIndex: sourceValidator.validatorindex,
+                            }}
+                          />
+                        </strong>
+                      ),
+                    }}
+                  />
+                </Text>
+                <Text>
+                  <FormattedMessage defaultMessage="You'll be asked to sign a message with your wallet. Processing of exits is not immediate, so account for up to several days before completion." />
+                </Text>
+                <Text>
+                  <FormattedMessage defaultMessage="Consolidation requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes." />
+                </Text>
+                <ul style={{ paddingInlineStart: '1.5rem', marginTop: 0 }}>
+                  <li>
+                    <Text as="span">
+                      <FormattedMessage defaultMessage="Action is permanent and irreversible" />
+                    </Text>
+                  </li>
+                  <li>
+                    <Text as="span">
+                      <FormattedMessage defaultMessage="Account still responsible for consensus duties until exit epoch reached (keep validator online)" />
+                    </Text>
+                  </li>
+                  <li>
+                    <Text as="span">
+                      <FormattedMessage
+                        defaultMessage="All remaining funds will be {transferredToDestination} within a few days after exit epoch reached"
+                        values={{
+                          transferredToDestination: (
+                            <strong>
+                              <FormattedMessage defaultMessage="transferred to the validator you select above" />
+                            </strong>
+                          ),
+                        }}
+                      />
+                    </Text>
+                  </li>
+                </ul>
+              </ModalContent>
+            )}
 
-              {targetValidator && validCredentials === false && (
-                <div style={{ marginBottom: '1.5rem' }}>
-                  <Alert variant={'error'}>
-                    <AlertContent>
-                      <AlertIcon />
-                      <div>
+            {targetValidator && validCredentials === false && (
+              <div style={{ marginBottom: '1.5rem' }}>
+                <Alert variant={'error'}>
+                  <AlertContent>
+                    <AlertIcon />
+                    <div>
+                      <Text style={{ marginBottom: '1rem' }}>
+                        <strong>
+                          <FormattedMessage defaultMessage="Target validator is does not have Type 2 credentials and must be upgraded before funds can be pushed to it." />
+                        </strong>
+                      </Text>
+                      {getCredentialType(targetValidator) ===
+                        ValidatorType.BLS && (
+                        <Text>
+                          <Link inline primary to="/withdrawals">
+                            <FormattedMessage defaultMessage="More on upgrading a validator with Type 0 credentials." />
+                          </Link>
+                        </Text>
+                      )}
+                      {getCredentialType(targetValidator) ===
+                        ValidatorType.Execution && (
+                        <Text>
+                          <FormattedMessage defaultMessage="To upgrade to a Type 2 validator, please go back, select the target validator, and go through the 'Upgrade Validator' flow." />
+                        </Text>
+                      )}
+                    </div>
+                  </AlertContent>
+                </Alert>
+              </div>
+            )}
+
+            {targetValidator && !showTx && validCredentials && (
+              <div style={{ marginBottom: '1.5rem' }}>
+                <Alert variant={matchingCredentials ? 'warning' : 'error'}>
+                  <AlertContent>
+                    <AlertIcon />
+                    <div>
+                      {!matchingCredentials && (
                         <Text style={{ marginBottom: '1rem' }}>
                           <strong>
-                            <FormattedMessage defaultMessage="Target validator is does not have Type 2 credentials and must be upgraded before funds can be pushed to it." />
+                            <FormattedMessage defaultMessage="Target validator is not associated with your current wallet!" />
                           </strong>
                         </Text>
-                        {getCredentialType(targetValidator) ===
-                          ValidatorType.BLS && (
-                          <Text>
-                            <Link inline primary to="/withdrawals">
-                              <FormattedMessage defaultMessage="More on upgrading a validator with Type 0 credentials." />
-                            </Link>
-                          </Text>
-                        )}
-                        {getCredentialType(targetValidator) ===
-                          ValidatorType.Execution && (
-                          <Text>
-                            <FormattedMessage defaultMessage="To upgrade to a Type 2 validator, please go back, select the target validator, and go through the 'Upgrade Validator' flow." />
-                          </Text>
-                        )}
-                      </div>
-                    </AlertContent>
-                  </Alert>
-                </div>
-              )}
+                      )}
+                      <Text>
+                        <strong>
+                          <FormattedMessage
+                            defaultMessage="Account {sourceIndex} will be exited from the network, and its full balance will be migrated to validator index {targetIndex}."
+                            values={{
+                              sourceIndex: sourceValidator.validatorindex,
+                              targetIndex: targetValidator.validatorindex,
+                            }}
+                          />
+                        </strong>
+                      </Text>
+                      <Text style={{ fontSize: '1rem' }}>
+                        <FormattedMessage defaultMessage="The exiting validator should remain online until exit epoch is reached." />
+                      </Text>
+                    </div>
+                  </AlertContent>
+                </Alert>
+              </div>
+            )}
 
-              {targetValidator && !showTx && validCredentials && (
-                <div style={{ marginBottom: '1.5rem' }}>
-                  <Alert variant={matchingCredentials ? 'warning' : 'error'}>
-                    <AlertContent>
-                      <AlertIcon />
-                      <div>
-                        {!matchingCredentials && (
-                          <Text style={{ marginBottom: '1rem' }}>
-                            <strong>
-                              <FormattedMessage defaultMessage="Target validator is not associated with your current wallet!" />
-                            </strong>
-                          </Text>
-                        )}
-                        <Text>
-                          <strong>
-                            <FormattedMessage
-                              defaultMessage="Account {sourceIndex} will be exited from the network, and its full balance will be migrated to validator index {targetIndex}."
-                              values={{
-                                sourceIndex: sourceValidator.validatorindex,
-                                targetIndex: targetValidator.validatorindex,
-                              }}
-                            />
-                          </strong>
-                        </Text>
-                        <Text style={{ fontSize: '1rem' }}>
-                          <FormattedMessage defaultMessage="The exiting validator should remain online until exit epoch is reached." />
-                        </Text>
-                      </div>
-                    </AlertContent>
-                  </Alert>
-                </div>
-              )}
+            {targetValidator && (
+              <ModalContent>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                  }}
+                >
+                  <div
+                    style={{
+                      background: '#fff',
+                      padding: '1rem',
+                      maxWidth: '100%',
+                      borderRadius: '8px',
+                      border: '2px solid darkred',
+                    }}
+                  >
+                    <Heading
+                      level={3}
+                      style={{ textTransform: 'uppercase', color: 'darkred' }}
+                    >
+                      <FormattedMessage defaultMessage="Exit" />
+                    </Heading>
+                    <Text>
+                      <strong>
+                        <FormattedMessage defaultMessage="Index" />:{' '}
+                        {sourceValidator.validatorindex}
+                      </strong>
+                    </Text>
+                    <Text
+                      style={{
+                        fontSize: '14px',
+                        color: '#555',
+                        marginBottom: '0.5rem',
+                      }}
+                    >
+                      <Hash>{sourceValidator.pubkey}</Hash>
+                    </Text>
 
-              {targetValidator && (
-                <ModalContent>
+                    <div
+                      style={{
+                        display: 'grid',
+                        gridTemplateColumns: 'repeat(2, 1fr)',
+                      }}
+                    >
+                      <Text
+                        style={{
+                          display: 'grid',
+                          gridColumn: 'span 2',
+                          gridTemplateColumns: 'subgrid',
+                          columnGap: '0.5rem',
+                        }}
+                      >
+                        <div>
+                          <FormattedMessage defaultMessage="Balance" />:
+                        </div>
+                        <div
+                          style={{
+                            textAlign: 'end',
+                            fontFamily: 'monospace',
+                          }}
+                        >
+                          {getEtherBalance(sourceValidator).toFixed(9)}{' '}
+                          {TICKER_NAME}
+                        </div>
+                      </Text>
+
+                      <Text
+                        style={{
+                          display: 'grid',
+                          gridColumn: 'span 2',
+                          gridTemplateColumns: 'subgrid',
+                          columnGap: '0.5rem',
+                        }}
+                      >
+                        <div>
+                          <FormattedMessage defaultMessage="New balance" />:
+                        </div>
+                        <div
+                          style={{
+                            textAlign: 'end',
+                            fontFamily: 'monospace',
+                          }}
+                        >
+                          {(0).toFixed(9)} {TICKER_NAME}
+                        </div>
+                      </Text>
+                    </div>
+                  </div>
+
                   <div
                     style={{
                       display: 'flex',
-                      flexDirection: 'column',
+                      alignItems: 'center',
+                      gap: '0.5rem',
+                      margin: '0.25rem auto',
                     }}
                   >
-                    <div
+                    <DownIcon />
+                    <Text
                       style={{
-                        background: '#fff',
-                        padding: '1rem',
-                        maxWidth: '100%',
-                        borderRadius: '8px',
-                        border: '2px solid darkred',
+                        fontFamily: 'monospace',
+                        fontSize: '1rem',
+                        color: 'darkred',
                       }}
                     >
-                      <Heading
-                        level={3}
-                        style={{ textTransform: 'uppercase', color: 'darkred' }}
-                      >
-                        <FormattedMessage defaultMessage="Exit" />
-                      </Heading>
-                      <Text>
-                        <strong>
-                          <FormattedMessage defaultMessage="Index" />:{' '}
-                          {sourceValidator.validatorindex}
-                        </strong>
-                      </Text>
-                      <Text
-                        style={{
-                          fontSize: '14px',
-                          color: '#555',
-                          marginBottom: '0.5rem',
-                        }}
-                      >
-                        <Hash>{sourceValidator.pubkey}</Hash>
-                      </Text>
-
-                      <div
-                        style={{
-                          display: 'grid',
-                          gridTemplateColumns: 'repeat(2, 1fr)',
-                        }}
-                      >
-                        <Text
-                          style={{
-                            display: 'grid',
-                            gridColumn: 'span 2',
-                            gridTemplateColumns: 'subgrid',
-                            columnGap: '0.5rem',
-                          }}
-                        >
-                          <div>
-                            <FormattedMessage defaultMessage="Balance" />:
-                          </div>
-                          <div
-                            style={{
-                              textAlign: 'end',
-                              fontFamily: 'monospace',
-                            }}
-                          >
-                            {getEtherBalance(sourceValidator).toFixed(9)}{' '}
-                            {TICKER_NAME}
-                          </div>
-                        </Text>
-
-                        <Text
-                          style={{
-                            display: 'grid',
-                            gridColumn: 'span 2',
-                            gridTemplateColumns: 'subgrid',
-                            columnGap: '0.5rem',
-                          }}
-                        >
-                          <div>
-                            <FormattedMessage defaultMessage="New balance" />:
-                          </div>
-                          <div
-                            style={{
-                              textAlign: 'end',
-                              fontFamily: 'monospace',
-                            }}
-                          >
-                            {(0).toFixed(9)} {TICKER_NAME}
-                          </div>
-                        </Text>
-                      </div>
-                    </div>
-
-                    <div
-                      style={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '0.5rem',
-                        margin: '0.25rem auto',
-                      }}
-                    >
-                      <DownIcon />
-                      <Text
-                        style={{
-                          fontFamily: 'monospace',
-                          fontSize: '1rem',
-                          color: 'darkred',
-                        }}
-                      >
-                        {getEtherBalance(sourceValidator).toFixed(9)}{' '}
-                        {TICKER_NAME}
-                      </Text>
-                    </div>
-
-                    <div
-                      style={{
-                        background: '#fff',
-                        padding: '1rem',
-                        maxWidth: '100%',
-                        borderRadius: '8px',
-                        border: '2px solid darkgreen',
-                      }}
-                    >
-                      <Heading
-                        level={3}
-                        style={{
-                          textTransform: 'uppercase',
-                          color: 'darkgreen',
-                        }}
-                      >
-                        <FormattedMessage defaultMessage="Migrate to" />
-                      </Heading>
-                      <Text>
-                        <strong>
-                          <FormattedMessage defaultMessage="Index" />:{' '}
-                          {targetValidator.validatorindex}
-                        </strong>
-                      </Text>
-                      <Text
-                        style={{
-                          fontSize: '14px',
-                          color: '#555',
-                          marginBottom: '0.5rem',
-                        }}
-                      >
-                        <Hash>{targetValidator.pubkey}</Hash>
-                      </Text>
-                      <div
-                        style={{
-                          display: 'grid',
-                          gridTemplateColumns: 'repeat(2, 1fr)',
-                        }}
-                      >
-                        <Text
-                          style={{
-                            display: 'grid',
-                            gridColumn: 'span 2',
-                            gridTemplateColumns: 'subgrid',
-                            columnGap: '0.5rem',
-                          }}
-                        >
-                          <div>
-                            <FormattedMessage defaultMessage="Current" />:
-                          </div>
-                          <div
-                            style={{
-                              textAlign: 'end',
-                              fontFamily: 'monospace',
-                            }}
-                          >
-                            {getEtherBalance(targetValidator).toFixed(9)}{' '}
-                            {TICKER_NAME}
-                          </div>
-                        </Text>
-
-                        <Text
-                          style={{
-                            display: 'grid',
-                            gridColumn: 'span 2',
-                            gridTemplateColumns: 'subgrid',
-                            columnGap: '0.5rem',
-                          }}
-                        >
-                          <div>
-                            <FormattedMessage defaultMessage="New balance" />:
-                          </div>
-                          <div
-                            style={{
-                              textAlign: 'end',
-                              fontFamily: 'monospace',
-                              color: 'darkgreen',
-                            }}
-                          >
-                            {(
-                              getEtherBalance(targetValidator) +
-                              getEtherBalance(sourceValidator)
-                            ).toFixed(9)}{' '}
-                            {TICKER_NAME}
-                          </div>
-                        </Text>
-                      </div>
-                    </div>
+                      {getEtherBalance(sourceValidator).toFixed(9)}{' '}
+                      {TICKER_NAME}
+                    </Text>
                   </div>
 
-                  {showTx && (
-                    <TransactionStatusInsert
-                      headerMessage={
-                        <>
-                          <span>{sourceValidator.validatorindex}</span>{' '}
-                          <span
-                            style={{
-                              transform: locale === 'ar' ? 'scale(-1)' : '',
-                            }}
-                          >
-                            {String.fromCodePoint(0x27a0)}
-                          </span>
-                          <span>{targetValidator.validatorindex}</span>
-                        </>
-                      }
-                      txHash={txHash}
-                      transactionStatus={txStatus}
-                    />
-                  )}
-                </ModalContent>
-              )}
-            </ModalBody>
-          </Box>
+                  <div
+                    style={{
+                      background: '#fff',
+                      padding: '1rem',
+                      maxWidth: '100%',
+                      borderRadius: '8px',
+                      border: '2px solid darkgreen',
+                    }}
+                  >
+                    <Heading
+                      level={3}
+                      style={{
+                        textTransform: 'uppercase',
+                        color: 'darkgreen',
+                      }}
+                    >
+                      <FormattedMessage defaultMessage="Migrate to" />
+                    </Heading>
+                    <Text>
+                      <strong>
+                        <FormattedMessage defaultMessage="Index" />:{' '}
+                        {targetValidator.validatorindex}
+                      </strong>
+                    </Text>
+                    <Text
+                      style={{
+                        fontSize: '14px',
+                        color: '#555',
+                        marginBottom: '0.5rem',
+                      }}
+                    >
+                      <Hash>{targetValidator.pubkey}</Hash>
+                    </Text>
+                    <div
+                      style={{
+                        display: 'grid',
+                        gridTemplateColumns: 'repeat(2, 1fr)',
+                      }}
+                    >
+                      <Text
+                        style={{
+                          display: 'grid',
+                          gridColumn: 'span 2',
+                          gridTemplateColumns: 'subgrid',
+                          columnGap: '0.5rem',
+                        }}
+                      >
+                        <div>
+                          <FormattedMessage defaultMessage="Current" />:
+                        </div>
+                        <div
+                          style={{
+                            textAlign: 'end',
+                            fontFamily: 'monospace',
+                          }}
+                        >
+                          {getEtherBalance(targetValidator).toFixed(9)}{' '}
+                          {TICKER_NAME}
+                        </div>
+                      </Text>
+
+                      <Text
+                        style={{
+                          display: 'grid',
+                          gridColumn: 'span 2',
+                          gridTemplateColumns: 'subgrid',
+                          columnGap: '0.5rem',
+                        }}
+                      >
+                        <div>
+                          <FormattedMessage defaultMessage="New balance" />:
+                        </div>
+                        <div
+                          style={{
+                            textAlign: 'end',
+                            fontFamily: 'monospace',
+                            color: 'darkgreen',
+                          }}
+                        >
+                          {(
+                            getEtherBalance(targetValidator) +
+                            getEtherBalance(sourceValidator)
+                          ).toFixed(9)}{' '}
+                          {TICKER_NAME}
+                        </div>
+                      </Text>
+                    </div>
+                  </div>
+                </div>
+
+                {showTx && (
+                  <TransactionStatusInsert
+                    headerMessage={
+                      <>
+                        <span>{sourceValidator.validatorindex}</span>{' '}
+                        <span
+                          style={{
+                            transform: locale === 'ar' ? 'scale(-1)' : '',
+                          }}
+                        >
+                          {String.fromCodePoint(0x27a0)}
+                        </span>
+                        <span>{targetValidator.validatorindex}</span>
+                      </>
+                    }
+                    txHash={txHash}
+                    transactionStatus={txStatus}
+                  />
+                )}
+              </ModalContent>
+            )}
+          </ModalBody>
           {targetValidator && validCredentials && (
             <ModalFooter>
               <QueueWarning queue={queue} />
@@ -571,11 +570,9 @@ const PushConsolidation = ({
                   >
                     <Text>
                       <FormattedMessage
-                        defaultMessage="Please type the target validator index ({targetIndex}) to acknowledge you understand where your validator balance is being transferred to."
+                        defaultMessage="Please type 'I TRANSFER MY FULL VALIDATOR BALANCE TO THE OWNER OF {targetIndex}' to acknowledge you understand where your validator balance is being transferred to."
                         values={{
-                          targetIndex: (
-                            <strong>{targetValidator.validatorindex}</strong>
-                          ),
+                          targetIndex: targetValidator.validatorindex,
                         }}
                       />
                     </Text>

--- a/src/pages/Actions/components/PushConsolidation.tsx
+++ b/src/pages/Actions/components/PushConsolidation.tsx
@@ -328,7 +328,16 @@ const PushConsolidation = ({
                       {getCredentialType(targetValidator) ===
                         ValidatorType.Execution && (
                         <Text>
-                          <FormattedMessage defaultMessage="To upgrade to a Type 2 validator, please go back, select the target validator, and go through the 'Upgrade Validator' flow." />
+                          <FormattedMessage
+                            defaultMessage="To upgrade to a Type 2 validator, please go back, select the target validator, and go through the {boldUpgradeAccount} flow."
+                            values={{
+                              boldUpgradeAccount: (
+                                <strong className="text-bold">
+                                  Upgrade Account
+                                </strong>
+                              ),
+                            }}
+                          />
                         </Text>
                       )}
                     </div>

--- a/src/pages/Actions/components/PushConsolidation.tsx
+++ b/src/pages/Actions/components/PushConsolidation.tsx
@@ -610,7 +610,7 @@ const PushConsolidation = ({
                   >
                     <Text>
                       <FormattedMessage
-                        defaultMessage="Please type {boldConfirmationMessage} to acknowledge you understand where your validator balance is being transferred to."
+                        defaultMessage="Please type {boldConfirmationMessage} to acknowledge you understand your validator is changing ownership."
                         values={{
                           boldConfirmationMessage: (
                             <strong

--- a/src/pages/Actions/components/PushConsolidation.tsx
+++ b/src/pages/Actions/components/PushConsolidation.tsx
@@ -180,7 +180,12 @@ const PushConsolidation = ({
       userConfirmationValue.trim().toLowerCase() ===
       CONFIRMATION_MESSAGE.toLowerCase()
     );
-  }, [matchingCredentials, userConfirmationValue, targetValidator]);
+  }, [
+    CONFIRMATION_MESSAGE,
+    matchingCredentials,
+    userConfirmationValue,
+    targetValidator,
+  ]);
 
   return (
     <>

--- a/src/pages/Actions/components/PushConsolidation.tsx
+++ b/src/pages/Actions/components/PushConsolidation.tsx
@@ -155,6 +155,10 @@ const PushConsolidation = ({
     }
   }, [targetValidator]);
 
+  const validValidatorState = useMemo(() => {
+    return targetValidator && targetValidator.status === 'active_ongoing';
+  }, [targetValidator]);
+
   const validConfirmationMessage = useMemo(() => {
     if (targetValidator && !matchingCredentials) {
       return (
@@ -264,7 +268,26 @@ const PushConsolidation = ({
               </ModalContent>
             )}
 
-            {targetValidator && validCredentials === false && (
+            {/* eslint-disable-next-line no-nested-ternary */}
+            {targetValidator && !validValidatorState ? (
+              <div style={{ marginBottom: '1.5rem' }}>
+                <Alert variant={'error'}>
+                  <AlertContent>
+                    <AlertIcon />
+                    <div>
+                      <Text style={{ marginBottom: '1rem' }}>
+                        <strong>
+                          <FormattedMessage defaultMessage="Target validator is not active" />
+                        </strong>
+                      </Text>
+                      <Text>
+                        <FormattedMessage defaultMessage="A validator can only be consolidated to if it is in the proper state of active ongoing." />
+                      </Text>
+                    </div>
+                  </AlertContent>
+                </Alert>
+              </div>
+            ) : targetValidator && validCredentials === false ? (
               <div style={{ marginBottom: '1.5rem' }}>
                 <Alert variant={'error'}>
                   <AlertContent>
@@ -293,40 +316,43 @@ const PushConsolidation = ({
                   </AlertContent>
                 </Alert>
               </div>
-            )}
+            ) : null}
 
-            {targetValidator && !showTx && validCredentials && (
-              <div style={{ marginBottom: '1.5rem' }}>
-                <Alert variant={matchingCredentials ? 'warning' : 'error'}>
-                  <AlertContent>
-                    <AlertIcon />
-                    <div>
-                      {!matchingCredentials && (
-                        <Text style={{ marginBottom: '1rem' }}>
+            {targetValidator &&
+              !showTx &&
+              validCredentials &&
+              validValidatorState && (
+                <div style={{ marginBottom: '1.5rem' }}>
+                  <Alert variant={matchingCredentials ? 'warning' : 'error'}>
+                    <AlertContent>
+                      <AlertIcon />
+                      <div>
+                        {!matchingCredentials && (
+                          <Text style={{ marginBottom: '1rem' }}>
+                            <strong>
+                              <FormattedMessage defaultMessage="Target validator is not associated with your current wallet!" />
+                            </strong>
+                          </Text>
+                        )}
+                        <Text>
                           <strong>
-                            <FormattedMessage defaultMessage="Target validator is not associated with your current wallet!" />
+                            <FormattedMessage
+                              defaultMessage="Account {sourceIndex} will be exited from the network, and its full balance will be migrated to validator index {targetIndex}."
+                              values={{
+                                sourceIndex: sourceValidator.validatorindex,
+                                targetIndex: targetValidator.validatorindex,
+                              }}
+                            />
                           </strong>
                         </Text>
-                      )}
-                      <Text>
-                        <strong>
-                          <FormattedMessage
-                            defaultMessage="Account {sourceIndex} will be exited from the network, and its full balance will be migrated to validator index {targetIndex}."
-                            values={{
-                              sourceIndex: sourceValidator.validatorindex,
-                              targetIndex: targetValidator.validatorindex,
-                            }}
-                          />
-                        </strong>
-                      </Text>
-                      <Text style={{ fontSize: '1rem' }}>
-                        <FormattedMessage defaultMessage="The exiting validator should remain online until exit epoch is reached." />
-                      </Text>
-                    </div>
-                  </AlertContent>
-                </Alert>
-              </div>
-            )}
+                        <Text style={{ fontSize: '1rem' }}>
+                          <FormattedMessage defaultMessage="The exiting validator should remain online until exit epoch is reached." />
+                        </Text>
+                      </div>
+                    </AlertContent>
+                  </Alert>
+                </div>
+              )}
 
             {targetValidator && (
               <ModalContent>
@@ -551,7 +577,7 @@ const PushConsolidation = ({
               </ModalContent>
             )}
           </ModalBody>
-          {targetValidator && validCredentials && (
+          {targetValidator && validCredentials && validValidatorState && (
             <ModalFooter>
               <QueueWarning queue={queue} />
 

--- a/src/pages/Actions/components/ValidatorActions.tsx
+++ b/src/pages/Actions/components/ValidatorActions.tsx
@@ -250,11 +250,6 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
             <FormattedMessage defaultMessage="Migrate funds" />
           </ActionTitle>
           <FormattedMessage defaultMessage="Transfer entire balance to another one of your validator accounts, consolidating two accounts into one. Target account must be upgraded to compounding type." />{' '}
-          {targetValidatorSet.length < 1 && (
-            <em>
-              <FormattedMessage defaultMessage="No eligible target accounts found." />
-            </em>
-          )}
         </div>
         <PushConsolidation
           sourceValidator={validator}

--- a/src/pages/Actions/components/ValidatorSelector.tsx
+++ b/src/pages/Actions/components/ValidatorSelector.tsx
@@ -28,6 +28,7 @@ const AccountType = styled.p`
 
 type ValidatorSelectorProps = {
   allowSearch?: boolean;
+  autoSelect?: boolean;
   validators: BeaconChainValidator[];
   setSelectedValidator: Dispatch<SetStateAction<BeaconChainValidator | null>>;
   selectedValidator: BeaconChainValidator | null;
@@ -35,6 +36,7 @@ type ValidatorSelectorProps = {
 
 const ValidatorSelector = ({
   allowSearch = false,
+  autoSelect = true,
   validators,
   setSelectedValidator,
   selectedValidator,
@@ -43,9 +45,10 @@ const ValidatorSelector = ({
 
   // If only one validator, select it by default
   useEffect(() => {
+    if (!autoSelect) return;
     if (validators.length !== 1) return;
     setSelectedValidator(validators[0]);
-  }, [validators, setSelectedValidator]);
+  }, [autoSelect, validators, setSelectedValidator]);
 
   const onValidatorSearch = async (value: string) => {
     // Check if user is searching by validator pubkey

--- a/src/pages/Actions/components/ValidatorSelector.tsx
+++ b/src/pages/Actions/components/ValidatorSelector.tsx
@@ -7,6 +7,7 @@ import { BeaconChainValidator } from '../../TopUp/types';
 import Select from '../../../components/Select';
 
 import { ETHER_TO_GWEI, TICKER_NAME } from '../../../utils/envVars';
+import { fetchValidatorsByPubkeys } from '../utils';
 
 const AccountType = styled.p`
   font-size: 0.875rem;
@@ -26,12 +27,14 @@ const AccountType = styled.p`
 `;
 
 type ValidatorSelectorProps = {
+  allowSearch?: boolean;
   validators: BeaconChainValidator[];
   setSelectedValidator: Dispatch<SetStateAction<BeaconChainValidator | null>>;
   selectedValidator: BeaconChainValidator | null;
 };
 
 const ValidatorSelector = ({
+  allowSearch = false,
   validators,
   setSelectedValidator,
   selectedValidator,
@@ -44,11 +47,23 @@ const ValidatorSelector = ({
     setSelectedValidator(validators[0]);
   }, [validators, setSelectedValidator]);
 
+  const onValidatorSearch = async (value: string) => {
+    // Check if user is searching by validator pubkey
+    if (value && value.length === 98) {
+      const newValidators = await fetchValidatorsByPubkeys([value]);
+
+      if (newValidators && newValidators.length === 1) {
+        setSelectedValidator(newValidators[0]);
+      }
+    }
+  };
+
   return (
     <Select
       placeholder={`Available validators: ${validators.length}`}
       searchPlaceholder={formatMessage({
-        defaultMessage: 'Filter by index or pubkey',
+        defaultMessage:
+          'Filter your validators by index or pubkey or search by pubkey',
       })}
       options={validators.map(v => {
         return {
@@ -93,6 +108,7 @@ const ValidatorSelector = ({
         const validator = validators.find(v => v.pubkey === value);
         setSelectedValidator(validator || null);
       }}
+      onSearchChange={allowSearch ? onValidatorSearch : undefined}
     />
   );
 };

--- a/src/pages/Actions/index.tsx
+++ b/src/pages/Actions/index.tsx
@@ -29,6 +29,7 @@ import WalletConnectModal from '../TopUp/components/WalletConnectModal';
 
 import { BEACONCHAIN_URL, MAX_QUERY_LIMIT } from '../../utils/envVars';
 import { hasValidatorExited } from '../../utils/validators';
+import { fetchValidatorsByPubkeys } from './utils';
 
 const FakeLink = styled.span`
   color: blue;
@@ -123,29 +124,6 @@ const fetchPubkeysByWithdrawalAddress = async (
   } catch (error) {
     console.warn(
       `Error fetching pubkeys (address ${address}, limit ${limit}, offset ${offset}):`,
-      error
-    );
-    return null;
-  }
-};
-
-const fetchValidatorsByPubkeys = async (
-  pubkeys: string[]
-): Promise<BeaconChainValidator[] | null> => {
-  try {
-    const response = await fetch(
-      `${BEACONCHAIN_URL}/api/v1/validator/${pubkeys.join(',')}`
-    );
-    if (!response.ok) throw new Error();
-    const json = await response.json();
-    const data: BeaconChainValidator[] = Array.isArray(json.data)
-      ? json.data
-      : [json.data];
-
-    return data;
-  } catch (error) {
-    console.warn(
-      `Error fetching validators (pubkeys ${pubkeys.join(',')}):`,
       error
     );
     return null;

--- a/src/pages/Actions/utils.ts
+++ b/src/pages/Actions/utils.ts
@@ -3,6 +3,7 @@ import Web3 from 'web3';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { TransactionConfig } from 'web3-core';
 import {
+  BEACONCHAIN_URL,
   COMPOUNDING_CONTRACT_ADDRESS,
   COMPOUNDING_FEE_ADDITION,
   EXCESS_INHIBITOR,
@@ -169,3 +170,26 @@ export const getEtherFeeFromQueue = (queue: Queue): string =>
 
 export const isValidatorNascent = (validator: BeaconChainValidator): boolean =>
   currentEpoch < validator.activationepoch + SHARD_COMMITTEE_PERIOD;
+
+export const fetchValidatorsByPubkeys = async (
+  pubkeys: string[]
+): Promise<BeaconChainValidator[] | null> => {
+  try {
+    const response = await fetch(
+      `${BEACONCHAIN_URL}/api/v1/validator/${pubkeys.join(',')}`
+    );
+    if (!response.ok) throw new Error();
+    const json = await response.json();
+    const data: BeaconChainValidator[] = Array.isArray(json.data)
+      ? json.data
+      : [json.data];
+
+    return data;
+  } catch (error) {
+    console.warn(
+      `Error fetching validators (pubkeys ${pubkeys.join(',')}):`,
+      error
+    );
+    return null;
+  }
+};

--- a/src/pages/ConnectWallet/web3Utils.ts
+++ b/src/pages/ConnectWallet/web3Utils.ts
@@ -19,7 +19,6 @@ export enum NetworkChainId {
   'Sepolia' = 11155111,
   'Holesky' = 17000,
   'Hoodi' = 560048,
-  'devnet6' = 7072151312,
 }
 
 export const NetworkChainIdDict: { [id: string]: number } = {
@@ -27,7 +26,6 @@ export const NetworkChainIdDict: { [id: string]: number } = {
   Sepolia: 11155111,
   Holesky: 17000,
   Hoodi: 560048,
-  devnet6: 7072151312,
 };
 
 /*
@@ -40,14 +38,12 @@ const supportedNetworks = [
   NetworkChainId.Sepolia,
   NetworkChainId.Holesky,
   NetworkChainId.Hoodi,
-  NetworkChainId.devnet6,
 ];
 
 enum Testnet {
   'Sepolia',
   'Holesky',
   'Hoodi',
-  'devnet6',
 }
 
 enum Mainnet {
@@ -59,7 +55,6 @@ export const NetworkNameToChainId: { [key: string]: NetworkChainId } = {
   Mainnet: NetworkChainId.Mainnet,
   Sepolia: NetworkChainId.Sepolia,
   Hoodi: NetworkChainId.Hoodi,
-  devnet6: NetworkChainId.devnet6,
 };
 
 export const TARGET_NETWORK_CHAIN_ID = IS_MAINNET

--- a/src/pages/ConnectWallet/web3Utils.ts
+++ b/src/pages/ConnectWallet/web3Utils.ts
@@ -19,6 +19,7 @@ export enum NetworkChainId {
   'Sepolia' = 11155111,
   'Holesky' = 17000,
   'Hoodi' = 560048,
+  'devnet6' = 7072151312,
 }
 
 export const NetworkChainIdDict: { [id: string]: number } = {
@@ -26,6 +27,7 @@ export const NetworkChainIdDict: { [id: string]: number } = {
   Sepolia: 11155111,
   Holesky: 17000,
   Hoodi: 560048,
+  devnet6: 7072151312,
 };
 
 /*
@@ -38,12 +40,14 @@ const supportedNetworks = [
   NetworkChainId.Sepolia,
   NetworkChainId.Holesky,
   NetworkChainId.Hoodi,
+  NetworkChainId.devnet6,
 ];
 
 enum Testnet {
   'Sepolia',
   'Holesky',
   'Hoodi',
+  'devnet6',
 }
 
 enum Mainnet {
@@ -55,6 +59,7 @@ export const NetworkNameToChainId: { [key: string]: NetworkChainId } = {
   Mainnet: NetworkChainId.Mainnet,
   Sepolia: NetworkChainId.Sepolia,
   Hoodi: NetworkChainId.Hoodi,
+  devnet6: NetworkChainId.devnet6,
 };
 
 export const TARGET_NETWORK_CHAIN_ID = IS_MAINNET


### PR DESCRIPTION
Adds ability to consolidate a validator into one that is not associated with the connected wallet. This is done by searching the validator dropdown by a pubkey. If one is discovered, it will be selected.  Also handling messaging if the discovered validator does not have 0x02 credentials. A little safety check is also being added in this case where the user will need to type the validator index of what they are sending to. This can be easily updated if a more strenuous message is desired.

This is branched off of #750 so that should be landed first