### PR TITLE
fix: apply font-weight:700; for strong elements

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -2313,6 +2313,24 @@
       "value": " pool"
     }
   ],
+  "CUd95N": [
+    {
+      "type": 0,
+      "value": "Compounding accounts are eligible to request partial withdrawals of any balance over "
+    },
+    {
+      "type": 1,
+      "value": "MIN_ACTIVATION_BALANCE"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "type": 1,
+      "value": "TICKER_NAME"
+    }
+  ],
   "CWKE9c": [
     {
       "type": 0,
@@ -6485,24 +6503,6 @@
     {
       "type": 0,
       "value": "Waiting for wallet confirmation"
-    }
-  ],
-  "fnV2qn": [
-    {
-      "type": 0,
-      "value": "Compounding accounts eligible to request partial withdrawals of any balance over "
-    },
-    {
-      "type": 1,
-      "value": "MIN_ACTIVATION_BALANCE"
-    },
-    {
-      "type": 0,
-      "value": " "
-    },
-    {
-      "type": 1,
-      "value": "TICKER_NAME"
     }
   ],
   "fpe4Gx": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -865,6 +865,9 @@
   "CT+gEC": {
     "message": "Upload to Beacon Node {btec} pool"
   },
+  "CUd95N": {
+    "message": "Compounding accounts are eligible to request partial withdrawals of any balance over {MIN_ACTIVATION_BALANCE} {TICKER_NAME}"
+  },
   "CWKE9c": {
     "message": "Your wallet is on the wrong network. Switch to {executionLayerName}"
   },
@@ -2461,9 +2464,6 @@
   },
   "fnMHGO": {
     "message": "Waiting for wallet confirmation"
-  },
-  "fnV2qn": {
-    "message": "Compounding accounts eligible to request partial withdrawals of any balance over {MIN_ACTIVATION_BALANCE} {TICKER_NAME}"
   },
   "fpe4Gx": {
     "message": "Active accounts with an effective balance or total balance less than {PRICE_PER_VALIDATOR} {TICKER_NAME} will be skipped"

--- a/src/pages/Actions/components/ForceExit.tsx
+++ b/src/pages/Actions/components/ForceExit.tsx
@@ -136,10 +136,8 @@ const ForceExit: React.FC<Props> = ({ validator }) => {
                 <AlertContent>
                   <AlertIcon />
                   <div>
-                    <Text>
-                      <strong>
-                        <FormattedMessage defaultMessage="This account will be permanently exited from the network." />
-                      </strong>
+                    <Text className="text-bold">
+                      <FormattedMessage defaultMessage="This account will be permanently exited from the network." />
                     </Text>
                     <Text style={{ fontSize: '1rem' }}>
                       <FormattedMessage defaultMessage="This validator should remain online until exit epoch is reached." />
@@ -180,7 +178,7 @@ const ForceExit: React.FC<Props> = ({ validator }) => {
                           defaultMessage="All remaining funds will be transferred to the {destination} within a few days after exit epoch reached"
                           values={{
                             destination: (
-                              <strong>
+                              <strong className="text-bold">
                                 <FormattedMessage defaultMessage="connected execution withdrawal address" />
                               </strong>
                             ),
@@ -217,11 +215,9 @@ const ForceExit: React.FC<Props> = ({ validator }) => {
                     >
                       <FormattedMessage defaultMessage="Exit" />
                     </Heading>
-                    <Text>
-                      <strong>
-                        <FormattedMessage defaultMessage="Index" />:{' '}
-                        {validator.validatorindex}
-                      </strong>
+                    <Text className="text-bold">
+                      <FormattedMessage defaultMessage="Index" />:{' '}
+                      {validator.validatorindex}
                     </Text>
                     <Text
                       style={{
@@ -316,10 +312,8 @@ const ForceExit: React.FC<Props> = ({ validator }) => {
                     >
                       <FormattedMessage defaultMessage="Withdraw to" />
                     </Heading>
-                    <Text>
-                      <strong>
-                        <FormattedMessage defaultMessage="Execution account" />:
-                      </strong>
+                    <Text className="text-bold">
+                      <FormattedMessage defaultMessage="Execution account" />:
                     </Text>
                     <Text
                       style={{
@@ -423,8 +417,11 @@ const ForceExit: React.FC<Props> = ({ validator }) => {
                     style={{ marginBottom: '0.25rem' }}
                   >
                     <Text>
-                      Please type <strong>{CONFIRM_EXIT_STRING}</strong> to
-                      confirm.
+                      Please type{' '}
+                      <strong className="text-bold">
+                        {CONFIRM_EXIT_STRING}
+                      </strong>{' '}
+                      to confirm.
                     </Text>
                   </label>
                   <TextInput

--- a/src/pages/Actions/components/PartialWithdraw.tsx
+++ b/src/pages/Actions/components/PartialWithdraw.tsx
@@ -191,11 +191,9 @@ const PartialWithdraw: React.FC<Props> = ({ validator }) => {
                       description="'Unstake' refers to this ETH no longer being considered at 'stake' nor contributing to consensus."
                     />
                   </Heading>
-                  <Text>
-                    <strong>
-                      <FormattedMessage defaultMessage="Index" />:{' '}
-                      {validator.validatorindex}
-                    </strong>
+                  <Text className="text-bold">
+                    <FormattedMessage defaultMessage="Index" />:{' '}
+                    {validator.validatorindex}
                   </Text>
                   <Text
                     style={{
@@ -301,10 +299,8 @@ const PartialWithdraw: React.FC<Props> = ({ validator }) => {
                   >
                     <FormattedMessage defaultMessage="Withdraw to" />
                   </Heading>
-                  <Text>
-                    <strong>
-                      <FormattedMessage defaultMessage="Execution account" />:
-                    </strong>
+                  <Text className="text-bold">
+                    <FormattedMessage defaultMessage="Execution account" />:
                   </Text>
                   <Text
                     style={{

--- a/src/pages/Actions/components/PullConsolidation.tsx
+++ b/src/pages/Actions/components/PullConsolidation.tsx
@@ -155,7 +155,7 @@ const PullConsolidation = ({
                       defaultMessage="Which validator would you like to {pullFrom}?"
                       values={{
                         pullFrom: (
-                          <strong>
+                          <strong className="text-bold">
                             <FormattedMessage defaultMessage="pull full balance from" />
                           </strong>
                         ),
@@ -176,16 +176,14 @@ const PullConsolidation = ({
                     <AlertContent>
                       <AlertIcon />
                       <div>
-                        <Text>
-                          <strong>
-                            <FormattedMessage
-                              defaultMessage="Account {sourceIndex} will be exited from the network, and its full balance will be migrated to validator index {targetIndex}."
-                              values={{
-                                targetIndex: targetValidator.validatorindex,
-                                sourceIndex: sourceValidator.validatorindex,
-                              }}
-                            />
-                          </strong>
+                        <Text className="text-bold">
+                          <FormattedMessage
+                            defaultMessage="Account {sourceIndex} will be exited from the network, and its full balance will be migrated to validator index {targetIndex}."
+                            values={{
+                              targetIndex: targetValidator.validatorindex,
+                              sourceIndex: sourceValidator.validatorindex,
+                            }}
+                          />
                         </Text>
                         <Text style={{ fontSize: '1rem' }}>
                           <FormattedMessage defaultMessage="The exiting validator should remain online until exit epoch is reached." />
@@ -219,11 +217,9 @@ const PullConsolidation = ({
                       >
                         <FormattedMessage defaultMessage="Exit" />
                       </Heading>
-                      <Text>
-                        <strong>
-                          <FormattedMessage defaultMessage="Index" />:{' '}
-                          {sourceValidator.validatorindex}
-                        </strong>
+                      <Text className="text-bold">
+                        <FormattedMessage defaultMessage="Index" />:{' '}
+                        {sourceValidator.validatorindex}
                       </Text>
                       <Text
                         style={{
@@ -325,11 +321,9 @@ const PullConsolidation = ({
                       >
                         <FormattedMessage defaultMessage="Migrate to" />
                       </Heading>
-                      <Text>
-                        <strong>
-                          <FormattedMessage defaultMessage="Index" />:{' '}
-                          {targetValidator.validatorindex}
-                        </strong>
+                      <Text className="text-bold">
+                        <FormattedMessage defaultMessage="Index" />:{' '}
+                        {targetValidator.validatorindex}
                       </Text>
                       <Text
                         style={{
@@ -424,7 +418,7 @@ const PullConsolidation = ({
                       defaultMessage="This will initiate the process of permanently {exiting} from the Ethereum proof-of-stake network."
                       values={{
                         exiting: (
-                          <strong>
+                          <strong className="text-bold">
                             <FormattedMessage defaultMessage="exiting the validator you choose above" />
                           </strong>
                         ),
@@ -455,7 +449,7 @@ const PullConsolidation = ({
                           defaultMessage="All remaining funds will be {transferredToDestination} within a few days after exit epoch reached"
                           values={{
                             transferredToDestination: (
-                              <strong>
+                              <strong className="text-bold">
                                 <FormattedMessage
                                   defaultMessage="transferred to validator index {index}"
                                   values={{

--- a/src/pages/Actions/components/PushConsolidation.tsx
+++ b/src/pages/Actions/components/PushConsolidation.tsx
@@ -152,7 +152,7 @@ const PushConsolidation = ({
                       description="{migrateFundsTo} indicates the direction funds will be transferred, and is emphasized visually"
                       values={{
                         migrateFundsTo: (
-                          <strong>
+                          <strong className="text-bold">
                             <FormattedMessage defaultMessage="migrate funds to" />
                           </strong>
                         ),
@@ -174,7 +174,7 @@ const PushConsolidation = ({
                       defaultMessage="This will initiate the process of permanently {exiting} from the Ethereum proof-of-stake network."
                       values={{
                         exiting: (
-                          <strong>
+                          <strong className="text-bold">
                             <FormattedMessage
                               defaultMessage="exiting index {sourceIndex}"
                               values={{
@@ -206,7 +206,7 @@ const PushConsolidation = ({
                           defaultMessage="All remaining funds will be {transferredToDestination} within a few days after exit epoch reached"
                           values={{
                             transferredToDestination: (
-                              <strong>
+                              <strong className="text-bold">
                                 <FormattedMessage defaultMessage="transferred to the validator you select above" />
                               </strong>
                             ),
@@ -224,16 +224,14 @@ const PushConsolidation = ({
                     <AlertContent>
                       <AlertIcon />
                       <div>
-                        <Text>
-                          <strong>
-                            <FormattedMessage
-                              defaultMessage="Account {sourceIndex} will be exited from the network, and its full balance will be migrated to validator index {targetIndex}."
-                              values={{
-                                sourceIndex: sourceValidator.validatorindex,
-                                targetIndex: targetValidator.validatorindex,
-                              }}
-                            />
-                          </strong>
+                        <Text className="text-bold">
+                          <FormattedMessage
+                            defaultMessage="Account {sourceIndex} will be exited from the network, and its full balance will be migrated to validator index {targetIndex}."
+                            values={{
+                              sourceIndex: sourceValidator.validatorindex,
+                              targetIndex: targetValidator.validatorindex,
+                            }}
+                          />
                         </Text>
                         <Text style={{ fontSize: '1rem' }}>
                           <FormattedMessage defaultMessage="The exiting validator should remain online until exit epoch is reached." />
@@ -267,11 +265,9 @@ const PushConsolidation = ({
                       >
                         <FormattedMessage defaultMessage="Exit" />
                       </Heading>
-                      <Text>
-                        <strong>
-                          <FormattedMessage defaultMessage="Index" />:{' '}
-                          {sourceValidator.validatorindex}
-                        </strong>
+                      <Text className="text-bold">
+                        <FormattedMessage defaultMessage="Index" />:{' '}
+                        {sourceValidator.validatorindex}
                       </Text>
                       <Text
                         style={{
@@ -373,11 +369,9 @@ const PushConsolidation = ({
                       >
                         <FormattedMessage defaultMessage="Migrate to" />
                       </Heading>
-                      <Text>
-                        <strong>
-                          <FormattedMessage defaultMessage="Index" />:{' '}
-                          {targetValidator.validatorindex}
-                        </strong>
+                      <Text className="text-bold">
+                        <FormattedMessage defaultMessage="Index" />:{' '}
+                        {targetValidator.validatorindex}
                       </Text>
                       <Text
                         style={{

--- a/src/pages/Actions/components/QueueWarning.tsx
+++ b/src/pages/Actions/components/QueueWarning.tsx
@@ -18,10 +18,11 @@ const QueueWarning = ({ queue }: QueueWarningProps) => {
   if (feeStatus === 'high')
     return (
       <Alert variant="warning" style={{ fontSize: '1rem', padding: '1rem' }}>
-        <Text style={{ fontSize: '1rem', lineHeight: '1.75rem' }}>
-          <strong>
-            <FormattedMessage defaultMessage="Caution - current request queue higher than normal volume" />
-          </strong>
+        <Text
+          style={{ fontSize: '1rem', lineHeight: '1.75rem' }}
+          className="text-bold"
+        >
+          <FormattedMessage defaultMessage="Caution - current request queue higher than normal volume" />
         </Text>
         <Text style={{ fontSize: '1rem' }}>
           <FormattedMessage
@@ -42,10 +43,9 @@ const QueueWarning = ({ queue }: QueueWarningProps) => {
               textTransform: 'uppercase',
               lineHeight: '1.75rem',
             }}
+            className="text-bold"
           >
-            <strong>
-              <FormattedMessage defaultMessage="Warning! Network traffic significantly elevated." />
-            </strong>
+            <FormattedMessage defaultMessage="Warning! Network traffic significantly elevated." />
           </Text>
           <Text style={{ fontSize: '1rem' }}>
             <FormattedMessage defaultMessage="Fee volatility is high during network congestion. Insufficient payments will result in your request failing without refund." />
@@ -54,7 +54,11 @@ const QueueWarning = ({ queue }: QueueWarningProps) => {
             <FormattedMessage
               defaultMessage="Current processing fee: {fee}."
               values={{
-                fee: <strong>{getEtherFeeFromQueue(queue)}</strong>,
+                fee: (
+                  <strong className="text-bold">
+                    {getEtherFeeFromQueue(queue)}
+                  </strong>
+                ),
               }}
             />
           </Text>

--- a/src/pages/Actions/components/UpgradeCompounding.tsx
+++ b/src/pages/Actions/components/UpgradeCompounding.tsx
@@ -136,10 +136,8 @@ const UpgradeCompounding: React.FC<Props> = ({ validator }) => {
                 <AlertContent>
                   <AlertIcon />
                   <div>
-                    <Text>
-                      <strong>
-                        <FormattedMessage defaultMessage="This validator account will be permanently upgraded to a compounding (Type 2) account." />
-                      </strong>
+                    <Text className="text-bold">
+                      <FormattedMessage defaultMessage="This validator account will be permanently upgraded to a compounding (Type 2) account." />
                     </Text>
                   </div>
                 </AlertContent>
@@ -171,7 +169,7 @@ const UpgradeCompounding: React.FC<Props> = ({ validator }) => {
                     <li>
                       <Text as="span">
                         <FormattedMessage
-                          defaultMessage="Compounding accounts eligible to request partial withdrawals of any balance over {MIN_ACTIVATION_BALANCE} {TICKER_NAME}"
+                          defaultMessage="Compounding accounts are eligible to request partial withdrawals of any balance over {MIN_ACTIVATION_BALANCE} {TICKER_NAME}"
                           values={{ MIN_ACTIVATION_BALANCE, TICKER_NAME }}
                         />
                       </Text>

--- a/src/pages/Actions/components/ValidatorDetails.tsx
+++ b/src/pages/Actions/components/ValidatorDetails.tsx
@@ -206,19 +206,17 @@ const ValidatorDetails = ({
             gap: '0.5rem',
           }}
         >
-          <Text>
-            <strong>
-              <FormattedMessage
-                defaultMessage="Validator exit {pending} - no further performable actions"
-                values={{
-                  pending: hasExitCompleted ? (
-                    ''
-                  ) : (
-                    <FormattedMessage defaultMessage="pending" />
-                  ),
-                }}
-              />
-            </strong>
+          <Text className="text-bold">
+            <FormattedMessage
+              defaultMessage="Validator exit {pending} - no further performable actions"
+              values={{
+                pending: hasExitCompleted ? (
+                  ''
+                ) : (
+                  <FormattedMessage defaultMessage="pending" />
+                ),
+              }}
+            />
           </Text>
           <Text>
             <FormattedMessage defaultMessage="Exit Epoch" />:{' '}

--- a/src/pages/Actions/index.tsx
+++ b/src/pages/Actions/index.tsx
@@ -304,10 +304,8 @@ const _ActionsPage = () => {
           >
             <AlertIcon color="redLight" />
             <div>
-              <Text className="mb10">
-                <strong>
-                  <FormattedMessage defaultMessage="No validators were found with withdrawal credentials matching connected account." />
-                </strong>
+              <Text className="mb10 text-bold">
+                <FormattedMessage defaultMessage="No validators were found with withdrawal credentials matching connected account." />
               </Text>
               <Text className="mb20">
                 <FormattedMessage defaultMessage="You may have a deposit that was accepted but is being processed through the activation queue. Please wait and try again or seek assistance if this error continues." />
@@ -373,10 +371,8 @@ const _ActionsPage = () => {
                     <AlertBody>
                       <AlertIcon />
                       <div>
-                        <AlertText className="mb10">
-                          <strong>
-                            <FormattedMessage defaultMessage="All actions are added to a queue for processing" />
-                          </strong>
+                        <AlertText className="mb10 text-bold">
+                          <FormattedMessage defaultMessage="All actions are added to a queue for processing" />
                         </AlertText>
                         <AlertText>
                           <FormattedMessage defaultMessage="Recent changes may not be reflected in validator details, and network congestion may result in delays. Use caution to avoid submitting duplicate requests." />

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -40,6 +40,7 @@ const shorthandClasses = `
     word-break: break-word;
   }
   .align-flex-end { align-items: flex-end; }
+  .text-bold { font-weight: 700; }
 `;
 
 const transitionClasses = `


### PR DESCRIPTION
## 🚨 Sub-PR, targets #744 

Fixes `strong` styling to appropriately use `font-weith: 700;` using a new `text-bold` class.

Example:
Before:
<img width="1097" alt="image" src="https://github.com/user-attachments/assets/35754509-7f30-4358-852a-ed84b12deafc" />

After:
<img width="1135" alt="image" src="https://github.com/user-attachments/assets/f72bc745-2542-40d0-a5e5-87d046945e4f" />
