### PR TITLE
Better handling for validator details API response in top ups

### DIFF
--- a/src/pages/TopUp/index.tsx
+++ b/src/pages/TopUp/index.tsx
@@ -131,18 +131,26 @@ const _TopUpPage: React.FC<Props> = () => {
                 `${BEACONCHAIN_URL}/api/v1/validator/${pubKeysCommaDelineated}`
               )
                 .then(r => r.json())
-                .then(({ data }: { data: BeaconChainValidator[] }) => {
-                  if (data.length === 0) {
-                    setShowDepositVerificationWarning(true);
+                .then(
+                  ({
+                    data,
+                  }: {
+                    data: BeaconChainValidator[] | BeaconChainValidator;
+                  }) => {
+                    const validatorsResponse = Array.isArray(data)
+                      ? data
+                      : [data];
+                    if (validatorsResponse.length === 0) {
+                      setShowDepositVerificationWarning(true);
+                      setValidators([]);
+                    } else {
+                      setValidators(
+                        validatorsResponse as BeaconChainValidator[]
+                      );
+                    }
+                    setLoading(false);
                   }
-                  // A single validator will not result in an array
-                  setValidators(
-                    response.length === 1
-                      ? (([data] as unknown) as BeaconChainValidator[])
-                      : data
-                  );
-                  setLoading(false);
-                })
+                )
                 .catch(error => {
                   console.log(error);
                   setLoading(false);


### PR DESCRIPTION
There is an issue with how we handle the combined responses from `/api/v1/validator/${pubKeys}` and `/api/v1/validator/eth1/${account}` where we can set an object to validators in the top up page causing this error:

```
react-dom.production.min.js:209 TypeError: a.map is not a function
    at ValidatorTable.tsx:129:23
    at yc (ValidatorTable.tsx:128:31)
index.tsx:147 TypeError: a.map is not a function
    at ValidatorTable.tsx:129:23
    at yc (ValidatorTable.tsx:128:31)
```

Both of these API can return a single object instead of an array and they need to be handled in this way. This change improved this response handling and it doesn't mix checking for the length of the first response to adjust the array of the second response.