### PR TITLE
Add dora validator statuses

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -1027,6 +1027,12 @@
       "value": "These terminology updates only change naming conventions; this does not alter Ethereum's goals or roadmap."
     }
   ],
+  "3a5wL8": [
+    {
+      "type": 0,
+      "value": "Active"
+    }
+  ],
   "3aykgN": [
     {
       "type": 0,
@@ -1223,6 +1229,12 @@
     {
       "type": 0,
       "value": "The remaining balance will be unlocked after the above exit epoch has been reached. Once unlocked, the remaining balance will automatically be transferred to either your connected withdrawal account, or your chosen target validator if you're migrating accounts, within a few days."
+    }
+  ],
+  "5/MOHn": [
+    {
+      "type": 0,
+      "value": "Active Exiting"
     }
   ],
   "57MWKW": [
@@ -1523,6 +1535,12 @@
     {
       "type": 0,
       "value": "Notes"
+    }
+  ],
+  "715MG7": [
+    {
+      "type": 0,
+      "value": "Pending Initialized"
     }
   ],
   "738tqz": [
@@ -2089,6 +2107,12 @@
     {
       "type": 0,
       "value": "understanding validator effective balance"
+    }
+  ],
+  "AhFU2+": [
+    {
+      "type": 0,
+      "value": "Pending Queued"
     }
   ],
   "AkVktj": [
@@ -3399,6 +3423,12 @@
       "value": "Further reading"
     }
   ],
+  "JcQdD5": [
+    {
+      "type": 0,
+      "value": "Active Slashed"
+    }
+  ],
   "JhUYU3": [
     {
       "type": 0,
@@ -4067,6 +4097,12 @@
       "value": ")"
     }
   ],
+  "NsVnBT": [
+    {
+      "type": 0,
+      "value": "Withdrawal Done"
+    }
+  ],
   "NwzcYT": [
     {
       "type": 0,
@@ -4145,6 +4181,12 @@
     {
       "type": 1,
       "value": "TICKER_NAME"
+    }
+  ],
+  "OPrOVV": [
+    {
+      "type": 0,
+      "value": "Exited Unslashed"
     }
   ],
   "ORVjVH": [
@@ -8351,6 +8393,12 @@
       "value": "Your wallet has disconnected"
     }
   ],
+  "qdoOtK": [
+    {
+      "type": 0,
+      "value": "Withdrawal Possible"
+    }
+  ],
   "qgqVCE": [
     {
       "type": 0,
@@ -8559,6 +8607,12 @@
     {
       "type": 0,
       "value": "Teku can also be configured via a YAML file which is passed in via a few different ways."
+    }
+  ],
+  "sF92ld": [
+    {
+      "type": 0,
+      "value": "Exited Slashed"
     }
   ],
   "sFD6T7": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -376,6 +376,9 @@
   "3SOKyg": {
     "message": "These terminology updates only change naming conventions; this does not alter Ethereum's goals or roadmap."
   },
+  "3a5wL8": {
+    "message": "Active"
+  },
   "3aykgN": {
     "message": "Your validator will also receives unburnt gas fees when proposing blocks. Validators are chosen randomly by the protocol to propose blocks, and only one validator can propose a block for each 12-second slot. There are 7200 slots each day, so each validator has 7200 chances-per-day to propose a block. If there are 500,000 validators, each validator will {average} a block proposal every 70 days."
   },
@@ -445,6 +448,9 @@
   },
   "4zqUmR": {
     "message": "The remaining balance will be unlocked after the above exit epoch has been reached. Once unlocked, the remaining balance will automatically be transferred to either your connected withdrawal account, or your chosen target validator if you're migrating accounts, within a few days."
+  },
+  "5/MOHn": {
+    "message": "Active Exiting"
   },
   "57MWKW": {
     "message": "Withdrawals as an operation, not a new transaction type"
@@ -531,6 +537,9 @@
   },
   "7+Domh": {
     "message": "Notes"
+  },
+  "715MG7": {
+    "message": "Pending Initialized"
   },
   "738tqz": {
     "message": "Prysm is written in Go and released under a GPL-3.0 license."
@@ -770,6 +779,9 @@
   },
   "AbBgEs": {
     "message": "understanding validator effective balance"
+  },
+  "AhFU2+": {
+    "message": "Pending Queued"
   },
   "AkVktj": {
     "message": "Check deposit contract address"
@@ -1274,6 +1286,9 @@
   "Ja5vXW": {
     "message": "Further reading"
   },
+  "JcQdD5": {
+    "message": "Active Slashed"
+  },
   "JhUYU3": {
     "message": "Download CLI app"
   },
@@ -1553,6 +1568,9 @@
   "NkFxlX": {
     "message": "At least {time} (four epochs) from the current epoch before reaching the exit epoch (with no others in the queue, {highlyVariable})"
   },
+  "NsVnBT": {
+    "message": "Withdrawal Done"
+  },
   "NwzcYT": {
     "message": "Teku needs to be pointed at files containing keystores and their associated passwords at startup. There are 3 methods for doing so."
   },
@@ -1582,6 +1600,9 @@
   },
   "ONXIv4": {
     "message": "Withdrawal some {TICKER_NAME}"
+  },
+  "OPrOVV": {
+    "message": "Exited Unslashed"
   },
   "ORVjVH": {
     "message": "Then another {time} (256 epochs) before those funds are flagged as withdrawable"
@@ -3173,6 +3194,9 @@
   "qdk7Hp": {
     "message": "Your wallet has disconnected"
   },
+  "qdoOtK": {
+    "message": "Withdrawal Possible"
+  },
   "qgqVCE": {
     "message": "reconnect your wallet"
   },
@@ -3253,6 +3277,9 @@
   },
   "s6gImC": {
     "message": "Teku can also be configured via a YAML file which is passed in via a few different ways."
+  },
+  "sF92ld": {
+    "message": "Exited Slashed"
   },
   "sFD6T7": {
     "message": "Lodestar is a Typescript ecosystem for Ethereum consensus, developed by ChainSafe Systems. Our beacon, validator client and tooling is uniquely situated as the go-to for researchers and developers for rapid prototyping."

--- a/src/pages/Actions/components/ValidatorDetails.tsx
+++ b/src/pages/Actions/components/ValidatorDetails.tsx
@@ -92,6 +92,24 @@ const ValidatorDetails = ({
       return <FormattedMessage defaultMessage="Exiting Offline" />;
     if (status === 'exited')
       return <FormattedMessage defaultMessage="Exited" />;
+    if (status === 'pending_initialized')
+      return <FormattedMessage defaultMessage="Pending Initialized" />;
+    if (status === 'pending_queued')
+      return <FormattedMessage defaultMessage="Pending Queued" />;
+    if (status === 'active_ongoing')
+      return <FormattedMessage defaultMessage="Active" />;
+    if (status === 'active_exiting')
+      return <FormattedMessage defaultMessage="Active Exiting" />;
+    if (status === 'active_slashed')
+      return <FormattedMessage defaultMessage="Active Slashed" />;
+    if (status === 'exited_unslashed')
+      return <FormattedMessage defaultMessage="Exited Unslashed" />;
+    if (status === 'exited_slashed')
+      return <FormattedMessage defaultMessage="Exited Slashed" />;
+    if (status === 'withdrawal_possible')
+      return <FormattedMessage defaultMessage="Withdrawal Possible" />;
+    if (status === 'withdrawal_done')
+      return <FormattedMessage defaultMessage="Withdrawal Done" />;
     return status
       .split('_')
       .map((word: string) => word.charAt(0).toUpperCase() + word.slice(1))
@@ -102,6 +120,7 @@ const ValidatorDetails = ({
     if (status.includes('offline')) return '#e74c3c';
     if (status.includes('slash')) return '#e74c3c';
     if (status.includes('online')) return 'green';
+    if (status.includes('active')) return 'green';
     if (status.includes('exit')) return 'darkred';
     return 'inherit';
   };

--- a/src/pages/TopUp/components/ValidatorTable.tsx
+++ b/src/pages/TopUp/components/ValidatorTable.tsx
@@ -120,6 +120,76 @@ const ValidatorTable: React.FC<{
           </Item>
         );
       }
+      case 'active_ongoing': {
+        return (
+          <Item>
+            <Wifi color={theme.green.dark} />
+            <Text>
+              <FormattedMessage defaultMessage="Online" />
+            </Text>
+          </Item>
+        );
+      }
+      case 'pending_initialized': {
+        return (
+          <Item>
+            <Refresh color="blueLight" />
+            <Text>
+              <FormattedMessage defaultMessage="Pending" />
+            </Text>
+          </Item>
+        );
+      }
+      case 'pending_queued': {
+        return (
+          <Item>
+            <Refresh color="blueLight" />
+            <Text>
+              <FormattedMessage defaultMessage="Pending" />
+            </Text>
+          </Item>
+        );
+      }
+      case 'active_slashed': {
+        return (
+          <Item>
+            <StatusWarning color={theme.red.light} />
+            <Text>
+              <FormattedMessage defaultMessage="Slashing" />
+            </Text>
+          </Item>
+        );
+      }
+      case 'exited_slashed': {
+        return (
+          <Item>
+            <StatusWarning color={theme.red.light} />
+            <Text>
+              <FormattedMessage defaultMessage="Slashed" />
+            </Text>
+          </Item>
+        );
+      }
+      case 'active_exiting': {
+        return (
+          <Item>
+            <StatusWarning color="yellowDark" />
+            <Text>
+              <FormattedMessage defaultMessage="Exiting" />
+            </Text>
+          </Item>
+        );
+      }
+      case 'exited_unslashed': {
+        return (
+          <Item>
+            <StatusDisabled color={theme.gray.medium} />
+            <Text>
+              <FormattedMessage defaultMessage="Exited" />
+            </Text>
+          </Item>
+        );
+      }
       default:
         return '';
     }


### PR DESCRIPTION
The Dora API uses different statuses than those from beaconcha.in. It uses the one from https://github.com/attestantio/go-eth2-client . The source can be found on https://github.com/attestantio/go-eth2-client/blob/07599e7891634b175c498ea5c5f842a19bc29a61/api/v1/validatorstate.go#L49

This PR add the additional statuses so we can use both sets of APIs. This is mostly for visual support for the staking-launchpad.