### PR TITLE
revert: duplicate REACT_APP_BEACONCHAIN_URL from template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -53,8 +53,6 @@ REACT_APP_ETH_DEPOSIT_OFFSET=0
 # string
 REACT_APP_FAUCET_URL=https://hoodi-faucet.pk910.de/
 # string
-REACT_APP_BEACONCHAIN_URL=https://dora.hoodi.ethpandaops.io/
-# string
 REACT_APP_TUTORIAL_URL=https://notes.ethereum.org/@launchpad/hoodi
 # number
 REACT_APP_MIN_GENESIS_TIME=1695902400000


### PR DESCRIPTION
## Description
Removes duplicate key from env var template

## Related issue
_Issue posted by @remyroy in https://github.com/ethereum/staking-launchpad/pull/756#discussion_r2074656051_