### PR TITLE
Pectra bug fixes

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -9663,6 +9663,12 @@
       "value": "Your old BLS withdrawal credentials"
     }
   ],
+  "z5YIRy": [
+    {
+      "type": 0,
+      "value": "Filter your validators by index or pubkey"
+    }
+  ],
   "z63I56": [
     {
       "type": 0,

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -3675,6 +3675,9 @@
   "yzvSUC": {
     "message": "Your old BLS withdrawal credentials"
   },
+  "z5YIRy": {
+    "message": "Filter your validators by index or pubkey"
+  },
   "z63I56": {
     "message": "validator"
   },

--- a/src/pages/Actions/components/ValidatorActions.tsx
+++ b/src/pages/Actions/components/ValidatorActions.tsx
@@ -110,9 +110,16 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
 
     setSourceValidatorSet(potentialSourceValidators);
 
-    const potentialTargetValidators = potentialSourceValidators.filter(
-      v => getCredentialType(v) >= ValidatorType.Compounding
-    );
+    const potentialTargetValidators = validators.filter(v => {
+      const compounding = getCredentialType(v) >= ValidatorType.Compounding;
+      const isSameValidator = v.pubkey === validator.pubkey;
+      const hasBalance = v.balance > 0;
+      // Should be filtered out from API call for validators by withdrawal address; backup check
+      const isSameCredentials =
+        v.withdrawalcredentials.slice(4) ===
+        validator.withdrawalcredentials.slice(4);
+      return compounding && !isSameValidator && hasBalance && isSameCredentials;
+    });
 
     setTargetValidatorSet(potentialTargetValidators);
   }, [validator, validators]);

--- a/src/pages/Actions/components/ValidatorActions.tsx
+++ b/src/pages/Actions/components/ValidatorActions.tsx
@@ -111,14 +111,16 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
     setSourceValidatorSet(potentialSourceValidators);
 
     const potentialTargetValidators = validators.filter(v => {
-      const compounding = getCredentialType(v) >= ValidatorType.Compounding;
+      const isCompounding = getCredentialType(v) >= ValidatorType.Compounding;
       const isSameValidator = v.pubkey === validator.pubkey;
       const hasBalance = v.balance > 0;
       // Should be filtered out from API call for validators by withdrawal address; backup check
       const isSameCredentials =
         v.withdrawalcredentials.slice(4) ===
         validator.withdrawalcredentials.slice(4);
-      return compounding && !isSameValidator && hasBalance && isSameCredentials;
+      return (
+        isCompounding && !isSameValidator && hasBalance && isSameCredentials
+      );
     });
 
     setTargetValidatorSet(potentialTargetValidators);

--- a/src/pages/Actions/components/ValidatorSelector.tsx
+++ b/src/pages/Actions/components/ValidatorSelector.tsx
@@ -61,13 +61,20 @@ const ValidatorSelector = ({
     }
   };
 
+  const defaultPlaceholder = formatMessage({
+    defaultMessage: 'Filter your validators by index or pubkey',
+  });
+  const searchablePlaceholder = formatMessage({
+    defaultMessage:
+      'Filter your validators by index or pubkey or search by pubkey',
+  });
+
   return (
     <Select
       placeholder={`Available validators: ${validators.length}`}
-      searchPlaceholder={formatMessage({
-        defaultMessage:
-          'Filter your validators by index or pubkey or search by pubkey',
-      })}
+      searchPlaceholder={
+        allowSearch ? searchablePlaceholder : defaultPlaceholder
+      }
       options={validators.map(v => {
         return {
           value: v.pubkey,

--- a/src/pages/Actions/index.tsx
+++ b/src/pages/Actions/index.tsx
@@ -162,7 +162,7 @@ const _ActionsPage = () => {
     if (!account) {
       deactivate();
     }
-  }, [account]);
+  }, [account, deactivate]);
 
   const handleConnect = useCallback((): void => {
     setLoading(true);
@@ -232,7 +232,7 @@ const _ActionsPage = () => {
 
   const onFetchMore = useCallback(() => {
     setFetchOffset(prev => prev + MAX_QUERY_LIMIT);
-  }, [fetchOffset]);
+  }, []);
 
   // an effect that fetches validators from beaconchain when the user connects or changes their wallet
   useEffect(() => {
@@ -422,13 +422,13 @@ const _ActionsPage = () => {
   }, [
     account,
     active,
-    fetchValidators,
     formatMessage,
     handleConnect,
     lastUpdate,
     loading,
     locale,
     moreToFetch,
+    onFetchMore,
     refreshing,
     refreshValidator,
     selectedValidator,

--- a/src/pages/Actions/index.tsx
+++ b/src/pages/Actions/index.tsx
@@ -151,6 +151,17 @@ const _ActionsPage = () => {
 
   const [fetchOffset, setFetchOffset] = useState(0);
 
+  useEffect(() => {
+    if (active) return;
+    deactivate();
+    // Reset state
+    setLoading(false);
+    setValidatorLoadError(false);
+    setValidators([]);
+    setSelectedValidator(null);
+    setFetchOffset(0);
+  }, [active, deactivate]);
+
   const handleConnect = useCallback((): void => {
     setLoading(true);
     deactivate();


### PR DESCRIPTION
Fixing issues I ran into when consolidating my validators and user report. They are separated in the three commits:

- **Remove isNascent check for target validators**: A user noted that they were unable to consolidate to a validator that was recently active. Looking at [the spec](https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#new-process_consolidation_request), it appears only the source validator has an activation requirement. I don't see any reference to the target: 
```python
    # Verify the source has been active long enough
    if current_epoch < source_validator.activation_epoch + SHARD_COMMITTEE_PERIOD:
        return
```
The problem is we would filter to valid source validators and then user the source validators to then filter target.

- **Will properly reset Actions when changing wallet**: When changing an account, the selected validator nor the available validators are properly recent. The underlying function that is called when an account is changed is `fetchMoreValidators` which would use an offset of `100` (from the initial wallet connection) and then add those validators to the existing set. There were a couple of ways to implement but went for the less intrusive version.

- **Don't show 'search by pubkey' placeholder outside of migrate flow**: Very minor but the validator select component would show in the placeholder `or search by pubkey` even if it wasn't available. This is now fixed in a very specific way to account for i18n. 