### PR TITLE
Add missing link in hamburger

### DIFF
--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -385,6 +385,9 @@ const _AppBar = ({ location }: RouteComponentProps) => {
                   <DropdownLink to={routesEnum.withdrawals}>
                     <FormattedMessage defaultMessage="Withdrawals" />
                   </DropdownLink>
+                  <DropdownLink to={routesEnum.topUpPage}>
+                    <FormattedMessage defaultMessage="Top Up" />
+                  </DropdownLink>
                   <DropdownLink to={routesEnum.actionsPage}>
                     <FormattedMessage defaultMessage="Actions" />
                   </DropdownLink>


### PR DESCRIPTION
The top up is not accessible from the hamburger menu when the resolution width is too small. This PR simply add that link in that menu.