### PR TITLE
feat: add activation warning and pectrified explorer links

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -53,6 +53,12 @@
       "value": "migrate funds to"
     }
   ],
+  "+Cp43+": [
+    {
+      "type": 0,
+      "value": "Learn more on Pectrified"
+    }
+  ],
   "+EZ9E/": [
     {
       "type": 0,
@@ -707,6 +713,36 @@
     {
       "type": 0,
       "value": "Consolidation requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes."
+    }
+  ],
+  "1iW5bS": [
+    {
+      "type": 0,
+      "value": "Note: Balance over "
+    },
+    {
+      "type": 1,
+      "value": "MIN_ACTIVATION_BALANCE"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "type": 1,
+      "value": "TICKER_NAME"
+    },
+    {
+      "type": 0,
+      "value": " will temporarily disappear from balance shown above while it processes through an activation queue. See "
+    },
+    {
+      "type": 1,
+      "value": "pectrified"
+    },
+    {
+      "type": 0,
+      "value": " for details."
     }
   ],
   "1ingnQ": [
@@ -1571,6 +1607,12 @@
     {
       "type": 0,
       "value": "Depending which method you use to generate your keys:"
+    }
+  ],
+  "7GeD1+": [
+    {
+      "type": 0,
+      "value": "View validator and queue details on Pectrified"
     }
   ],
   "7Iz3JI": [
@@ -8965,6 +9007,28 @@
     {
       "type": 0,
       "value": "Checklist"
+    }
+  ],
+  "spvBxs": [
+    {
+      "type": 0,
+      "value": "Balance over "
+    },
+    {
+      "type": 1,
+      "value": "MIN_ACTIVATION_BALANCE"
+    },
+    {
+      "type": 0,
+      "value": " "
+    },
+    {
+      "type": 1,
+      "value": "TICKER_NAME"
+    },
+    {
+      "type": 0,
+      "value": " will automatically be staked, requiring activation queue processing and a delay."
     }
   ],
   "sraQ3P": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -15,6 +15,9 @@
   "+88H3v": {
     "message": "migrate funds to"
   },
+  "+Cp43+": {
+    "message": "Learn more on Pectrified"
+  },
   "+EZ9E/": {
     "message": "Interactive mode"
   },
@@ -262,6 +265,9 @@
   },
   "1iI5Ju": {
     "message": "Consolidation requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes."
+  },
+  "1iW5bS": {
+    "message": "Note: Balance over {MIN_ACTIVATION_BALANCE} {TICKER_NAME} will temporarily disappear from balance shown above while it processes through an activation queue. See {pectrified} for details."
   },
   "1ingnQ": {
     "message": "More on Ethereum staking economics"
@@ -561,6 +567,9 @@
   },
   "7GLK15": {
     "message": "Depending which method you use to generate your keys:"
+  },
+  "7GeD1+": {
+    "message": "View validator and queue details on Pectrified"
   },
   "7Iz3JI": {
     "message": "Consensus Client"
@@ -3370,6 +3379,9 @@
   },
   "soCLV+": {
     "message": "Checklist"
+  },
+  "spvBxs": {
+    "message": "Balance over {MIN_ACTIVATION_BALANCE} {TICKER_NAME} will automatically be staked, requiring activation queue processing and a delay."
   },
   "sraQ3P": {
     "message": "Waiting to connect..."

--- a/src/pages/Actions/components/UpgradeCompounding.tsx
+++ b/src/pages/Actions/components/UpgradeCompounding.tsx
@@ -174,6 +174,14 @@ const UpgradeCompounding: React.FC<Props> = ({ validator }) => {
                         />
                       </Text>
                     </li>
+                    <li>
+                      <Text as="span">
+                        <FormattedMessage
+                          defaultMessage="Balance over {MIN_ACTIVATION_BALANCE} {TICKER_NAME} will automatically be staked, requiring activation queue processing and a delay."
+                          values={{ MIN_ACTIVATION_BALANCE, TICKER_NAME }}
+                        />
+                      </Text>
+                    </li>
                   </ul>
                   <Text style={{ fontSize: '0.875rem', lineHeight: '1.25rem' }}>
                     <FormattedMessage defaultMessage="Upgrade and consolidation requests enter a separate queue with a small fee, shown as the transaction's send amount. The fee is minimal when the queue is short, with a small buffer added to prevent rejections from sudden activity spikes." />

--- a/src/pages/Actions/components/ValidatorActions.tsx
+++ b/src/pages/Actions/components/ValidatorActions.tsx
@@ -11,6 +11,7 @@ import PartialWithdraw from './PartialWithdraw';
 import PullConsolidation from './PullConsolidation';
 import PushConsolidation from './PushConsolidation';
 import { Section as SharedSection } from './Shared';
+import { Link } from '../../../components/Link';
 import { Text } from '../../../components/Text';
 import UpgradeCompounding from './UpgradeCompounding';
 
@@ -139,6 +140,21 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
                 TICKER_NAME,
               }}
             />
+            <br />
+            <em>
+              <FormattedMessage
+                defaultMessage="Note: Balance over {MIN_ACTIVATION_BALANCE} {TICKER_NAME} will temporarily disappear from balance shown above while it processes through an activation queue. See {pectrified} for details."
+                values={{
+                  MIN_ACTIVATION_BALANCE,
+                  TICKER_NAME,
+                  pectrified: (
+                    <Link inline primary to="https://pectrified.com/">
+                      pectrified.com
+                    </Link>
+                  ),
+                }}
+              />
+            </em>
           </div>
           <UpgradeCompounding validator={validator} />
         </Row>

--- a/src/pages/Actions/index.tsx
+++ b/src/pages/Actions/index.tsx
@@ -27,7 +27,11 @@ import { web3ReactInterface } from '../ConnectWallet';
 import { AllowedELNetworks, NetworkChainId } from '../ConnectWallet/web3Utils';
 import WalletConnectModal from '../TopUp/components/WalletConnectModal';
 
-import { BEACONCHAIN_URL, MAX_QUERY_LIMIT } from '../../utils/envVars';
+import {
+  BEACONCHAIN_URL,
+  MAX_QUERY_LIMIT,
+  IS_MAINNET,
+} from '../../utils/envVars';
 import { hasValidatorExited } from '../../utils/validators';
 import { fetchValidatorsByPubkeys } from './utils';
 
@@ -354,6 +358,25 @@ const _ActionsPage = () => {
                         </AlertText>
                         <AlertText>
                           <FormattedMessage defaultMessage="Recent changes may not be reflected in validator details, and network congestion may result in delays. Use caution to avoid submitting duplicate requests." />
+                        </AlertText>
+                        <AlertText className="mt20">
+                          {IS_MAINNET ? (
+                            <Link
+                              primary
+                              to={`https://www.pectrified.com/mainnet/validator/${selectedValidator.validatorindex}`}
+                              className="text-bold"
+                            >
+                              <FormattedMessage defaultMessage="View validator and queue details on Pectrified" />
+                            </Link>
+                          ) : (
+                            <Link
+                              primary
+                              to="https://www.pectrified.com/"
+                              className="text-bold"
+                            >
+                              <FormattedMessage defaultMessage="Learn more on Pectrified" />
+                            </Link>
+                          )}
                         </AlertText>
                       </div>
                       <div


### PR DESCRIPTION
## Description
- Adds mainnet link to pectrified.com validator/queue status
- For non-mainnet, links to general pectrified.com as a learning resource to learn about the queues
- Adds notes to "Upgrade" flow warning user that balance over 32 will go through the activation queue and disappear from their shown balance while being processed (with link to pectrified)