### PR TITLE
fix: ethstaker github repo

### DIFF
--- a/src/pages/BtecGuide/index.tsx
+++ b/src/pages/BtecGuide/index.tsx
@@ -184,7 +184,7 @@ export const BtecGuide = () => {
                     <Link
                       primary
                       inline
-                      to="https://github.com/eth-educators/ethstaker-deposit-cli/releases"
+                      to="https://github.com/ethstaker/ethstaker-deposit-cli/releases"
                     >
                       <FormattedMessage defaultMessage="EthStaker Deposit CLI releases" />
                     </Link>
@@ -207,7 +207,7 @@ export const BtecGuide = () => {
             </Text>
             <CodeBlock>
               git clone
-              https://github.com/eth-educators/ethstaker-deposit-cli.git
+              https://github.com/ethstaker/ethstaker-deposit-cli.git
             </CodeBlock>
             <Text className="mb10">
               <FormattedMessage defaultMessage="Install and set virtualenv:" />

--- a/src/pages/GenerateKeys/Option1.tsx
+++ b/src/pages/GenerateKeys/Option1.tsx
@@ -62,7 +62,7 @@ export const Option1 = ({
       </Text>
       <Link
         isTextLink={false}
-        to="https://github.com/eth-educators/ethstaker-deposit-cli/releases/"
+        to="https://github.com/ethstaker/ethstaker-deposit-cli/releases/"
         className="my40"
       >
         <Button
@@ -86,7 +86,7 @@ export const Option1 = ({
               values={{
                 url: (
                   <strong>
-                    https://github.com/eth-educators/ethstaker-deposit-cli/releases/
+                    https://github.com/ethstaker/ethstaker-deposit-cli/releases/
                   </strong>
                 ),
               }}

--- a/src/pages/GenerateKeys/Option3.tsx
+++ b/src/pages/GenerateKeys/Option3.tsx
@@ -327,7 +327,7 @@ export const Option3 = ({
           inline
           primary
           isTextLink={false}
-          to="https://github.com/eth-educators/ethstaker-deposit-cli/archive/master.zip"
+          to="https://github.com/ethstaker/ethstaker-deposit-cli/archive/master.zip"
         >
           <Button
             className="my20"
@@ -345,7 +345,7 @@ export const Option3 = ({
               gitClone: (
                 <Code>
                   git clone -b master --single-branch
-                  https://github.com/eth-educators/ethstaker-deposit-cli.git
+                  https://github.com/ethstaker/ethstaker-deposit-cli.git
                 </Code>
               ),
               master: <Code>master</Code>,
@@ -418,9 +418,9 @@ export const Option3 = ({
         <Link
           primary
           inline
-          to="https://github.com/eth-educators/ethstaker-deposit-cli"
+          to="https://github.com/ethstaker/ethstaker-deposit-cli"
         >
-          https://github.com/eth-educators/ethstaker-deposit-cli
+          https://github.com/ethstaker/ethstaker-deposit-cli
         </Link>
       </Text>
     </div>


### PR DESCRIPTION
Use the new ethstaker github repo org in the various links on the project. This will fix all the related dead links.