### PR TITLE
bugfix: Properly showing fetch more validators button in actions page

### DIFF
--- a/src/pages/Actions/index.tsx
+++ b/src/pages/Actions/index.tsx
@@ -258,7 +258,13 @@ const _ActionsPage = () => {
     return () => clearInterval(interval);
   }, [refreshValidator]);
 
-  const moreToFetch = validators.length === fetchOffset;
+  // fetchOffset lags behind and is used as a trigger to fetch more validators when increased by user action
+  const moreToFetch = useMemo(() => {
+    return (
+      validators.length > 0 &&
+      validators.length === fetchOffset + MAX_QUERY_LIMIT
+    );
+  }, [validators, fetchOffset]);
 
   const actionsPageContent = useMemo(() => {
     if (loading) {


### PR DESCRIPTION
As reported #785 there was a regression in the recent release that stopped the fetch more validators button from showing properly.

I updated the logic to use the `fetchOffset` as a trigger to fetch more validators. Instead of having this value update after a successful request is made, the user would click the button updating the offset. The problem is the logic to determine if the show more button was displayed was not updated to account for this lagging value.