### PR TITLE
fix: beaconcha.in API rate limiting

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,8 @@
 # https://docs.netlify.com/configure-builds/file-based-configuration/
 
+[functions]
+  directory = "netlify/functions"
+
 [context.production.environment]
   NODE_VERSION = "14.19.2"
 [context.deploy-preview.environment]

--- a/netlify/functions/beaconchain-api.js
+++ b/netlify/functions/beaconchain-api.js
@@ -1,8 +1,8 @@
 const axios = require('axios');
 
 exports.handler = async function(event) {
-  // Get the API path from query parameters
-  const { path, ...otherParams } = event.queryStringParameters || {};
+  // Get the API path and base URL from query parameters
+  const { path, url, ...otherParams } = event.queryStringParameters || {};
 
   if (!path) {
     return {
@@ -11,8 +11,13 @@ exports.handler = async function(event) {
     };
   }
 
-  const BEACONCHAIN_URL =
-    process.env.REACT_APP_BEACONCHAIN_URL || 'https://mainnet.beaconcha.in';
+  if (!url) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Missing url parameter' }),
+    };
+  }
+
   const BEACONCHAIN_API_KEY = process.env.BEACONCHAIN_API_KEY || '';
 
   // Build the full URL with API key
@@ -21,10 +26,10 @@ exports.handler = async function(event) {
     ...(BEACONCHAIN_API_KEY && { apikey: BEACONCHAIN_API_KEY }),
   });
 
-  const url = `${BEACONCHAIN_URL}/api/v1/${path}?${params.toString()}`;
+  const fullUrl = `${url}/api/v1/${path}?${params.toString()}`;
 
   try {
-    const response = await axios.get(url);
+    const response = await axios.get(fullUrl);
 
     return {
       statusCode: response.status,

--- a/netlify/functions/beaconchain-api.js
+++ b/netlify/functions/beaconchain-api.js
@@ -1,0 +1,51 @@
+const axios = require('axios');
+
+exports.handler = async function(event) {
+  // Get the API path from query parameters
+  const { path, ...otherParams } = event.queryStringParameters || {};
+
+  if (!path) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: 'Missing path parameter' }),
+    };
+  }
+
+  const BEACONCHAIN_URL =
+    process.env.REACT_APP_BEACONCHAIN_URL || 'https://mainnet.beaconcha.in';
+  const BEACONCHAIN_API_KEY = process.env.BEACONCHAIN_API_KEY || '';
+
+  // Build the full URL with API key
+  const params = new URLSearchParams({
+    ...otherParams,
+    ...(BEACONCHAIN_API_KEY && { apikey: BEACONCHAIN_API_KEY }),
+  });
+
+  const url = `${BEACONCHAIN_URL}/api/v1/${path}?${params.toString()}`;
+
+  try {
+    const response = await axios.get(url);
+
+    return {
+      statusCode: response.status,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(response.data),
+    };
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Beaconchain API error:', error.message);
+
+    return {
+      statusCode: error.response?.status || 500,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        error: 'Failed to fetch from Beaconchain API',
+        message: error.message,
+      }),
+    };
+  }
+};

--- a/src/components/WithdrawalCredentials.tsx
+++ b/src/components/WithdrawalCredentials.tsx
@@ -8,7 +8,8 @@ import { Alert } from './Alert';
 import { Button } from './Button';
 import { Spinner } from './Spinner';
 // Constants
-import { BEACONCHAIN_URL, IS_MAINNET, NETWORK_NAME } from '../utils/envVars';
+import { IS_MAINNET, NETWORK_NAME } from '../utils/envVars';
+import { getBeaconchainV1ApiUrl } from '../utils/getBeaconchainV1ApiUrl';
 import { screenSizes } from '../styles/styledComponentsTheme';
 
 const Container = styled.div`
@@ -284,7 +285,8 @@ export const WithdrawalCredentials: FC<IProps> = () => {
   const checkWithdrawalCredentials = async () => {
     setHasError(false);
     setIsLoading(true);
-    const endpoint = `${BEACONCHAIN_URL}/api/v1/validator/${inputValue}`;
+    const endpoint = getBeaconchainV1ApiUrl(`validator/${inputValue}`);
+
     try {
       const response = await fetch(endpoint);
       const { data } = await response.json();

--- a/src/pages/Actions/index.tsx
+++ b/src/pages/Actions/index.tsx
@@ -217,6 +217,9 @@ const _ActionsPage = () => {
       return;
     }
 
+    // Delay 1 second to account for beaconcha.in per second rate limit
+    await new Promise(r => setTimeout(r, 1000));
+
     const newValidators = await fetchValidatorsByPubkeys(pubkeys);
 
     if (!newValidators) {

--- a/src/pages/Actions/index.tsx
+++ b/src/pages/Actions/index.tsx
@@ -32,6 +32,7 @@ import {
   MAX_QUERY_LIMIT,
   IS_MAINNET,
 } from '../../utils/envVars';
+import { getBeaconchainV1ApiUrl } from '../../utils/getBeaconchainV1ApiUrl';
 import { hasValidatorExited } from '../../utils/validators';
 import { fetchValidatorsByPubkeys } from './utils';
 
@@ -115,9 +116,11 @@ const fetchPubkeysByWithdrawalAddress = async (
   limit = MAX_QUERY_LIMIT
 ): Promise<string[] | null> => {
   try {
-    const response = await fetch(
-      `${BEACONCHAIN_URL}/api/v1/validator/withdrawalCredentials/${address}?limit=${limit}&offset=${offset}`
+    const url = getBeaconchainV1ApiUrl(
+      `validator/withdrawalCredentials/${address}`,
+      { limit: limit.toString(), offset: offset.toString() }
     );
+    const response = await fetch(url);
     if (!response.ok) throw new Error();
     const json = await response.json();
     const data: BeaconChainValidatorResponse[] = Array.isArray(json.data)

--- a/src/pages/Actions/utils.ts
+++ b/src/pages/Actions/utils.ts
@@ -3,7 +3,6 @@ import Web3 from 'web3';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { TransactionConfig } from 'web3-core';
 import {
-  BEACONCHAIN_URL,
   COMPOUNDING_CONTRACT_ADDRESS,
   COMPOUNDING_FEE_ADDITION,
   EXCESS_INHIBITOR,
@@ -12,6 +11,7 @@ import {
   WITHDRAWAL_CONTRACT_ADDRESS,
   WITHDRAWAL_FEE_ADDITION,
 } from '../../utils/envVars';
+import { getBeaconchainV1ApiUrl } from '../../utils/getBeaconchainV1ApiUrl';
 import { BeaconChainValidator } from '../TopUp/types';
 import { currentEpoch } from '../../utils/beaconchain';
 
@@ -175,9 +175,8 @@ export const fetchValidatorsByPubkeys = async (
   pubkeys: string[]
 ): Promise<BeaconChainValidator[] | null> => {
   try {
-    const response = await fetch(
-      `${BEACONCHAIN_URL}/api/v1/validator/${pubkeys.join(',')}`
-    );
+    const url = getBeaconchainV1ApiUrl(`validator/${pubkeys.join(',')}`);
+    const response = await fetch(url);
     if (!response.ok) throw new Error();
     const json = await response.json();
     const data: BeaconChainValidator[] = Array.isArray(json.data)

--- a/src/pages/Checklist/index.tsx
+++ b/src/pages/Checklist/index.tsx
@@ -407,7 +407,8 @@ export const Checklist = () => {
       discord: 'https://discord.gg/z9efH7e',
       defaultTcp: 13000,
       defaultUdp: 12000,
-      jwtUrl: 'https://prysm.offchainlabs.com/docs/configure-prysm/authentication/',
+      jwtUrl:
+        'https://prysm.offchainlabs.com/docs/configure-prysm/authentication/',
       feeRecipientUrl:
         'https://prysm.offchainlabs.com/docs/configure-prysm/fee-recipient/',
       metricsUrl:

--- a/src/pages/TopUp/index.tsx
+++ b/src/pages/TopUp/index.tsx
@@ -18,12 +18,12 @@ import TopupPage from './components/TopupPage';
 import Spinner from '../../components/Spinner';
 import { PageTemplate } from '../../components/PageTemplate';
 import {
-  BEACONCHAIN_URL,
   MAX_EFFECTIVE_BALANCE,
   MIN_ACTIVATION_BALANCE,
   EJECTION_PRICE,
   TICKER_NAME,
 } from '../../utils/envVars';
+import { getBeaconchainV1ApiUrl } from '../../utils/getBeaconchainV1ApiUrl';
 import { AllowedELNetworks, NetworkChainId } from '../ConnectWallet/web3Utils';
 import { Alert } from '../../components/Alert';
 import { Link } from '../../components/Link';
@@ -100,7 +100,8 @@ const _TopUpPage: React.FC<Props> = () => {
       // beaconchain API requires two fetches - one that gets the public keys for an Ethereum address, and one that
       // queries by the validators public keys
 
-      fetch(`${BEACONCHAIN_URL}/api/v1/validator/eth1/${account}`)
+      const url = getBeaconchainV1ApiUrl(`validator/eth1/${account}`);
+      fetch(url)
         .then(r => r.json())
         .then(
           ({
@@ -127,9 +128,10 @@ const _TopUpPage: React.FC<Props> = () => {
                 .map(validator => validator.publickey)
                 .join(',')}`;
 
-              fetch(
-                `${BEACONCHAIN_URL}/api/v1/validator/${pubKeysCommaDelineated}`
-              )
+              const validatorUrl = getBeaconchainV1ApiUrl(
+                `validator/${pubKeysCommaDelineated}`
+              );
+              fetch(validatorUrl)
                 .then(r => r.json())
                 .then(
                   ({

--- a/src/pages/UploadValidator/validateDepositKey.ts
+++ b/src/pages/UploadValidator/validateDepositKey.ts
@@ -12,11 +12,11 @@ import {
 } from '../../store/reducers';
 import {
   ETHER_TO_GWEI,
-  BEACONCHAIN_URL,
   MIN_DEPOSIT_GWEI,
   MAX_EFFECTIVE_BALANCE,
   MIN_ACTIVATION_BALANCE,
 } from '../../utils/envVars';
+import { getBeaconchainV1ApiUrl } from '../../utils/getBeaconchainV1ApiUrl';
 
 const validateFieldFormatting = (
   depositDatum: DepositKeyInterface
@@ -99,9 +99,9 @@ export const getExistingDepositsForPubkeys = async (
   files: DepositKeyInterface[]
 ): Promise<BeaconchainDepositInterface> => {
   const pubkeys = files.flatMap(x => x.pubkey);
-  const beaconScanUrl = `${BEACONCHAIN_URL}/api/v1/validator/${pubkeys.join(
-    ','
-  )}/deposits`;
+  const beaconScanUrl = getBeaconchainV1ApiUrl(
+    `validator/${pubkeys.join(',')}/deposits`
+  );
   const { data: beaconScanCheck } = await axios.get<
     BeaconchainDepositInterface
   >(beaconScanUrl);

--- a/src/utils/envVars.ts
+++ b/src/utils/envVars.ts
@@ -12,6 +12,7 @@ export const NETWORK_NAME               = IS_MAINNET ? 'Mainnet' : TESTNET_LAUNC
 export const TICKER_NAME                = IS_MAINNET ? 'ETH' : `${NETWORK_NAME}ETH`;
 export const ETHERSCAN_URL              = IS_MAINNET ? 'https://etherscan.io/tx' : `https://${TESTNET_LAUNCHPAD_NAME.toLowerCase()}.etherscan.io/tx`;
 export const BEACONCHAIN_URL            = (IS_NON_INFURA_TESTNET && process.env.REACT_APP_BEACONCHAIN_URL) ||  `https://${NETWORK_NAME.toLowerCase()}.beaconcha.in`;
+export const IS_DEV                     = process.env.NODE_ENV !== 'production';
 export const FORTMATIC_KEY              = process.env.REACT_APP_FORTMATIC_KEY       || 'pk_test_D113D979E0D3508F';
 export const DEPOSIT_CONTRACT_ADDRESS   = IS_MAINNET ? '0x00000000219ab540356cBB839Cbe05303d7705Fa' : process.env.REACT_APP_CONTRACT_ADDRESS;
 export const COMPOUNDING_CONTRACT_ADDRESS = process.env.REACT_APP_COMPOUNDING_CONTRACT_ADDRESS || '0x0000BBdDc7CE488642fb579F8B00f3a590007251'

--- a/src/utils/fetchTotalStakeAndAPR.ts
+++ b/src/utils/fetchTotalStakeAndAPR.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
-import { BEACONCHAIN_URL, ETH_DEPOSIT_OFFSET } from './envVars';
+import { ETH_DEPOSIT_OFFSET } from './envVars';
+import { getBeaconchainV1ApiUrl } from './getBeaconchainV1ApiUrl';
 
 interface EthstoreData {
   data: {
@@ -17,9 +18,9 @@ export interface FetchTotalStakeAndAPRResponse {
   };
 }
 export const fetchTotalStakeAndAPR = async (): Promise<FetchTotalStakeAndAPRResponse> => {
-  const { href } = new URL('/api/v1/ethstore/latest', BEACONCHAIN_URL);
+  const endpoint = getBeaconchainV1ApiUrl('ethstore/latest');
   try {
-    const response = await axios.get<EthstoreData>(href);
+    const response = await axios.get<EthstoreData>(endpoint);
     if (response.status !== 200) throw new Error(response.statusText);
     const { data } = response;
     const { apr, effective_balances_sum_wei: totalWei } = data.data;

--- a/src/utils/fetchTotalValidators.ts
+++ b/src/utils/fetchTotalValidators.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { BEACONCHAIN_URL } from './envVars';
+import { getBeaconchainV1ApiUrl } from './getBeaconchainV1ApiUrl';
 
 interface EpochData {
   data: {
@@ -15,9 +15,9 @@ export interface FetchTotalValidatorsResponse {
 }
 
 export const fetchTotalValidators = async (): Promise<FetchTotalValidatorsResponse> => {
-  const { href } = new URL('/api/v1/epoch/latest', BEACONCHAIN_URL);
+  const endpoint = getBeaconchainV1ApiUrl('epoch/latest');
   try {
-    const response = await axios.get<EpochData>(href);
+    const response = await axios.get<EpochData>(endpoint);
     if (response.status !== 200) throw new Error(response.statusText);
     const { data } = response;
     const { validatorscount: totalValidators } = data.data;

--- a/src/utils/getBeaconchainV1ApiUrl.ts
+++ b/src/utils/getBeaconchainV1ApiUrl.ts
@@ -1,0 +1,29 @@
+import { BEACONCHAIN_URL, IS_DEV } from './envVars';
+
+/**
+ * Helper function to build Beaconcha.in API URL
+ * In development: calls API directly without key
+ * In production: routes through Netlify function with server-side key
+ *
+ * @param path - The API path (e.g., 'validator/123', 'ethstore/latest')
+ * @param queryParams - Optional query parameters to append
+ * @returns The full URL to call
+ */
+export const getBeaconchainV1ApiUrl = (
+  path: string,
+  queryParams?: Record<string, string | number>
+): string => {
+  if (IS_DEV) {
+    const params = new URLSearchParams(queryParams as Record<string, string>);
+    const queryString = params.toString();
+    return `${BEACONCHAIN_URL}/api/v1/${path}${
+      queryString ? `?${queryString}` : ''
+    }`;
+  }
+
+  const params = new URLSearchParams({
+    path,
+    ...(queryParams as Record<string, string>),
+  });
+  return `/.netlify/functions/beaconchain-api?${params.toString()}`;
+};

--- a/src/utils/getBeaconchainV1ApiUrl.ts
+++ b/src/utils/getBeaconchainV1ApiUrl.ts
@@ -23,6 +23,7 @@ export const getBeaconchainV1ApiUrl = (
 
   const params = new URLSearchParams({
     path,
+    url: BEACONCHAIN_URL,
     ...(queryParams as Record<string, string>),
   });
   return `/.netlify/functions/beaconchain-api?${params.toString()}`;


### PR DESCRIPTION
## Description
- Add proxy API call to beaconchain API, using key via Netlify serverless function
- Falls back to direct key-less API query for development mode
- 1 second "waiting" timeout in between calls that immediately proceed each other to obey rate limits

## Preview link
https://deploy-preview-794--phenomenal-frangipane-7c4bd1.netlify.app/

## Related issue
- Fixes #791