### PR TITLE
Add missing title and meta tags to index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,10 +21,12 @@
       };
     </script>
     <meta charset="utf-8" />
+    <title>Staking Launchpad</title>
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1, minimum-scale=1"
     />
+    <meta name="description" content="Become a validator and help secure the future of Ethereum." />
     <link
       rel="apple-touch-icon"
       sizes="180x180"
@@ -45,6 +47,8 @@
 
     <meta property="og:url" content="https://launchpad.ethereum.org/" />
     <meta property="og:type" content="website" />
+    <meta property="og:title" content="Staking Launchpad" />
+    <meta property="og:description" content="Become a validator and help secure the future of Ethereum." />
     <meta
       property="og:image"
       content="https://launchpad.ethereum.org/static/media/eth2-leslie-rhino.243747b9.png"
@@ -55,6 +59,8 @@
       name="twitter:card"
       content="summary_large_image"
     />
+    <meta name="twitter:title" content="Staking Launchpad" />
+    <meta name="twitter:description" content="Become a validator and help secure the future of Ethereum." />
     <meta name="twitter:creator" content="@ethereum" />
     <meta name="twitter:site" content="@ethereum" />
     <meta


### PR DESCRIPTION
## Summary
- Add default `<title>` tag for SEO crawlers
- Add `<meta name="description">` tag
- Add `og:title` and `og:description` meta tags
- Add `twitter:title` and `twitter:description` meta tags

This fixes the "Title tag missing or empty" issue flagged by AHREFS on:
- launchpad.ethereum.org/
- launchpad.ethereum.org/en/
- hoodi.launchpad.ethereum.org/
- holesky.launchpad.ethereum.org/

The issue is that crawlers don't execute JavaScript, so they see the raw HTML which had no title. React Helmet sets titles client-side, but this default ensures crawlers see something.

## Test plan
- [ ] Verify title appears in page source before JS loads
- [ ] Verify React Helmet still overrides with localized content

🤖 Generated with [Claude Code](https://claude.com/claude-code)