### PR TITLE
refactor: use bearer auth for beaconcha.in fetch

### DIFF
--- a/netlify/functions/beaconchain-api.js
+++ b/netlify/functions/beaconchain-api.js
@@ -18,18 +18,17 @@ exports.handler = async function(event) {
     };
   }
 
-  const BEACONCHAIN_API_KEY = process.env.BEACONCHAIN_API_KEY || '';
+  const apiKey = process.env.BEACONCHAIN_API_KEY || '';
 
-  // Build the full URL with API key
-  const params = new URLSearchParams({
-    ...otherParams,
-    ...(BEACONCHAIN_API_KEY && { apikey: BEACONCHAIN_API_KEY }),
+  const requestUrl = new URL(`/api/v1/${path}`, url);
+  Object.entries(otherParams).forEach(([key, value]) => {
+    requestUrl.searchParams.set(key, value);
   });
 
-  const fullUrl = `${url}/api/v1/${path}?${params.toString()}`;
-
   try {
-    const response = await axios.get(fullUrl);
+    const response = await axios.get(requestUrl.toString(), {
+      ...(apiKey && { headers: { Authorization: `Bearer ${apiKey}` } }),
+    });
 
     return {
       statusCode: response.status,


### PR DESCRIPTION
## Summary
- Switch beaconcha.in API authentication from `apikey` query parameter to `Authorization: Bearer` header
- Clean up URL construction using `new URL()` instead of string interpolation

## Context
API calls through the Netlify proxy function were failing in production despite correct env var configuration. The beaconcha.in docs support both query param and Bearer token auth -- switching to the header approach to resolve the issue.

## Test plan
- [ ] Verify landing page loads network stats (total staked, validator count, APR)
- [ ] Verify TopUp page fetches validators by connected wallet
- [ ] Verify Actions page fetches validators by withdrawal credentials
- [ ] Check Netlify function logs for any auth errors