### PR TITLE
fix: disable Pull funds for inactive target validator

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -7437,6 +7437,12 @@
       "value": "View Wagyu Key Gen audit by HashCloak"
     }
   ],
+  "k4Vqjz": [
+    {
+      "type": 0,
+      "value": "Selected account must be active before it can absorb another validator."
+    }
+  ],
   "k4x6Ud": [
     {
       "type": 0,

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -2817,6 +2817,9 @@
   "k43c+l": {
     "message": "View Wagyu Key Gen audit by HashCloak"
   },
+  "k4Vqjz": {
+    "message": "Selected account must be active before it can absorb another validator."
+  },
   "k4x6Ud": {
     "message": "This marked the merging of the execution layer (existing Mainnet) with the new consensus layer (the Beacon Chain) to form the single Ethereum chain of today."
   },

--- a/src/pages/Actions/components/PullConsolidation.tsx
+++ b/src/pages/Actions/components/PullConsolidation.tsx
@@ -27,7 +27,11 @@ import ValidatorSelector from './ValidatorSelector';
 
 import { generateCompoundParams } from '../utils';
 import { TICKER_NAME } from '../../../utils/envVars';
-import { getEtherBalance, getCredentialType } from '../../../utils/validators';
+import {
+  getEtherBalance,
+  getCredentialType,
+  isValidatorActive,
+} from '../../../utils/validators';
 import { getSignTxStatus } from '../../../utils/txStatus';
 import { useTxModal } from '../../../hooks/useTxModal';
 import { useCompoundingQueue } from '../../../hooks/useCompoundingQueue';
@@ -129,7 +133,8 @@ const PullConsolidation = ({
         label={<FormattedMessage defaultMessage="Pull funds" />}
         disabled={
           getCredentialType(targetValidator) < ValidatorType.Compounding ||
-          sourceValidatorSet.length < 1
+          sourceValidatorSet.length < 1 ||
+          !isValidatorActive(targetValidator)
         }
         destructive
         secondary

--- a/src/pages/Actions/components/PushConsolidation.tsx
+++ b/src/pages/Actions/components/PushConsolidation.tsx
@@ -28,7 +28,11 @@ import ValidatorSelector from './ValidatorSelector';
 
 import { generateCompoundParams } from '../utils';
 import { COMPOUNDING_CREDENTIALS, TICKER_NAME } from '../../../utils/envVars';
-import { getCredentialType, getEtherBalance } from '../../../utils/validators';
+import {
+  getCredentialType,
+  getEtherBalance,
+  isValidatorActive,
+} from '../../../utils/validators';
 import { getSignTxStatus } from '../../../utils/txStatus';
 
 import { useCompoundingQueue } from '../../../hooks/useCompoundingQueue';
@@ -155,15 +159,10 @@ const PushConsolidation = ({
     }
   }, [targetValidator]);
 
-  const validValidatorStatus = useMemo(() => {
-    // Handle both dora and beaconcha.in status'
-    return (
-      targetValidator &&
-      ['active_online', 'active_offline', 'active_ongoing'].includes(
-        targetValidator.status
-      )
-    );
-  }, [targetValidator]);
+  const validValidatorStatus = useMemo(
+    () => !!targetValidator && isValidatorActive(targetValidator),
+    [targetValidator]
+  );
 
   const CONFIRMATION_MESSAGE = formatMessage(
     {

--- a/src/pages/Actions/components/ValidatorActions.tsx
+++ b/src/pages/Actions/components/ValidatorActions.tsx
@@ -19,6 +19,7 @@ import {
   getCredentialType,
   getEtherBalance,
   hasValidatorExited,
+  isValidatorActive,
 } from '../../../utils/validators';
 
 import {
@@ -257,6 +258,12 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
             <em>
               {' '}
               <FormattedMessage defaultMessage="Selected account must be upgraded to compounding type to absorb another validator." />
+            </em>
+          )}
+          {!isValidatorActive(validator) && (
+            <em>
+              {' '}
+              <FormattedMessage defaultMessage="Selected account must be active before it can absorb another validator." />
             </em>
           )}
           {sourceValidatorSet.length < 1 && (

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -15,6 +15,12 @@ export const hasExitEpochBeenSet = (exitEpoch: BigNumber | number) =>
 export const hasValidatorExited = (validator: BeaconChainValidator) =>
   hasExitEpochBeenSet(validator.exitepoch);
 
+// Handles both dora and beaconcha.in status strings
+export const isValidatorActive = (validator: BeaconChainValidator): boolean =>
+  ['active_online', 'active_offline', 'active_ongoing'].includes(
+    validator.status
+  );
+
 export const getCredentialType = (
   validator: BeaconChainValidator
 ): ValidatorType =>


### PR DESCRIPTION
## Summary

The "Absorb another validator -> Pull funds" action allowed users to initiate a consolidation request targeting a registered-but-not-yet-active validator (e.g. a 1 ETH validator still awaiting funds). Per the [Electra consensus spec](https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain.md#new-process_consolidation_request), consolidations require both source and target validators to be active, so the EL silently ignores these requests, leaving them appearing stuck indefinitely.

## Changes

- Added an `isValidatorActive` helper in `src/utils/validators.ts` to centralize the active-status check.
- `PullConsolidation`: extended the Pull funds button's `disabled` predicate to also check `isValidatorActive(targetValidator)`.
- `ValidatorActions`: added an explanatory note under "Absorb another validator" when the validator isn't active, matching the existing pattern for other disabled states.
- `PushConsolidation`: refactored the existing inline status check to use the shared helper. No behavior change.

## Test plan

- [ ] On a validator with status `active_online` / `active_offline`, the Pull funds button remains enabled.
- [ ] On a validator with status `pending` / `pending_initialized` / `deposited`, the Pull funds button is disabled and the explainer appears.
- [ ] On a validator with status `exited` / `slashed`, the Pull funds button is disabled.
- [ ] Migrate funds (PushConsolidation) behavior is unchanged.
