### PR TITLE
fix: disable consolidation/upgrade actions on inactive validators

### DIFF
--- a/src/intl/compiled/en.json
+++ b/src/intl/compiled/en.json
@@ -2755,6 +2755,12 @@
       "value": "Stakers must provide a fee recipient address to their consensus client in order to receive transaction fee rewards. This is a normal Ethereum address that you're used to."
     }
   ],
+  "Ebtzqs": [
+    {
+      "type": 0,
+      "value": "Selected account must be active before its funds can be migrated. Inactive sources cause consolidation requests to be ignored on-chain."
+    }
+  ],
   "EcCME0": [
     {
       "type": 0,
@@ -3091,6 +3097,12 @@
       "value": "Languages"
     }
   ],
+  "GsS25q": [
+    {
+      "type": 0,
+      "value": "Selected account must be active before it can be upgraded. Inactive validators cause upgrade requests to be ignored on-chain."
+    }
+  ],
   "GuIwY6": [
     {
       "type": 0,
@@ -3373,6 +3385,12 @@
     {
       "type": 0,
       "value": "Beacon chain push withdrawals as operations"
+    }
+  ],
+  "IrL25o": [
+    {
+      "type": 0,
+      "value": "Selected account must be active before it can absorb funds from another validator. Inactive targets cause consolidation requests to be ignored on-chain."
     }
   ],
   "Is1tie": [

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -1034,6 +1034,9 @@
   "EXt8Xd": {
     "message": "Stakers must provide a fee recipient address to their consensus client in order to receive transaction fee rewards. This is a normal Ethereum address that you're used to."
   },
+  "Ebtzqs": {
+    "message": "Selected account must be active before its funds can be migrated. Inactive sources cause consolidation requests to be ignored on-chain."
+  },
   "EcCME0": {
     "message": "Staking Launchpad"
   },
@@ -1161,6 +1164,9 @@
   "GsBRWL": {
     "message": "Languages"
   },
+  "GsS25q": {
+    "message": "Selected account must be active before it can be upgraded. Inactive validators cause upgrade requests to be ignored on-chain."
+  },
   "GuIwY6": {
     "message": "When should I top up my validator’s balance?"
   },
@@ -1270,6 +1276,9 @@
   },
   "InUvmv": {
     "message": "Beacon chain push withdrawals as operations"
+  },
+  "IrL25o": {
+    "message": "Selected account must be active before it can absorb funds from another validator. Inactive targets cause consolidation requests to be ignored on-chain."
   },
   "Is1tie": {
     "message": "For Type 1 validators (0x01) any balance > {PRICE_PER_VALIDATOR} {TICKER_NAME} is queued for sweep to the withdrawal address."

--- a/src/pages/Actions/components/PullConsolidation.tsx
+++ b/src/pages/Actions/components/PullConsolidation.tsx
@@ -27,7 +27,11 @@ import ValidatorSelector from './ValidatorSelector';
 
 import { generateCompoundParams } from '../utils';
 import { TICKER_NAME } from '../../../utils/envVars';
-import { getEtherBalance, getCredentialType } from '../../../utils/validators';
+import {
+  getEtherBalance,
+  getCredentialType,
+  isValidatorActive,
+} from '../../../utils/validators';
 import { getSignTxStatus } from '../../../utils/txStatus';
 import { useTxModal } from '../../../hooks/useTxModal';
 import { useCompoundingQueue } from '../../../hooks/useCompoundingQueue';
@@ -129,7 +133,8 @@ const PullConsolidation = ({
         label={<FormattedMessage defaultMessage="Pull funds" />}
         disabled={
           getCredentialType(targetValidator) < ValidatorType.Compounding ||
-          sourceValidatorSet.length < 1
+          sourceValidatorSet.length < 1 ||
+          !isValidatorActive(targetValidator)
         }
         destructive
         secondary

--- a/src/pages/Actions/components/PushConsolidation.tsx
+++ b/src/pages/Actions/components/PushConsolidation.tsx
@@ -28,7 +28,11 @@ import ValidatorSelector from './ValidatorSelector';
 
 import { generateCompoundParams } from '../utils';
 import { COMPOUNDING_CREDENTIALS, TICKER_NAME } from '../../../utils/envVars';
-import { getCredentialType, getEtherBalance } from '../../../utils/validators';
+import {
+  getCredentialType,
+  getEtherBalance,
+  isValidatorActive,
+} from '../../../utils/validators';
 import { getSignTxStatus } from '../../../utils/txStatus';
 
 import { useCompoundingQueue } from '../../../hooks/useCompoundingQueue';
@@ -156,13 +160,7 @@ const PushConsolidation = ({
   }, [targetValidator]);
 
   const validValidatorStatus = useMemo(() => {
-    // Handle both dora and beaconcha.in status'
-    return (
-      targetValidator &&
-      ['active_online', 'active_offline', 'active_ongoing'].includes(
-        targetValidator.status
-      )
-    );
+    return targetValidator && isValidatorActive(targetValidator);
   }, [targetValidator]);
 
   const CONFIRMATION_MESSAGE = formatMessage(
@@ -192,6 +190,7 @@ const PushConsolidation = ({
       <Button
         label={<FormattedMessage defaultMessage="Migrate funds" />}
         destructive
+        disabled={!isValidatorActive(sourceValidator)}
         onClick={handleOpen}
       />
 

--- a/src/pages/Actions/components/UpgradeCompounding.tsx
+++ b/src/pages/Actions/components/UpgradeCompounding.tsx
@@ -25,6 +25,7 @@ import { TransactionStatusInsert } from '../../../components/TransactionStatusMo
 
 import { generateCompoundParams } from '../utils';
 import { getSignTxStatus } from '../../../utils/txStatus';
+import { isValidatorActive } from '../../../utils/validators';
 
 import { useCompoundingQueue } from '../../../hooks/useCompoundingQueue';
 import { useTxModal } from '../../../hooks/useTxModal';
@@ -113,6 +114,7 @@ const UpgradeCompounding: React.FC<Props> = ({ validator }) => {
     <>
       <Button
         onClick={handleOpen}
+        disabled={!isValidatorActive(validator)}
         label={<FormattedMessage defaultMessage="Upgrade account" />}
       />
 

--- a/src/pages/Actions/components/ValidatorActions.tsx
+++ b/src/pages/Actions/components/ValidatorActions.tsx
@@ -19,6 +19,7 @@ import {
   getCredentialType,
   getEtherBalance,
   hasValidatorExited,
+  isValidatorActive,
 } from '../../../utils/validators';
 
 import {
@@ -115,12 +116,17 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
       const isCompounding = getCredentialType(v) >= ValidatorType.Compounding;
       const isSameValidator = v.pubkey === validator.pubkey;
       const hasBalance = v.balance > 0;
+      const isActive = isValidatorActive(v);
       // Should be filtered out from API call for validators by withdrawal address; backup check
       const isSameCredentials =
         v.withdrawalcredentials.slice(4) ===
         validator.withdrawalcredentials.slice(4);
       return (
-        isCompounding && !isSameValidator && hasBalance && isSameCredentials
+        isCompounding &&
+        !isSameValidator &&
+        hasBalance &&
+        isSameCredentials &&
+        isActive
       );
     });
 
@@ -164,6 +170,14 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
                 }}
               />
             </em>
+            {!isValidatorActive(validator) && (
+              <>
+                <br />
+                <em>
+                  <FormattedMessage defaultMessage="Selected account must be active before it can be upgraded. Inactive validators cause upgrade requests to be ignored on-chain." />
+                </em>
+              </>
+            )}
           </div>
           <UpgradeCompounding validator={validator} />
         </Row>
@@ -259,6 +273,12 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
               <FormattedMessage defaultMessage="Selected account must be upgraded to compounding type to absorb another validator." />
             </em>
           )}
+          {!isValidatorActive(validator) && (
+            <em>
+              {' '}
+              <FormattedMessage defaultMessage="Selected account must be active before it can absorb funds from another validator. Inactive targets cause consolidation requests to be ignored on-chain." />
+            </em>
+          )}
           {sourceValidatorSet.length < 1 && (
             <em>
               {' '}
@@ -278,6 +298,12 @@ const ValidatorActions: React.FC<Props> = ({ validator, validators }) => {
             <FormattedMessage defaultMessage="Migrate funds" />
           </ActionTitle>
           <FormattedMessage defaultMessage="Transfer entire balance to another one of your validator accounts, consolidating two accounts into one. Target account must be upgraded to compounding type." />{' '}
+          {!isValidatorActive(validator) && (
+            <em>
+              {' '}
+              <FormattedMessage defaultMessage="Selected account must be active before its funds can be migrated. Inactive sources cause consolidation requests to be ignored on-chain." />
+            </em>
+          )}
         </div>
         <PushConsolidation
           sourceValidator={validator}

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,6 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { ValidatorType } from '../pages/Actions/types';
 import { BeaconChainValidator } from '../pages/TopUp/types';
+import { currentEpoch } from './beaconchain';
 import {
   ETHER_TO_GWEI,
   MAX_EFFECTIVE_BALANCE,
@@ -14,6 +15,17 @@ export const hasExitEpochBeenSet = (exitEpoch: BigNumber | number) =>
 
 export const hasValidatorExited = (validator: BeaconChainValidator) =>
   hasExitEpochBeenSet(validator.exitepoch);
+
+// Mirrors `is_active_validator` from the consensus spec
+// https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/beacon-chain.md#is_active_validator
+export const isValidatorActive = (validator: BeaconChainValidator): boolean => {
+  const activationEpoch = new BigNumber(validator.activationepoch);
+  const exitEpoch = new BigNumber(validator.exitepoch);
+  return (
+    activationEpoch.isLessThanOrEqualTo(currentEpoch) &&
+    new BigNumber(currentEpoch).isLessThan(exitEpoch)
+  );
+};
 
 export const getCredentialType = (
   validator: BeaconChainValidator


### PR DESCRIPTION
## Summary

Block the Actions UI from submitting consolidation and upgrade-to-compounding requests against validators that fail the consensus-spec [`is_active_validator`](https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain.md#new-process_consolidation_request) check.

Per `process_consolidation_request`, requests where either source or target is not active are silently ignored on-chain, which leaves users with stuck requests that look pending but will never process. Reported by @jakubgs after pulling funds into a registered-but-pending 1 ETH validator — request stayed stuck for 8+ days despite a 1-2 day queue.

```python
if not is_active_validator(source_validator, current_epoch):
    return
if not is_active_validator(target_validator, current_epoch):
    return
```

## Changes

- Add `isValidatorActive` helper in `src/utils/validators.ts` using the spec definition `activation_epoch <= current_epoch < exit_epoch`
- `ValidatorActions.tsx`: filter `potentialTargetValidators` by active status; add hint text on Upgrade/Absorb/Migrate rows when the selected validator isn't active
- `PullConsolidation.tsx`: disable "Pull funds" when target isn't active — the exact path that triggered the bug
- `PushConsolidation.tsx`: disable "Migrate funds" when source isn't active; replace the hardcoded `['active_online','active_offline','active_ongoing']` status-string check with the spec helper (also handles dora's status naming consistently)
- `UpgradeCompounding.tsx`: disable "Upgrade account" (self-consolidation) when validator isn't active — same spec rule applies

## Test plan

- [ ] Connect a wallet with at least one active compounding validator and one pending (registered but inactive) compounding validator from the same withdrawal address
- [ ] Select the pending validator: confirm "Pull funds" / "Migrate funds" / "Upgrade account" buttons are disabled with hint text explaining why
- [ ] Select an active validator: confirm consolidation flows still work; pending validators do not appear as selectable targets in the "Migrate funds" target selector
- [ ] Confirm `yarn tsc --noEmit` passes (verified locally, exit 0)